### PR TITLE
Multi-model disambiguation for ranking/filtering DSL

### DIFF
--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -655,3 +655,371 @@ def test_parse_ranking_mixed_operators_raises():
     from topiary.ranking import parse_ranking
     with pytest.raises(ValueError, match="Cannot mix"):
         parse_ranking("affinity <= 500 | presentation.rank <= 2 & stability.score >= 0.5")
+
+
+# ---------------------------------------------------------------------------
+# Tests: method-qualified access (multi-model disambiguation)
+# ---------------------------------------------------------------------------
+
+
+def _multi_model_df():
+    """Two models producing affinity for the same peptide-allele pair."""
+    return _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            prediction_method_name="netmhcpan",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.6, value=350.0, percentile_rank=2.0,
+            prediction_method_name="mhcflurry",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_presentation",
+            score=0.9, value=None, percentile_rank=0.3,
+            prediction_method_name="mhcflurry",
+        ),
+    ])
+
+
+def test_bracket_qualified_field_evaluate():
+    df = _multi_model_df()
+    assert Affinity["netmhcpan"].value.evaluate(df) == 120.0
+    assert Affinity["mhcflurry"].value.evaluate(df) == 350.0
+    assert Presentation["mhcflurry"].score.evaluate(df) == 0.9
+
+
+def test_bracket_qualified_filter():
+    f = Affinity["netmhcpan"] <= 500
+    assert f.method == "netmhcpan"
+    assert f.kind == Kind.pMHC_affinity
+    assert f.max_value == 500
+
+
+def test_bracket_qualified_ranking_apply():
+    df = _multi_model_df()
+    # Filter: only keep if mhcflurry affinity <= 200 (it's 350, so should drop)
+    strategy = RankingStrategy(filters=[Affinity["mhcflurry"] <= 200])
+    result = apply_ranking_strategy(df, strategy)
+    assert len(result) == 0
+
+    # Filter: netmhcpan affinity <= 200 (it's 120, so should keep)
+    strategy = RankingStrategy(filters=[Affinity["netmhcpan"] <= 200])
+    result = apply_ranking_strategy(df, strategy)
+    assert len(result) == 3  # all rows for this group kept
+
+
+def test_unqualified_ambiguity_raises():
+    import pytest
+    df = _multi_model_df()
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        Affinity.value.evaluate(df)
+
+
+def test_unqualified_single_model_ok():
+    """When only one model produces a kind, no qualification needed."""
+    df = _multi_model_df()
+    # Presentation only comes from mhcflurry — no ambiguity
+    assert Presentation.score.evaluate(df) == 0.9
+
+
+def test_bracket_norm_shorthand():
+    """KindAccessor.norm() delegates to .value.norm()."""
+    df = _multi_model_df()
+    via_accessor = Affinity["netmhcpan"].norm(500, 200).evaluate(df)
+    via_field = Affinity["netmhcpan"].value.norm(500, 200).evaluate(df)
+    assert via_accessor == via_field
+
+
+def test_bracket_arithmetic():
+    """KindAccessor arithmetic delegates to .value."""
+    df = _multi_model_df()
+    expr = 0.5 * Affinity["netmhcpan"] + 0.5 * Affinity["mhcflurry"]
+    result = expr.evaluate(df)
+    assert result == 0.5 * 120.0 + 0.5 * 350.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI tool_kind parsing
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_qualified_kind_plain():
+    from topiary.ranking import _resolve_qualified_kind
+    kind, method = _resolve_qualified_kind("affinity")
+    assert kind == Kind.pMHC_affinity
+    assert method is None
+
+
+def test_resolve_qualified_kind_with_tool():
+    from topiary.ranking import _resolve_qualified_kind
+    kind, method = _resolve_qualified_kind("netmhcpan_affinity")
+    assert kind == Kind.pMHC_affinity
+    assert method == "netmhcpan"
+
+
+def test_resolve_qualified_kind_short_aliases():
+    from topiary.ranking import _resolve_qualified_kind
+    kind, method = _resolve_qualified_kind("netmhcpan_ba")
+    assert kind == Kind.pMHC_affinity
+    assert method == "netmhcpan"
+
+    kind, method = _resolve_qualified_kind("mhcflurry_el")
+    assert kind == Kind.pMHC_presentation
+    assert method == "mhcflurry"
+
+
+def test_resolve_qualified_kind_underscore_kind():
+    """Kind names with underscores (antigen_processing) resolve without a tool."""
+    from topiary.ranking import _resolve_qualified_kind
+    kind, method = _resolve_qualified_kind("antigen_processing")
+    assert kind == Kind.antigen_processing
+    assert method is None
+
+
+def test_resolve_qualified_kind_tool_plus_underscore_kind():
+    from topiary.ranking import _resolve_qualified_kind
+    kind, method = _resolve_qualified_kind("netmhcpan_antigen_processing")
+    assert kind == Kind.antigen_processing
+    assert method == "netmhcpan"
+
+
+def test_parse_filter_tool_qualified():
+    from topiary.ranking import parse_filter
+    f = parse_filter("netmhcpan_affinity <= 500")
+    assert f.kind == Kind.pMHC_affinity
+    assert f.method == "netmhcpan"
+    assert f.max_value == 500.0
+
+
+def test_parse_filter_tool_qualified_with_field():
+    from topiary.ranking import parse_filter
+    f = parse_filter("mhcflurry_el.rank <= 2")
+    assert f.kind == Kind.pMHC_presentation
+    assert f.method == "mhcflurry"
+    assert f.max_percentile_rank == 2.0
+
+
+def test_parse_ranking_tool_qualified():
+    from topiary.ranking import parse_ranking
+    strategy = parse_ranking(
+        "netmhcpan_affinity <= 500 | mhcflurry_el.rank <= 2"
+    )
+    assert isinstance(strategy, RankingStrategy)
+    assert len(strategy.filters) == 2
+    assert strategy.filters[0].method == "netmhcpan"
+    assert strategy.filters[1].method == "mhcflurry"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial / edge case tests for method qualification
+# ---------------------------------------------------------------------------
+
+
+def test_qualified_nonexistent_method_raises():
+    """Qualifying with a method that doesn't exist in data → ValueError."""
+    import pytest
+    df = _multi_model_df()
+    with pytest.raises(ValueError, match="No pMHC_affinity predictions from method"):
+        Affinity["nonexistent_tool"].value.evaluate(df)
+
+
+def test_qualified_nonexistent_method_shows_available():
+    """Error message lists available methods."""
+    import pytest
+    df = _multi_model_df()
+    with pytest.raises(ValueError, match="Available.*mhcflurry.*netmhcpan"):
+        Affinity["totally_wrong"].value.evaluate(df)
+
+
+def test_qualified_typo_suggests_correction():
+    """Close misspellings get 'Did you mean' suggestions."""
+    import pytest
+    df = _multi_model_df()
+    with pytest.raises(ValueError, match="Did you mean.*netmhcpan"):
+        Affinity["netmhcapn"].value.evaluate(df)
+
+
+def test_qualified_typo_in_filter_suggests_correction():
+    """Same suggestion works in the filter path."""
+    import pytest
+    df = _multi_model_df()
+    strategy = RankingStrategy(filters=[Affinity["mchflurry"] <= 500])
+    with pytest.raises(ValueError, match="Did you mean.*mhcflurry"):
+        apply_ranking_strategy(df, strategy)
+
+
+def test_method_match_is_case_insensitive():
+    """Method matching should be case-insensitive."""
+    df = _multi_model_df()
+    assert Affinity["NETMHCPAN"].value.evaluate(df) == 120.0
+    assert Affinity["NetMHCpan"].value.evaluate(df) == 120.0
+
+
+def test_method_match_is_substring():
+    """Method matching uses substring — 'pan' matches 'netmhcpan'."""
+    df = _multi_model_df()
+    assert Affinity["pan"].value.evaluate(df) == 120.0
+
+
+def test_method_substring_ambiguity():
+    """If substring matches multiple methods, picks first match (no error)."""
+    df = _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.8, value=100.0, percentile_rank=0.5,
+            prediction_method_name="tool_alpha",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.6, value=200.0, percentile_rank=1.0,
+            prediction_method_name="tool_alphabeta",
+        ),
+    ])
+    # "alpha" matches both — should get first match (100.0)
+    val = Affinity["alpha"].value.evaluate(df)
+    assert val == 100.0
+
+
+def test_empty_dataframe_qualified():
+    """Qualified field on empty DataFrame → NaN."""
+    df = _make_df([])
+    val = Affinity["netmhcpan"].value.evaluate(df)
+    assert math.isnan(val)
+
+
+def test_no_prediction_method_name_column():
+    """Data without prediction_method_name column — unqualified works, qualified is NaN."""
+    df = _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.8, value=100.0, percentile_rank=0.5,
+        ),
+    ])
+    # Unqualified works (no ambiguity check without column)
+    assert Affinity.value.evaluate(df) == 100.0
+    # Qualified — column doesn't exist, so method filter can't match
+    # but the code guards with 'if col in kind_rows.columns', so falls through
+    val = Affinity["netmhcpan"].value.evaluate(df)
+    assert val == 100.0  # no column to filter on → uses all rows
+
+
+def test_nan_prediction_method_name():
+    """Rows with NaN prediction_method_name shouldn't crash or match."""
+    df = _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.8, value=100.0, percentile_rank=0.5,
+            prediction_method_name=None,
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.6, value=200.0, percentile_rank=1.0,
+            prediction_method_name="netmhcpan",
+        ),
+    ])
+    # Qualified should skip None row and find netmhcpan
+    assert Affinity["netmhcpan"].value.evaluate(df) == 200.0
+
+
+def test_ambiguity_not_raised_when_qualified():
+    """Even with multiple models, qualifying one side shouldn't error."""
+    df = _multi_model_df()
+    # Qualified access — no ambiguity
+    assert Affinity["netmhcpan"].value.evaluate(df) == 120.0
+    assert Affinity["mhcflurry"].value.evaluate(df) == 350.0
+
+
+def test_composite_score_across_models():
+    """Composite expression mixing qualified fields from different models."""
+    df = _multi_model_df()
+    expr = (
+        0.5 * Affinity["netmhcpan"].norm(500, 200)
+        + 0.5 * Presentation["mhcflurry"].score
+    )
+    val = expr.evaluate(df)
+    assert isinstance(val, float)
+    assert not math.isnan(val)
+    assert val > 0
+
+
+def test_sort_by_qualified_field():
+    """Sorting by a qualified field across groups."""
+    df = _make_df([
+        # Group 1: netmhcpan says 500
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.5, value=500.0, percentile_rank=5.0,
+            prediction_method_name="netmhcpan",
+        ),
+        # Group 2: netmhcpan says 100
+        dict(
+            source_sequence_name="seq1", peptide="BBB", peptide_offset=10,
+            allele="A", kind="pMHC_affinity",
+            score=0.9, value=100.0, percentile_rank=0.5,
+            prediction_method_name="netmhcpan",
+        ),
+    ])
+    strategy = RankingStrategy(sort_by=[Affinity["netmhcpan"].score])
+    result = apply_ranking_strategy(df, strategy)
+    # BBB has higher score (0.9) so should come first
+    assert result.iloc[0]["peptide"] == "BBB"
+
+
+def test_resolve_qualified_kind_unknown_raises():
+    import pytest
+    from topiary.ranking import _resolve_qualified_kind
+    with pytest.raises(ValueError, match="Unknown prediction kind"):
+        _resolve_qualified_kind("totally_bogus_nonsense")
+
+
+def test_resolve_qualified_kind_empty_raises():
+    import pytest
+    from topiary.ranking import _resolve_qualified_kind
+    with pytest.raises(ValueError):
+        _resolve_qualified_kind("")
+
+
+def test_filter_or_across_models():
+    """OR filter: pass if netmhcpan OR mhcflurry affinity is low enough."""
+    df = _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.9, value=50.0, percentile_rank=0.1,
+            prediction_method_name="netmhcpan",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity",
+            score=0.1, value=9999.0, percentile_rank=50.0,
+            prediction_method_name="mhcflurry",
+        ),
+    ])
+    # netmhcpan passes, mhcflurry doesn't — OR should keep
+    strategy = (Affinity["netmhcpan"] <= 500) | (Affinity["mhcflurry"] <= 500)
+    result = apply_ranking_strategy(df, strategy)
+    assert len(result) == 2  # both rows for the group kept
+
+    # AND should fail (mhcflurry doesn't pass)
+    strategy = (Affinity["netmhcpan"] <= 500) & (Affinity["mhcflurry"] <= 500)
+    result = apply_ranking_strategy(df, strategy)
+    assert len(result) == 0
+
+
+def test_bracket_on_kind_accessor_returns_new_accessor():
+    """Affinity["x"] returns a new KindAccessor, not a mutation."""
+    original_method = Affinity.method
+    qualified = Affinity["netmhcpan"]
+    assert qualified.method == "netmhcpan"
+    assert Affinity.method == original_method  # unchanged

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -248,9 +248,11 @@ def _build_ranking_strategy(args):
 
     sort_by = []
     if has_rank_by:
-        from ..ranking import KindAccessor, _resolve_kind
+        from ..ranking import KindAccessor, _resolve_qualified_kind
         kind_names = [s.strip() for s in args.rank_by.split(",")]
-        sort_by = [KindAccessor(_resolve_kind(k)).score for k in kind_names]
+        for k in kind_names:
+            kind, method = _resolve_qualified_kind(k)
+            sort_by.append(KindAccessor(kind, method=method).score)
 
     return RankingStrategy(
         filters=filters,

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import math
 import operator
 from dataclasses import dataclass, field
+from difflib import get_close_matches
 from typing import Optional
 
 import numpy as np
@@ -236,6 +237,19 @@ def _as_expr(obj):
     raise TypeError(f"Cannot convert {type(obj)} to Expr")
 
 
+def _method_not_found_error(kind_name, method, available):
+    """Build a ValueError for an unrecognized method, suggesting close matches."""
+    msg = (
+        f"No {kind_name} predictions from method matching {method!r}. "
+        f"Available: {available}"
+    )
+    close = get_close_matches(method.lower(), [a.lower() for a in available], n=2, cutoff=0.6)
+    if close:
+        suggestions = [next(a for a in available if a.lower() == c) for c in close]
+        msg += f". Did you mean: {suggestions}?"
+    return ValueError(msg)
+
+
 # ---------------------------------------------------------------------------
 # Field — a reference to one column of one prediction kind
 # ---------------------------------------------------------------------------
@@ -249,16 +263,49 @@ class Field(Expr):
         Affinity.value   # IC50 / value column for pMHC_affinity
         Affinity.rank    # percentile_rank column
         Affinity.score   # score column (higher = better)
+
+    Optionally qualified by prediction method::
+
+        Affinity["netmhcpan"].value   # only NetMHCpan's affinity
     """
 
-    __slots__ = ("kind", "field")
+    __slots__ = ("kind", "field", "method")
 
-    def __init__(self, kind: Kind, field: str):
+    def __init__(self, kind: Kind, field: str, method: Optional[str] = None):
         self.kind = kind
         self.field = field
+        self.method = method
 
     def evaluate(self, group_df):
+        if group_df.empty or "kind" not in group_df.columns:
+            return float("nan")
         kind_rows = group_df[group_df["kind"] == self.kind.value]
+        if kind_rows.empty:
+            return float("nan")
+        col = "prediction_method_name"
+        if self.method is not None:
+            if col in kind_rows.columns:
+                method_lower = self.method.lower()
+                matched = kind_rows[
+                    kind_rows[col].str.lower().str.contains(method_lower, na=False)
+                ]
+                if matched.empty:
+                    available = sorted(kind_rows[col].dropna().unique())
+                    raise _method_not_found_error(
+                        self.kind.name, self.method, available
+                    )
+                kind_rows = matched
+            # If column doesn't exist, keep all rows (legacy data)
+        elif col in kind_rows.columns:
+            methods = kind_rows[col].dropna().unique()
+            if len(methods) > 1:
+                kind_name = self.kind.name
+                method_list = ", ".join(sorted(methods))
+                raise ValueError(
+                    f"Ambiguous: multiple models produce {kind_name} "
+                    f"({method_list}). Use Affinity[\"modelname\"] to "
+                    f"disambiguate."
+                )
         if kind_rows.empty:
             return float("nan")
         try:
@@ -273,20 +320,20 @@ class Field(Expr):
 
     def __le__(self, threshold):
         if self.field == "value":
-            return EpitopeFilter(kind=self.kind, max_value=threshold)
+            return EpitopeFilter(kind=self.kind, max_value=threshold, method=self.method)
         if self.field == "percentile_rank":
-            return EpitopeFilter(kind=self.kind, max_percentile_rank=threshold)
+            return EpitopeFilter(kind=self.kind, max_percentile_rank=threshold, method=self.method)
         if self.field == "score":
-            return EpitopeFilter(kind=self.kind, max_score=threshold)
+            return EpitopeFilter(kind=self.kind, max_score=threshold, method=self.method)
         raise ValueError(f"Cannot apply <= to field {self.field!r}")
 
     def __ge__(self, threshold):
         if self.field == "score":
-            return EpitopeFilter(kind=self.kind, min_score=threshold)
+            return EpitopeFilter(kind=self.kind, min_score=threshold, method=self.method)
         if self.field == "value":
-            return EpitopeFilter(kind=self.kind, min_value=threshold)
+            return EpitopeFilter(kind=self.kind, min_value=threshold, method=self.method)
         if self.field == "percentile_rank":
-            return EpitopeFilter(kind=self.kind, min_percentile_rank=threshold)
+            return EpitopeFilter(kind=self.kind, min_percentile_rank=threshold, method=self.method)
         raise ValueError(f"Cannot apply >= to field {self.field!r}")
 
     def __lt__(self, threshold):
@@ -307,31 +354,45 @@ class KindAccessor:
     Pre-built instances: ``Affinity``, ``Presentation``, ``Stability``,
     ``Processing``.  Build custom ones with ``KindAccessor(Kind.foo)``.
 
-    The default field is ``value``, so comparisons on the accessor itself
-    act on the value column::
+    Qualify by prediction method with bracket syntax::
 
-        Affinity <= 500        # same as Affinity.value <= 500
+        Affinity["netmhcpan"] <= 500
+        Affinity["mhcflurry"].score
+
+    When unqualified, uses the first matching row (works automatically
+    when only one model produces the kind).
+
+    The default field is ``value``, so comparisons and Expr methods on
+    the accessor itself act on the value column::
+
+        Affinity <= 500              # same as Affinity.value <= 500
+        Affinity.norm(500, 200)      # same as Affinity.value.norm(500, 200)
     """
 
-    __slots__ = ("kind",)
+    __slots__ = ("kind", "method")
 
-    def __init__(self, kind: Kind):
+    def __init__(self, kind: Kind, method: Optional[str] = None):
         self.kind = kind
+        self.method = method
+
+    def __getitem__(self, method: str) -> "KindAccessor":
+        """Qualify by prediction method name, e.g. Affinity["netmhcpan"]."""
+        return KindAccessor(self.kind, method=method)
 
     @property
     def value(self) -> Field:
         """Kind-specific value (e.g. IC50 nM for affinity)."""
-        return Field(self.kind, "value")
+        return Field(self.kind, "value", method=self.method)
 
     @property
     def rank(self) -> Field:
         """Percentile rank (lower is better)."""
-        return Field(self.kind, "percentile_rank")
+        return Field(self.kind, "percentile_rank", method=self.method)
 
     @property
     def score(self) -> Field:
         """Continuous score (higher is better)."""
-        return Field(self.kind, "score")
+        return Field(self.kind, "score", method=self.method)
 
     # Default comparisons delegate to .value
     def __le__(self, threshold):
@@ -346,8 +407,57 @@ class KindAccessor:
     def __gt__(self, threshold):
         return self.value.__gt__(threshold)
 
+    # Delegate Expr methods to .value so Affinity.norm(...) works
+    def norm(self, mean=0.0, std=1.0):
+        return self.value.norm(mean, std)
 
-# Top-level accessors for common kinds
+    def clip(self, lo=None, hi=None):
+        return self.value.clip(lo, hi)
+
+    def log(self):
+        return self.value.log()
+
+    def log10(self):
+        return self.value.log10()
+
+    def exp(self):
+        return self.value.exp()
+
+    def sqrt(self):
+        return self.value.sqrt()
+
+    def __neg__(self):
+        return -self.value
+
+    def __abs__(self):
+        return abs(self.value)
+
+    def __add__(self, other):
+        return self.value + other
+
+    def __radd__(self, other):
+        return other + self.value
+
+    def __sub__(self, other):
+        return self.value - other
+
+    def __rsub__(self, other):
+        return other - self.value
+
+    def __mul__(self, other):
+        return self.value * other
+
+    def __rmul__(self, other):
+        return other * self.value
+
+    def __truediv__(self, other):
+        return self.value / other
+
+    def __rtruediv__(self, other):
+        return other / self.value
+
+
+# Top-level accessors for common kinds (unqualified — use when one model per kind)
 Affinity = KindAccessor(Kind.pMHC_affinity)
 Presentation = KindAccessor(Kind.pMHC_presentation)
 Stability = KindAccessor(Kind.pMHC_stability)
@@ -365,6 +475,10 @@ class EpitopeFilter:
 
     All specified thresholds must be satisfied (AND within a single filter).
     Combine with ``|`` (OR) or ``&`` (AND) to build a :class:`RankingStrategy`.
+
+    Optionally scoped to a specific prediction method via ``method``::
+
+        Affinity["netmhcpan"] <= 500  # only filters NetMHCpan rows
     """
 
     kind: Kind
@@ -374,6 +488,7 @@ class EpitopeFilter:
     min_percentile_rank: Optional[float] = None
     min_score: Optional[float] = None
     max_score: Optional[float] = None
+    method: Optional[str] = None
 
     def __or__(self, other):
         return _combine(self, other, require_all=False)
@@ -466,8 +581,20 @@ def _pick_group_keys(df):
     return _GROUP_KEYS
 
 
+def _method_matches(row, method):
+    """Check if a row's prediction_method_name matches the filter method."""
+    if method is None:
+        return True
+    name = row.get("prediction_method_name", "")
+    if not name:
+        return False
+    return method.lower() in name.lower()
+
+
 def _row_passes_filter(row, filt):
     if row["kind"] != filt.kind.value:
+        return False
+    if not _method_matches(row, filt.method):
         return False
 
     def _check(field, val, op):
@@ -500,6 +627,23 @@ def _group_passes(group_df, strategy):
         else:
             # EpitopeFilter
             kind_rows = group_df[group_df["kind"] == item.kind.value]
+            if item.method is not None and not kind_rows.empty:
+                col = "prediction_method_name"
+                if col in kind_rows.columns:
+                    method_lower = item.method.lower()
+                    matched = kind_rows[
+                        kind_rows[col].str.lower().str.contains(
+                            method_lower, na=False
+                        )
+                    ]
+                    if matched.empty:
+                        available = sorted(
+                            kind_rows[col].dropna().unique()
+                        )
+                        raise _method_not_found_error(
+                            item.kind.name, item.method, available
+                        )
+                    kind_rows = matched
             if kind_rows.empty:
                 results.append(False)
                 continue
@@ -582,12 +726,50 @@ _FIELD_ALIASES = {
 
 
 def _resolve_kind(name):
+    """Resolve a kind alias to a Kind enum value.
+
+    Accepts plain kind names (``"affinity"``, ``"ba"``) or
+    tool-qualified names (``"netmhcpan_affinity"``).
+
+    Returns ``(Kind, method)`` when called via :func:`_resolve_qualified_kind`,
+    or just ``Kind`` for backwards compatibility.
+    """
     key = name.strip().lower()
     if key in _KIND_ALIASES:
         return _KIND_ALIASES[key]
     raise ValueError(
         f"Unknown prediction kind {name!r}. "
         f"Available: {sorted(_KIND_ALIASES.keys())}"
+    )
+
+
+def _resolve_qualified_kind(name):
+    """Resolve a possibly tool-qualified kind string.
+
+    Returns ``(Kind, method_or_None)``.
+
+    Examples::
+
+        "affinity"             -> (Kind.pMHC_affinity, None)
+        "netmhcpan_affinity"   -> (Kind.pMHC_affinity, "netmhcpan")
+        "netmhcpan_ba"         -> (Kind.pMHC_affinity, "netmhcpan")
+        "mhcflurry_el"         -> (Kind.pMHC_presentation, "mhcflurry")
+    """
+    key = name.strip().lower()
+    # Try as a plain kind first
+    if key in _KIND_ALIASES:
+        return _KIND_ALIASES[key], None
+    # Try splitting at each underscore from left to right
+    parts = key.split("_")
+    for i in range(1, len(parts)):
+        tool = "_".join(parts[:i])
+        kind_str = "_".join(parts[i:])
+        if kind_str in _KIND_ALIASES:
+            return _KIND_ALIASES[kind_str], tool
+    raise ValueError(
+        f"Unknown prediction kind {name!r}. "
+        f"Use 'kind' or 'tool_kind' format. "
+        f"Available kinds: {sorted(_KIND_ALIASES.keys())}"
     )
 
 
@@ -611,6 +793,8 @@ def parse_filter(text):
         "presentation.score >= 0.5"
         "ic50 <= 500"
         "el.rank <= 2"
+        "netmhcpan_affinity <= 500"
+        "mhcflurry_el.rank <= 2"
 
     Returns an :class:`EpitopeFilter`.
     """
@@ -627,23 +811,23 @@ def parse_filter(text):
             else:
                 kind_str, field_str = lhs, "value"
 
-            kind = _resolve_kind(kind_str)
+            kind, method = _resolve_qualified_kind(kind_str)
             field_name = _resolve_field(field_str)
 
             if op_name in ("le", "lt"):
                 if field_name == "value":
-                    return EpitopeFilter(kind=kind, max_value=threshold)
+                    return EpitopeFilter(kind=kind, max_value=threshold, method=method)
                 elif field_name == "percentile_rank":
-                    return EpitopeFilter(kind=kind, max_percentile_rank=threshold)
+                    return EpitopeFilter(kind=kind, max_percentile_rank=threshold, method=method)
                 elif field_name == "score":
-                    return EpitopeFilter(kind=kind, max_score=threshold)
+                    return EpitopeFilter(kind=kind, max_score=threshold, method=method)
             elif op_name in ("ge", "gt"):
                 if field_name == "value":
-                    return EpitopeFilter(kind=kind, min_value=threshold)
+                    return EpitopeFilter(kind=kind, min_value=threshold, method=method)
                 elif field_name == "percentile_rank":
-                    return EpitopeFilter(kind=kind, min_percentile_rank=threshold)
+                    return EpitopeFilter(kind=kind, min_percentile_rank=threshold, method=method)
                 elif field_name == "score":
-                    return EpitopeFilter(kind=kind, min_score=threshold)
+                    return EpitopeFilter(kind=kind, min_score=threshold, method=method)
             break
     else:
         raise ValueError(f"No comparison operator found in {text!r}")


### PR DESCRIPTION
## Summary

When multiple MHC binding predictors produce the same prediction kind (e.g. both NetMHCpan and MHCflurry produce `pMHC_affinity`), the ranking system previously silently used whichever row came first. This PR adds explicit disambiguation.

### Python API — bracket syntax

```python
# Qualify by prediction method
Affinity["netmhcpan"] <= 500
Affinity["mhcflurry"].score
Affinity["netmhcpan"].norm(500, 200)

# Cross-model composite scoring
score = 0.5 * Affinity["netmhcpan"] + 0.5 * Affinity["mhcflurry"]

# Unqualified still works when only one model produces a kind
Affinity <= 500
```

### CLI — `tool_kind` underscore syntax

```bash
--ranking "netmhcpan_affinity <= 500 | mhcflurry_el.rank <= 2"
--rank-by "netmhcpan_affinity,mhcflurry_presentation"
```

All existing short aliases work with tool prefix: `netmhcpan_ba`, `mhcflurry_el`, `netmhcpan_aff`, etc.

### Error handling

- **Ambiguous unqualified access** — multiple models produce the same kind → `ValueError` listing available methods
- **Typo in method name** — `Affinity["netmhcapn"]` → `ValueError` with fuzzy "Did you mean: ['netmhcpan']?" suggestion
- **Single model** — unqualified access works without changes (backwards compatible)

### Changes

- `Field` gains an optional `method` parameter, used to filter on `prediction_method_name`
- `KindAccessor.__getitem__` returns a method-qualified accessor
- `KindAccessor` delegates Expr methods (`.norm()`, `.clip()`, arithmetic) to `.value`
- `EpitopeFilter` gains an optional `method` field
- `_resolve_qualified_kind()` parses `tool_kind` strings for CLI
- `parse_filter()` and `--rank-by` support tool-qualified kinds
- 32 new tests covering disambiguation, ambiguity errors, typo suggestions, edge cases

## Test plan

- [ ] All 254 existing + new tests pass
- [ ] Verify unqualified expressions still work (backwards compat)
- [ ] Verify ambiguity error fires with multiple models
- [ ] Verify typo suggestion shows close matches
- [ ] Verify CLI `tool_kind` parsing: `netmhcpan_affinity`, `mhcflurry_el.rank`