### PR TITLE
Move to OpenVax organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 env:
   global:
     # MHC_BUNDLE_PASS
-    - secure: "bWJ1eCA19Qt8dHarlUC/5SfgkOk08VdASljeC7NVy7jAzNnhZna6My39BkBWHUxDGGN6PxeaNzb8COMo94dcfk5OoIQ8ZB8CXwtg/o5Unpi8S2uNC1+H6SvR06xYXPCNozqPwBO151HAK+8IhEpJidQ0Mj1qjrYC3BiWePrXwgs="
+    - secure: "TLTzSIABO/iYke8C66c0PRaWDZ5lx90s8XimSfDONOTXaX74V25O65qxzIWPAihxcdfLYA+bE2YRsjYOtuK+6DB2vjXbmoCQAXIFT/QXz4+iZTxN3g/s5N4hIR8tf9MSQ3KdNHOw7lKzdgAWKsFDQ8vwrqzYUNJGVtvoQSWCmPw="
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
@@ -32,7 +32,7 @@ before_install:
   - conda info -a
 
   # install MHC predictors
-  - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/hammerlab/netmhc-bundle.git
+  - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/openvax/netmhc-bundle.git
   - export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
   - mkdir tmp
   - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
@@ -56,8 +56,8 @@ after_success:
 deploy:
   provider: pypi
   distributions: sdist
-  user: hammerlab
+  user: openvax
   password: # See http://docs.travis-ci.com/user/encryption-keys/
-    secure: "WmjH4aashVXAmW/0eKkmO3TwFL2eZpo1Dyb0+hZeJrKMPSfqyObvKjTANBfqgGvR3XoShy8egHaFuLvDMO3/Xh77tjOAq12KZVcYi0IsFADZrPOJzmUqU9Ck9j7fN0sly+mSwNNMHel3OOi77/EVOEm95LNLb1VncsPjwYoHTj8="
+    secure: "S4KWAhJpKYx5F/cBc6cf9GCZ8Hd+WtMA6V6PP25PglLnVaXrxB5QxuAIWGAvr/jGuTHjfCSCNDwTptW3natLjJR9IfJdJPp3gNvM0RDjWY4FsziFz/nG/bZo9qnh4ZCDhK/Po1izxXM0u9z6gUc0U2iKK1ZSdfawyW4nZbAXQUU="
   on:
     branch: master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hammerlab/topiary.svg?branch=master)](https://travis-ci.org/hammerlab/topiary) [![Coverage Status](https://coveralls.io/repos/hammerlab/topiary/badge.svg?branch=master&service=github)](https://coveralls.io/github/hammerlab/topiary?branch=master) [![DOI](https://zenodo.org/badge/18834/hammerlab/topiary.svg)](https://zenodo.org/badge/latestdoi/18834/hammerlab/topiary)
+[![Build Status](https://travis-ci.org/openvax/topiary.svg?branch=master)](https://travis-ci.org/openvax/topiary) [![Coverage Status](https://coveralls.io/repos/openvax/topiary/badge.svg?branch=master&service=github)](https://coveralls.io/github/openvax/topiary?branch=master) [![DOI](https://zenodo.org/badge/18834/hammerlab/topiary.svg)](https://zenodo.org/badge/latestdoi/18834/hammerlab/topiary)
 
 # Topiary
 Predict mutation-derived cancer T-cell epitopes from (1) somatic variants (2) tumor RNA expression data, and (3) patient HLA type.


### PR DESCRIPTION
I changed the Travis encrypted values after noticing issues in some builds, and assumed that since the values (like the `mhcbundle` user's password) were encrypted using `-r hammerlab/<repo name>` rather than `openvax`, that might explain the issues. Turns out the issue was just that the `mhcbundle` user no longer had access to the `netmhc-bundle` repo.

In any event, what I did here was...

```
travis encrypt MHC_BUNDLE_PASS='<mhcbundle GitHub password>' -r openvax/<repo name>
travis encrypt '<openvax pypi password>' -r openvax/<repo name>
```

...in addition to changing the `PyPi` username and `README` badges. Only the latter seem necessary in other repos.