### PR TITLE
add --protein-change commandline arg

### DIFF
--- a/test/test_cli_protein_changes.py
+++ b/test/test_cli_protein_changes.py
@@ -1,0 +1,49 @@
+from nose.tools import eq_
+from topiary.cli.protein_changes import protein_change_effects_from_args
+from topiary.cli.args import create_arg_parser
+
+arg_parser = create_arg_parser(
+    mhc=False,
+    rna=False,
+    output=False)
+
+def test_protein_change_effects_from_args_substitutions():
+    args = arg_parser.parse_args([
+        "--protein-change", "EGFR", "T790M",
+        "--genome", "grch37",
+    ])
+
+    effects = protein_change_effects_from_args(args)
+    eq_(len(effects), 1)
+    effect = effects[0]
+    eq_(effect.aa_ref, "T")
+    eq_(effect.aa_mutation_start_offset, 789)
+    eq_(effect.aa_alt, "M")
+
+    transcript = effect.transcript
+    eq_(transcript.name, "EGFR-001")
+
+def test_protein_change_effects_from_args_malformed_missing_ref():
+
+    args = arg_parser.parse_args([
+        "--protein-change", "EGFR", "790M",
+        "--genome", "grch37"])
+
+    effects = protein_change_effects_from_args(args)
+    eq_(len(effects), 0)
+
+def test_protein_change_effects_from_args_malformed_missing_alt():
+    args = arg_parser.parse_args([
+        "--protein-change", "EGFR", "T790",
+        "--genome", "grch37"])
+    effects = protein_change_effects_from_args(args)
+    eq_(len(effects), 0)
+
+def test_protein_change_effects_from_args_multiple_effects():
+    args = arg_parser.parse_args([
+        "--protein-change", "EGFR", "T790M",
+        "--protein-change", "KRAS", "G10D",
+        "--genome", "grch37"])
+    effects = protein_change_effects_from_args(args)
+    print(effects)
+    eq_(len(effects), 2)

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -31,18 +31,35 @@ from .rna import (
 from .sequence import add_sequence_args
 from .errors import add_error_args
 from .outputs import add_output_args
-
+from .protein_changes import add_protein_change_args
 from ..predictor import TopiaryPredictor
 
-def create_arg_parser():
+def create_arg_parser(
+        rna=True,
+        mhc=True,
+        variants=True,
+        protein_changes=True,
+        filters=True,
+        sequence_options=True,
+        error_options=True,
+        output=True):
     arg_parser = ArgumentParser()
-    add_rna_args(arg_parser)
-    add_mhc_args(arg_parser)
-    add_variant_args(arg_parser)
-    add_filter_args(arg_parser)
-    add_sequence_args(arg_parser)
-    add_error_args(arg_parser)
-    add_output_args(arg_parser)
+    if rna:
+        add_rna_args(arg_parser)
+    if mhc:
+        add_mhc_args(arg_parser)
+    if variants:
+        add_variant_args(arg_parser)
+    if protein_changes:
+        add_protein_change_args(arg_parser)
+    if filters:
+        add_filter_args(arg_parser)
+    if sequence_options:
+        add_sequence_args(arg_parser)
+    if error_options:
+        add_error_args(arg_parser)
+    if output:
+        add_output_args(arg_parser)
     return arg_parser
 
 # keeping global instance for backwards compatibility with existing code

--- a/topiary/cli/protein_changes.py
+++ b/topiary/cli/protein_changes.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2018. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from pyensembl import ensembl_grch38
+from varcode import EffectCollection
+from varcode.effects import Substitution
+from varcode.reference import infer_genome
+import re
+
+def add_protein_change_args(arg_parser):
+    protein_change_group = arg_parser.add_argument_group(
+        title="Protein Changes",
+        description="Input protein changes without associated genomic variants")
+
+    protein_change_group.add_argument(
+        "--protein-change",
+        default=[],
+        nargs=2,
+        action="append",
+        help="Protein modification without genomic variant (e.g. EGFR T790M)")
+
+    return arg_parser
+
+def genome_from_args(args):
+    if args.genome:
+        return infer_genome(args.genome)
+    else:
+        # no genome specified, assume it can be inferred from the file(s)
+        # we're loading
+        return ensembl_grch38
+
+def transcript_sort_key(transcript):
+    """
+    Key function used to sort transcripts. Taking the negative of
+    protein sequence length and nucleotide sequence length so that
+    the transcripts with longest sequences come first in the list. This couldn't
+    be accomplished with `reverse=True` since we're also sorting by
+    transcript name (which places TP53-001 before TP53-002).
+    """
+    return (
+        -len(transcript.protein_sequence),
+        -len(transcript.sequence),
+        transcript.name
+    )
+
+def best_transcript(transcripts):
+    """
+    Given a set of coding transcripts, choose the one with the longest
+    protein sequence and in cases of ties use the following tie-breaking
+    criteria:
+        - transcript sequence (including UTRs)
+        - transcript name (so TP53-001 should come before TP53-202)
+    """
+    assert len(transcripts) > 0
+    sorted_list = sorted(transcripts, key=transcript_sort_key)
+    return sorted_list[0]
+
+def protein_change_effects_from_args(args):
+    genome = genome_from_args(args)
+    valid_gene_names = set(genome.gene_names())
+    substitution_regex = re.compile("([A-Z]+)([0-9]+)([A-Z]+)")
+    effects = []
+    for gene_name, protein_change_string in args.protein_change:
+        match_obj = substitution_regex.match(protein_change_string)
+        if match_obj is None:
+            logging.warn(
+                "Unable to parse protein modification: '%s'" % protein_change_string)
+            continue
+
+        ref, base1_pos, alt = match_obj.groups()
+
+        base1_pos = int(base1_pos)
+
+        if gene_name not in valid_gene_names:
+            logging.warn("Invalid gene name '%s' in protein modification: '%s'" % (
+                gene_name, protein_change_string))
+            continue
+
+        candidate_transcripts = []
+        for candidate_gene in genome.genes_by_name(gene_name):
+            for candidate_transcript in candidate_gene.transcripts:
+                if not candidate_transcript.is_protein_coding:
+                    continue
+                protein_sequence = candidate_transcript.protein_sequence
+                if protein_sequence is None:
+                    continue
+                if len(protein_sequence) < (base1_pos + len(ref) - 1):
+                    # protein sequence too short for this modification
+                    # e.g. EGFR T790M can't happen in an EGFR transcript
+                    # with only 789 amino acids
+                    continue
+
+                seq_at_pos = protein_sequence[base1_pos - 1: base1_pos + len(ref) - 1]
+                if seq_at_pos != ref:
+                    # if this transcript doesn't have the same reference amino
+                    # acids as the change then skip it and use a different
+                    # transcript
+                    continue
+                candidate_transcripts.append(candidate_transcript)
+        if len(candidate_transcripts) > 0:
+            transcript = best_transcript(candidate_transcripts)
+            effects.append(Substitution(
+                variant=None,
+                transcript=transcript,
+                aa_ref=ref,
+                aa_alt=alt,
+                aa_mutation_start_offset=base1_pos - 1))
+    return EffectCollection(effects)


### PR DESCRIPTION
Instead of specifying genomic variants (whose protein effect is predicted) you can now instead use `--protein-change GENE-NAME <change>`. This currently only works for amino acid substitutions (in a format like "T790M") and not for other kinds of mutations. Another limitations is that the gene names must match what's used in Ensembl, other gene synonyms will not work. 

Internally the protein change strings are parsed into Varcode effects (whose `variant` field is `None`). The transcript for each protein change is selected by filtering to coding transcripts whose amino acid sequence matches the reference amino acids from the change descriptor. If multiple matching transcripts exist, then the longest is chosen. 