### PR TITLE
DSL extensions: logistic, Column, WT, peptide properties

### DIFF
--- a/tests/test_dsl_extensions.py
+++ b/tests/test_dsl_extensions.py
@@ -207,6 +207,16 @@ class TestColumn:
         assert abs(Column("charge")).evaluate(df) == 1.0
         assert Column("charge").clip(lo=0).evaluate(df) == 0.0
 
+    def test_non_numeric_column_raises(self):
+        """String column gives clear error, not generic ValueError."""
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="AAA", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=0.5, value=100.0,
+            percentile_rank=1.0, gene_name="BRAF",
+        )])
+        with pytest.raises(TypeError, match="non-numeric value"):
+            Column("gene_name").evaluate(df)
+
 
 class TestColumnFilter:
     def test_parse_column_filter(self):
@@ -250,6 +260,14 @@ class TestColumnFilter:
         f = parse_ranking("affinity <= 500 | column(charge) >= 0")
         assert isinstance(f, RankingStrategy)
         assert f.require_all is False
+
+    def test_parse_column_empty_name_raises(self):
+        with pytest.raises(ValueError, match="requires a column name"):
+            parse_filter("column() <= 5")
+
+    def test_parse_column_nested_parens_raises(self):
+        with pytest.raises(ValueError, match="must be a plain name"):
+            parse_filter("column(func()) <= 5")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dsl_extensions.py
+++ b/tests/test_dsl_extensions.py
@@ -1,0 +1,512 @@
+"""Tests for DSL extensions: logistic, Column, WT, peptide properties."""
+
+import math
+
+import pandas as pd
+import pytest
+from mhctools import Kind
+
+from topiary.ranking import (
+    Affinity,
+    Column,
+    ColumnFilter,
+    EpitopeFilter,
+    KindAccessor,
+    Presentation,
+    RankingStrategy,
+    WT,
+    apply_ranking_strategy,
+    parse_filter,
+    parse_ranking,
+)
+
+
+def _make_df(rows):
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _basic_group():
+    """Single peptide-allele group with affinity + presentation."""
+    return _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            prediction_method_name="netmhcpan",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_presentation",
+            score=0.92, value=None, percentile_rank=0.3,
+            prediction_method_name="netmhcpan",
+        ),
+    ])
+
+
+def _group_with_wt():
+    """Group with wt_* columns populated."""
+    return _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            wt_score=0.3, wt_value=800.0, wt_percentile_rank=5.0,
+            prediction_method_name="netmhcpan",
+        ),
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_presentation",
+            score=0.92, value=None, percentile_rank=0.3,
+            wt_score=0.4, wt_value=None, wt_percentile_rank=3.0,
+            prediction_method_name="netmhcpan",
+        ),
+    ])
+
+
+def _group_with_properties():
+    """Group with peptide property columns."""
+    return _make_df([
+        dict(
+            source_sequence_name="seq1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            prediction_method_name="netmhcpan",
+            charge=-1.0, hydrophobicity=0.5, cysteine_count=0,
+        ),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Tests: .logistic()
+# ---------------------------------------------------------------------------
+
+
+class TestLogistic:
+    def test_basic(self):
+        df = _basic_group()
+        # IC50=120, midpoint=350, width=150 → strong binder → high score
+        val = Affinity.logistic(midpoint=350, width=150).evaluate(df)
+        assert 0.5 < val < 1.0  # 120 is well below midpoint
+
+    def test_at_midpoint(self):
+        """At the midpoint, logistic should return 0.5."""
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=0.5, value=350.0,
+            percentile_rank=1.0,
+        )])
+        val = Affinity.logistic(midpoint=350, width=150).evaluate(df)
+        assert abs(val - 0.5) < 1e-10
+
+    def test_high_ic50_low_score(self):
+        """Very high IC50 → near 0."""
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=0.1, value=10000.0,
+            percentile_rank=50.0,
+        )])
+        val = Affinity.logistic(midpoint=350, width=150).evaluate(df)
+        assert val < 0.01
+
+    def test_nan_input(self):
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=float("nan"),
+            value=float("nan"), percentile_rank=float("nan"),
+        )])
+        val = Affinity.logistic(350, 150).evaluate(df)
+        assert math.isnan(val)
+
+    def test_width_zero(self):
+        df = _basic_group()
+        val = Affinity.logistic(350, 0).evaluate(df)
+        assert math.isnan(val)
+
+    def test_overflow_protection(self):
+        """Very large (x - midpoint) / width shouldn't crash."""
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=0.0, value=1e10,
+            percentile_rank=99.0,
+        )])
+        val = Affinity.logistic(350, 150).evaluate(df)
+        assert val == 0.0  # effectively 0
+
+    def test_kind_accessor_delegation(self):
+        """KindAccessor.logistic() should delegate to .value.logistic()."""
+        df = _basic_group()
+        via_accessor = Affinity.logistic(350, 150).evaluate(df)
+        via_field = Affinity.value.logistic(350, 150).evaluate(df)
+        assert via_accessor == via_field
+
+    def test_qualified(self):
+        """Bracket + logistic."""
+        df = _basic_group()
+        val = Affinity["netmhcpan"].logistic(350, 150).evaluate(df)
+        assert 0.5 < val < 1.0
+
+    def test_in_composite(self):
+        """Logistic in arithmetic expression."""
+        df = _basic_group()
+        expr = 0.5 * Affinity.logistic(350, 150) + 0.5 * Presentation.score
+        val = expr.evaluate(df)
+        assert isinstance(val, float)
+        assert not math.isnan(val)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Column()
+# ---------------------------------------------------------------------------
+
+
+class TestColumn:
+    def test_basic_read(self):
+        df = _group_with_properties()
+        assert Column("charge").evaluate(df) == -1.0
+        assert Column("hydrophobicity").evaluate(df) == 0.5
+        assert Column("cysteine_count").evaluate(df) == 0.0
+
+    def test_missing_column_raises(self):
+        df = _basic_group()
+        with pytest.raises(ValueError, match="Column 'nonexistent' not found"):
+            Column("nonexistent").evaluate(df)
+
+    def test_missing_column_suggests_close_match(self):
+        df = _group_with_properties()
+        with pytest.raises(ValueError, match="Did you mean"):
+            Column("hydrophobicty").evaluate(df)  # typo
+
+    def test_in_arithmetic(self):
+        df = _group_with_properties()
+        expr = 0.5 * Affinity.score - 0.2 * Column("cysteine_count")
+        val = expr.evaluate(df)
+        assert val == 0.5 * 0.8 - 0.2 * 0.0
+
+    def test_empty_df(self):
+        df = _make_df([])
+        val = Column("anything").evaluate(df)
+        assert math.isnan(val)
+
+    def test_nan_value(self):
+        df = _make_df([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=0.5, value=100.0,
+            percentile_rank=1.0, charge=float("nan"),
+        )])
+        val = Column("charge").evaluate(df)
+        assert math.isnan(val)
+
+    def test_transforms(self):
+        """Column supports all Expr transforms."""
+        df = _group_with_properties()
+        # charge = -1.0
+        assert abs(Column("charge")).evaluate(df) == 1.0
+        assert Column("charge").clip(lo=0).evaluate(df) == 0.0
+
+
+class TestColumnFilter:
+    def test_parse_column_filter(self):
+        f = parse_filter("column(cysteine_count) <= 2")
+        assert isinstance(f, ColumnFilter)
+        assert f.col_name == "cysteine_count"
+        assert f.max_value == 2.0
+
+    def test_parse_column_filter_ge(self):
+        f = parse_filter("column(hydrophobicity) >= -0.5")
+        assert isinstance(f, ColumnFilter)
+        assert f.col_name == "hydrophobicity"
+        assert f.min_value == -0.5
+
+    def test_column_filter_in_strategy(self):
+        df = _make_df([
+            dict(
+                source_sequence_name="seq1", peptide="AAA", peptide_offset=0,
+                allele="A", kind="pMHC_affinity", score=0.9, value=50.0,
+                percentile_rank=0.1, cysteine_count=0,
+            ),
+            dict(
+                source_sequence_name="seq1", peptide="CCC", peptide_offset=5,
+                allele="A", kind="pMHC_affinity", score=0.8, value=80.0,
+                percentile_rank=0.2, cysteine_count=3,
+            ),
+        ])
+        strategy = RankingStrategy(
+            filters=[ColumnFilter("cysteine_count", max_value=1)]
+        )
+        result = apply_ranking_strategy(df, strategy)
+        assert set(result["peptide"]) == {"AAA"}
+
+    def test_column_filter_combined_with_epitope_filter(self):
+        f = parse_ranking("affinity <= 500 & column(cysteine_count) <= 2")
+        assert isinstance(f, RankingStrategy)
+        assert f.require_all is True
+        assert len(f.filters) == 2
+
+    def test_column_filter_or(self):
+        f = parse_ranking("affinity <= 500 | column(charge) >= 0")
+        assert isinstance(f, RankingStrategy)
+        assert f.require_all is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: WT()
+# ---------------------------------------------------------------------------
+
+
+class TestWT:
+    def test_basic_wt_access(self):
+        df = _group_with_wt()
+        assert WT(Affinity).value.evaluate(df) == 800.0
+        assert WT(Affinity).score.evaluate(df) == 0.3
+        assert WT(Affinity).rank.evaluate(df) == 5.0
+
+    def test_differential_binding(self):
+        df = _group_with_wt()
+        diff = Affinity.score - WT(Affinity).score
+        val = diff.evaluate(df)
+        assert val == 0.8 - 0.3
+
+    def test_wt_qualified(self):
+        df = _group_with_wt()
+        val = WT(Affinity["netmhcpan"]).value.evaluate(df)
+        assert val == 800.0
+
+    def test_wt_bracket_on_wt(self):
+        """WT(Affinity)["netmhcpan"] also works."""
+        df = _group_with_wt()
+        val = WT(Affinity)["netmhcpan"].value.evaluate(df)
+        assert val == 800.0
+
+    def test_wt_no_columns_returns_nan(self):
+        """When wt_* columns don't exist, returns NaN."""
+        df = _basic_group()
+        val = WT(Affinity).value.evaluate(df)
+        assert math.isnan(val)
+
+    def test_wt_comparison_raises(self):
+        """WT fields can't be used in filters — only in ranking expressions."""
+        with pytest.raises(TypeError, match="WT fields can't be used in filters"):
+            WT(Affinity) <= 1000
+
+    def test_wt_logistic(self):
+        df = _group_with_wt()
+        val = WT(Affinity).logistic(350, 150).evaluate(df)
+        assert 0 < val < 0.5  # WT IC50=800, above midpoint
+
+    def test_wt_norm(self):
+        df = _group_with_wt()
+        val = WT(Affinity).norm(500, 200).evaluate(df)
+        assert isinstance(val, float)
+        assert not math.isnan(val)
+
+    def test_wt_arithmetic(self):
+        df = _group_with_wt()
+        expr = 0.5 * WT(Affinity) + 0.5 * Affinity
+        val = expr.evaluate(df)
+        assert val == 0.5 * 800.0 + 0.5 * 120.0
+
+    def test_wt_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="expects a KindAccessor"):
+            WT("not an accessor")
+
+    def test_wt_presentation(self):
+        df = _group_with_wt()
+        val = WT(Presentation).score.evaluate(df)
+        assert val == 0.4
+
+
+# ---------------------------------------------------------------------------
+# Tests: peptide properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    def test_add_all(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df)
+        assert "charge" in result.columns
+        assert "hydrophobicity" in result.columns
+        assert "aromaticity" in result.columns
+        assert "molecular_weight" in result.columns
+        assert "cysteine_count" in result.columns
+        assert "instability_index" in result.columns
+        assert "tcr_charge" in result.columns
+
+    def test_core_group(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df, groups=["core"])
+        assert "charge" in result.columns
+        assert "hydrophobicity" in result.columns
+        assert "aromaticity" in result.columns
+        assert "molecular_weight" in result.columns
+        assert "cysteine_count" not in result.columns
+        assert "tcr_charge" not in result.columns
+
+    def test_manufacturability_group(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df, groups=["manufacturability"])
+        assert "cysteine_count" in result.columns
+        assert "asp_pro_bonds" in result.columns
+        assert "difficult_nterm" in result.columns
+        # core is included
+        assert "charge" in result.columns
+        # immunogenicity-only excluded
+        assert "tcr_charge" not in result.columns
+
+    def test_immunogenicity_group(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df, groups=["immunogenicity"])
+        assert "tcr_charge" in result.columns
+        assert "tcr_aromaticity" in result.columns
+        assert "tcr_hydrophobicity" in result.columns
+        # core is included
+        assert "charge" in result.columns
+
+    def test_include_specific(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df, include=["charge", "cysteine_count"])
+        assert "charge" in result.columns
+        assert "cysteine_count" in result.columns
+        assert "hydrophobicity" not in result.columns
+
+    def test_charge_values(self):
+        from topiary.properties import add_peptide_properties
+        # K and R are +1, E and D are -1
+        df = _make_df([
+            dict(peptide="KKRR"),    # +4
+            dict(peptide="DDEE"),    # -4
+            dict(peptide="AAAA"),    # 0
+            dict(peptide="KRDE"),    # 0
+        ])
+        result = add_peptide_properties(df, include=["charge"])
+        assert list(result["charge"]) == pytest.approx([4.0, -4.0, 0.0, 0.0], abs=0.2)
+
+    def test_aromaticity_counts(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([
+            dict(peptide="FWY"),     # 3
+            dict(peptide="AAA"),     # 0
+            dict(peptide="AFWY"),    # 3
+        ])
+        result = add_peptide_properties(df, include=["aromaticity"])
+        assert list(result["aromaticity"]) == [3, 0, 3]
+
+    def test_cysteine_count(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([
+            dict(peptide="CCCC"),
+            dict(peptide="AAAA"),
+            dict(peptide="ACAC"),
+        ])
+        result = add_peptide_properties(df, include=["cysteine_count"])
+        assert list(result["cysteine_count"]) == [4, 0, 2]
+
+    def test_asp_pro_bonds(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([
+            dict(peptide="ADPGDP"),   # 2 DP bonds
+            dict(peptide="AAPAA"),    # 0
+            dict(peptide="DPAAA"),    # 1
+        ])
+        result = add_peptide_properties(df, include=["asp_pro_bonds"])
+        assert list(result["asp_pro_bonds"]) == [2, 0, 1]
+
+    def test_difficult_nterm(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([
+            dict(peptide="QAAA"),   # Q → difficult
+            dict(peptide="EAAA"),   # E → difficult
+            dict(peptide="CAAA"),   # C → difficult
+            dict(peptide="AAAA"),   # A → fine
+        ])
+        result = add_peptide_properties(df, include=["difficult_nterm"])
+        assert list(result["difficult_nterm"]) == [True, True, True, False]
+
+    def test_difficult_cterm(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([
+            dict(peptide="AAAP"),   # P → difficult
+            dict(peptide="AAAC"),   # C → difficult
+            dict(peptide="AAAA"),   # A → fine
+        ])
+        result = add_peptide_properties(df, include=["difficult_cterm"])
+        assert list(result["difficult_cterm"]) == [True, True, False]
+
+    def test_tcr_properties_9mer(self):
+        from topiary.properties import add_peptide_properties
+        # 9-mer: TCR positions are p4,p5,p6,p8 (0-indexed: 3,4,5,7)
+        # SIINFEKL? → need 9-mer
+        df = _make_df([dict(peptide="AAAAFFFAA")])
+        # TCR-facing: positions 3,4,5,7 = A,F,F,A → 2 aromatic
+        result = add_peptide_properties(df, include=["tcr_aromaticity"])
+        assert result["tcr_aromaticity"].iloc[0] == 2
+
+    def test_tcr_nan_for_unsupported_length(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="AAAAAAAAAAAAAAAA")])  # 16-mer, no TCR map
+        result = add_peptide_properties(df, include=["tcr_aromaticity"])
+        assert math.isnan(result["tcr_aromaticity"].iloc[0])
+
+    def test_prefix(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="AAA", wt_peptide="KKK")])
+        result = add_peptide_properties(
+            df, include=["charge"], peptide_column="wt_peptide", prefix="wt_"
+        )
+        assert "wt_charge" in result.columns
+        assert result["wt_charge"].iloc[0] == pytest.approx(3.0)
+
+    def test_unknown_property_raises(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="AAA")])
+        with pytest.raises(ValueError, match="Unknown properties"):
+            add_peptide_properties(df, include=["nonexistent"])
+
+    def test_unknown_group_raises(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="AAA")])
+        with pytest.raises(ValueError, match="Unknown groups"):
+            add_peptide_properties(df, groups=["bogus"])
+
+    def test_missing_peptide_column_raises(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(sequence="AAA")])
+        with pytest.raises(ValueError, match="Column 'peptide' not found"):
+            add_peptide_properties(df)
+
+    def test_does_not_mutate_input(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        original_cols = set(df.columns)
+        add_peptide_properties(df, include=["charge"])
+        assert set(df.columns) == original_cols
+
+    def test_molecular_weight_reasonable(self):
+        from topiary.properties import add_peptide_properties
+        df = _make_df([dict(peptide="SIINFEKL")])
+        result = add_peptide_properties(df, include=["molecular_weight"])
+        mw = result["molecular_weight"].iloc[0]
+        # SIINFEKL is ~963 Da
+        assert 900 < mw < 1050
+
+    def test_instability_index_uses_dipeptides(self):
+        from topiary.properties import add_peptide_properties
+        # A sequence with known high instability
+        df = _make_df([
+            dict(peptide="AAAAAA"),  # mostly neutral dipeptides
+            dict(peptide="HYHY"),    # HY has DIWV=44.94
+        ])
+        result = add_peptide_properties(df, include=["instability_index"])
+        # HYHY should have higher instability than AAAAAA
+        assert result["instability_index"].iloc[1] > result["instability_index"].iloc[0]
+
+

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -1,6 +1,8 @@
 from .predictor import TopiaryPredictor
 from .ranking import (
     Affinity,
+    Column,
+    ColumnFilter,
     EpitopeFilter,
     Expr,
     KindAccessor,
@@ -8,6 +10,7 @@ from .ranking import (
     Processing,
     RankingStrategy,
     Stability,
+    WT,
     affinity_filter,
     apply_ranking_strategy,
     parse_ranking,
@@ -25,6 +28,8 @@ __version__ = "4.4.0"
 __all__ = [
     "TopiaryPredictor",
     "Affinity",
+    "Column",
+    "ColumnFilter",
     "EpitopeFilter",
     "Expr",
     "KindAccessor",
@@ -32,6 +37,7 @@ __all__ = [
     "Processing",
     "RankingStrategy",
     "Stability",
+    "WT",
     "affinity_filter",
     "apply_ranking_strategy",
     "presentation_filter",

--- a/topiary/properties.py
+++ b/topiary/properties.py
@@ -1,0 +1,327 @@
+"""
+Peptide amino acid properties for ranking and analysis.
+
+Computes properties directly from the peptide sequence column using
+vectorized pandas string operations. All properties are pure functions
+of the amino acid sequence — no external dependencies.
+
+Usage::
+
+    from topiary.properties import add_peptide_properties
+
+    df = predictor.predict_from_named_sequences(seqs)
+    df = add_peptide_properties(df)                             # all properties
+    df = add_peptide_properties(df, groups=["core"])            # named group
+    df = add_peptide_properties(df, include=["charge", "cysteine_count"])
+
+Then use in ranking via :class:`~topiary.ranking.Column`::
+
+    from topiary.ranking import Column, Affinity
+    score = 0.5 * Affinity.score - 0.2 * Column("cysteine_count")
+"""
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Amino acid property tables
+# ---------------------------------------------------------------------------
+
+# Kyte-Doolittle hydrophobicity scale
+_KD_HYDRO = {
+    "A": 1.8, "R": -4.5, "N": -3.5, "D": -3.5, "C": 2.5,
+    "Q": -3.5, "E": -3.5, "G": -0.4, "H": -3.2, "I": 4.5,
+    "L": 3.8, "K": -3.9, "M": 1.9, "F": 2.8, "P": -1.6,
+    "S": -0.8, "T": -0.7, "W": -0.9, "Y": -1.3, "V": 4.2,
+}
+
+# Net charge at pH 7.4 (simple model: K,R = +1; D,E = -1; H ≈ +0.1)
+_CHARGE = {
+    "K": 1.0, "R": 1.0, "H": 0.1, "D": -1.0, "E": -1.0,
+}
+
+# Average amino acid molecular weights (Da)
+_MASS = {
+    "A": 89.09, "R": 174.20, "N": 132.12, "D": 133.10, "C": 121.16,
+    "Q": 146.15, "E": 147.13, "G": 75.03, "H": 155.16, "I": 131.17,
+    "L": 131.17, "K": 146.19, "M": 149.21, "F": 165.19, "P": 115.13,
+    "S": 105.09, "T": 119.12, "W": 204.23, "Y": 181.19, "V": 117.15,
+}
+
+# Instability index dipeptide weights (Guruprasad et al. 1990)
+# Subset of the 400 dipeptide DIWV values; missing pairs default to 0.
+_DIWV = {
+    "WW": 1.0, "WC": 1.0, "WM": 24.68, "CW": -14.03,
+    "CH": 33.60, "CK": -7.49, "CC": 1.0, "CF": -6.54,
+    "WG": -9.37, "WL": -7.49, "DG": 1.0, "DK": -7.49,
+    "DD": 1.0, "DE": 1.0, "DF": -6.54, "DW": 1.0,
+    "DY": 1.0, "DA": 2.36, "DN": 2.05, "DR": -6.54,
+    "DS": 0.46, "EG": -6.54, "EK": -7.49, "ED": 2.27,
+    "EE": 33.60, "EF": -6.54, "EW": -14.03, "EY": -6.54,
+    "EA": 11.0, "EN": 1.0, "ER": 2.36, "ES": 0.46,
+    "FW": 1.0, "FL": 1.0, "FK": -14.03, "FD": 13.34,
+    "FE": -6.54, "FF": 1.0, "FG": 1.0, "FY": 33.60,
+    "FA": 1.0, "GG": 13.34, "GK": -7.49, "GD": -7.49,
+    "GE": -6.54, "GF": -6.54, "GW": 13.34, "GY": -7.49,
+    "GA": -7.49, "GN": -7.49, "GR": 1.0, "GS": 1.0,
+    "HG": 1.0, "HK": 24.68, "HD": 1.0, "HE": 1.0,
+    "HF": -6.54, "HW": -1.88, "HY": 44.94, "HA": 1.0,
+    "HN": 24.68, "HR": 1.0, "HS": 2.36, "IG": 1.0,
+    "IK": -7.49, "ID": 1.0, "IE": 44.94, "IF": 1.0,
+    "IW": 1.0, "IY": 1.0, "IA": 1.0, "IN": 1.0,
+    "IR": 1.0, "IS": 1.0, "KG": -7.49, "KK": 1.0,
+    "KD": 1.0, "KE": 1.0, "KF": 1.0, "KW": 1.0,
+    "KY": 1.0, "KA": 1.0, "KN": 1.0, "KR": 33.60,
+    "KS": 1.0, "LG": 14.45, "LK": -7.49, "LD": 1.0,
+    "LE": -6.54, "LF": 1.0, "LW": 24.68, "LY": 1.0,
+    "LA": 1.0, "LN": 1.0, "LR": -6.54, "LS": 1.0,
+    "MG": 1.0, "MK": 1.0, "MD": 1.0, "ME": 1.0,
+    "MF": 1.0, "MW": 1.0, "MY": 24.68, "MA": 13.34,
+    "MN": 1.0, "MR": -6.54, "MS": 44.94, "NG": -14.03,
+    "NK": 1.0, "ND": 1.0, "NE": 1.0, "NF": -14.03,
+    "NW": -9.37, "NY": 1.0, "NA": 1.0, "NN": 1.0,
+    "NR": 1.0, "NS": 1.0, "PG": 1.0, "PK": 1.0,
+    "PD": -6.54, "PE": 18.38, "PF": 20.26, "PW": -1.88,
+    "PY": 1.0, "PA": 20.26, "PN": -6.54, "PR": -6.54,
+    "PS": 20.26, "QG": 1.0, "QK": 1.0, "QD": 20.26,
+    "QE": 33.60, "QF": -6.54, "QW": 1.0, "QY": -6.54,
+    "QA": 1.0, "QN": 1.0, "QR": 1.0, "QS": 44.94,
+    "RG": -7.49, "RK": 1.0, "RD": 1.0, "RE": 1.0,
+    "RF": 1.0, "RW": 58.28, "RY": -6.54, "RA": 1.0,
+    "RN": 13.34, "RR": 58.28, "RS": 44.94, "SG": 1.0,
+    "SK": 1.0, "SD": 1.0, "SE": 1.0, "SF": 1.0,
+    "SW": 1.0, "SY": 1.0, "SA": 1.0, "SN": 1.0,
+    "SR": 20.26, "SS": 1.0, "TG": -7.49, "TK": 1.0,
+    "TD": 1.0, "TE": 1.0, "TF": 13.34, "TW": -14.03,
+    "TY": 1.0, "TA": 1.0, "TN": -14.03, "TR": 1.0,
+    "TS": 1.0, "VG": -7.49, "VK": -7.49, "VD": -14.03,
+    "VE": 1.0, "VF": 1.0, "VW": 1.0, "VY": -7.49,
+    "VA": 1.0, "VN": 1.0, "VR": 1.0, "VS": 1.0,
+    "WK": 1.0, "WD": 1.0, "WE": 1.0, "WF": 1.0,
+    "WY": 1.0, "WA": -14.03, "WN": 13.34, "WR": 1.0,
+    "WS": 1.0, "YG": -7.49, "YK": 1.0, "YD": 24.68,
+    "YE": -6.54, "YF": 13.34, "YW": -9.37, "YY": 13.34,
+    "YA": 24.68, "YN": 1.0, "YR": -15.91, "YS": 1.0,
+}
+
+# TCR-facing positions for MHC-I peptides (0-indexed)
+_TCR_POSITIONS = {
+    8: [3, 4, 5, 6],       # 8-mer: p4-p7
+    9: [3, 4, 5, 7],       # 9-mer: p4,p5,p6,p8
+    10: [3, 4, 5, 6, 8],   # 10-mer: p4-p7,p9
+    11: [3, 4, 5, 6, 7, 9],  # 11-mer: p4-p8,p10
+}
+
+_DIFFICULT_NTERM = {"Q", "E", "C"}
+_DIFFICULT_CTERM = {"P", "C"}
+
+
+# ---------------------------------------------------------------------------
+# Per-peptide computation functions (operate on a single string)
+# ---------------------------------------------------------------------------
+
+
+def _sum_lookup(peptide, table):
+    return sum(table.get(c, 0.0) for c in peptide)
+
+
+def _mean_lookup(peptide, table):
+    if not peptide:
+        return 0.0
+    return _sum_lookup(peptide, table) / len(peptide)
+
+
+def _max_window_mean(peptide, table, window=7):
+    """Max mean of a sliding window across the peptide."""
+    if len(peptide) <= window:
+        return _mean_lookup(peptide, table)
+    values = [table.get(c, 0.0) for c in peptide]
+    best = -float("inf")
+    window_sum = sum(values[:window])
+    best = window_sum / window
+    for i in range(1, len(values) - window + 1):
+        window_sum += values[i + window - 1] - values[i - 1]
+        best = max(best, window_sum / window)
+    return best
+
+
+def _instability_index(peptide):
+    """Guruprasad instability index (>40 = unstable)."""
+    if len(peptide) < 2:
+        return 0.0
+    total = sum(_DIWV.get(peptide[i:i+2], 0.0) for i in range(len(peptide) - 1))
+    return (10.0 / len(peptide)) * total
+
+
+def _tcr_residues(peptide):
+    """Extract TCR-facing residues for MHC-I peptides."""
+    positions = _TCR_POSITIONS.get(len(peptide))
+    if positions is None:
+        return None
+    return "".join(peptide[i] for i in positions if i < len(peptide))
+
+
+# ---------------------------------------------------------------------------
+# Property registry
+# ---------------------------------------------------------------------------
+
+# Each property: (column_name, compute_fn(peptides: pd.Series) -> pd.Series)
+
+def _compute_charge(peptides):
+    return peptides.apply(lambda p: _sum_lookup(p, _CHARGE))
+
+
+def _compute_hydrophobicity(peptides):
+    return peptides.apply(lambda p: _mean_lookup(p, _KD_HYDRO))
+
+
+def _compute_aromaticity(peptides):
+    return peptides.str.count("[FWY]")
+
+
+def _compute_molecular_weight(peptides):
+    # Sum of residue masses minus (n-1) water molecules lost in peptide bonds
+    return peptides.apply(
+        lambda p: _sum_lookup(p, _MASS) - 18.015 * (len(p) - 1) if p else 0.0
+    )
+
+
+def _compute_cysteine_count(peptides):
+    return peptides.str.count("C")
+
+
+def _compute_instability_index(peptides):
+    return peptides.apply(_instability_index)
+
+
+def _compute_max_7mer_hydrophobicity(peptides):
+    return peptides.apply(lambda p: _max_window_mean(p, _KD_HYDRO, 7))
+
+
+def _compute_cterm_7mer_hydrophobicity(peptides):
+    return peptides.apply(lambda p: _mean_lookup(p[-7:], _KD_HYDRO))
+
+
+def _compute_difficult_nterm(peptides):
+    return peptides.str[0].isin(_DIFFICULT_NTERM)
+
+
+def _compute_difficult_cterm(peptides):
+    return peptides.str[-1].isin(_DIFFICULT_CTERM)
+
+
+def _compute_asp_pro_bonds(peptides):
+    return peptides.str.count("DP")
+
+
+def _compute_tcr_charge(peptides):
+    return peptides.apply(
+        lambda p: _sum_lookup(r, _CHARGE) if (r := _tcr_residues(p)) else float("nan")
+    )
+
+
+def _compute_tcr_aromaticity(peptides):
+    return peptides.apply(
+        lambda p: sum(1 for c in r if c in "FWY") if (r := _tcr_residues(p)) else float("nan")
+    )
+
+
+def _compute_tcr_hydrophobicity(peptides):
+    return peptides.apply(
+        lambda p: _mean_lookup(r, _KD_HYDRO) if (r := _tcr_residues(p)) else float("nan")
+    )
+
+
+# Property name -> (compute function, groups it belongs to)
+_PROPERTIES = {
+    "charge":                    (_compute_charge, {"core", "manufacturability", "immunogenicity"}),
+    "hydrophobicity":            (_compute_hydrophobicity, {"core", "manufacturability", "immunogenicity"}),
+    "aromaticity":               (_compute_aromaticity, {"core", "manufacturability", "immunogenicity"}),
+    "molecular_weight":          (_compute_molecular_weight, {"core", "manufacturability", "immunogenicity"}),
+    "cysteine_count":            (_compute_cysteine_count, {"manufacturability"}),
+    "instability_index":         (_compute_instability_index, {"manufacturability"}),
+    "max_7mer_hydrophobicity":   (_compute_max_7mer_hydrophobicity, {"manufacturability"}),
+    "cterm_7mer_hydrophobicity": (_compute_cterm_7mer_hydrophobicity, {"manufacturability"}),
+    "difficult_nterm":           (_compute_difficult_nterm, {"manufacturability"}),
+    "difficult_cterm":           (_compute_difficult_cterm, {"manufacturability"}),
+    "asp_pro_bonds":             (_compute_asp_pro_bonds, {"manufacturability"}),
+    "tcr_charge":                (_compute_tcr_charge, {"immunogenicity"}),
+    "tcr_aromaticity":           (_compute_tcr_aromaticity, {"immunogenicity"}),
+    "tcr_hydrophobicity":        (_compute_tcr_hydrophobicity, {"immunogenicity"}),
+}
+
+
+def available_properties():
+    """Return dict of property_name -> set of groups it belongs to."""
+    return {name: groups for name, (_, groups) in _PROPERTIES.items()}
+
+
+def add_peptide_properties(
+    df,
+    groups=None,
+    include=None,
+    peptide_column="peptide",
+    prefix="",
+):
+    """Add amino acid property columns to a predictions DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain a column with peptide sequences.
+
+    groups : list of str, optional
+        Named property groups: ``"core"``, ``"manufacturability"``,
+        ``"immunogenicity"``. If None and include is None, computes all.
+
+    include : list of str, optional
+        Specific property names to compute. Overrides groups.
+
+    peptide_column : str
+        Column containing peptide sequences (default ``"peptide"``).
+
+    prefix : str
+        Prefix for output column names (e.g. ``"wt_"`` for WT peptides).
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy with new property columns added.
+    """
+    if peptide_column not in df.columns:
+        raise ValueError(
+            f"Column {peptide_column!r} not found. "
+            f"Available: {sorted(df.columns)}"
+        )
+
+    if include is not None:
+        names = include
+        bad = [n for n in names if n not in _PROPERTIES]
+        if bad:
+            raise ValueError(
+                f"Unknown properties: {bad}. "
+                f"Available: {sorted(_PROPERTIES.keys())}"
+            )
+    elif groups is not None:
+        group_set = set(groups)
+        bad = group_set - {"core", "manufacturability", "immunogenicity"}
+        if bad:
+            raise ValueError(
+                f"Unknown groups: {sorted(bad)}. "
+                f"Available: core, manufacturability, immunogenicity"
+            )
+        names = [
+            name for name, (_, prop_groups) in _PROPERTIES.items()
+            if prop_groups & group_set
+        ]
+    else:
+        names = list(_PROPERTIES.keys())
+
+    df = df.copy()
+    peptides = df[peptide_column]
+    for name in names:
+        compute_fn, _ = _PROPERTIES[name]
+        df[prefix + name] = compute_fn(peptides)
+
+    return df

--- a/topiary/properties.py
+++ b/topiary/properties.py
@@ -20,8 +20,6 @@ Then use in ranking via :class:`~topiary.ranking.Column`::
     score = 0.5 * Affinity.score - 0.2 * Column("cysteine_count")
 """
 
-import numpy as np
-import pandas as pd
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -66,6 +66,16 @@ class Expr:
         """
         return _NormExpr(self, mean, std)
 
+    def logistic(self, midpoint=0.0, width=1.0):
+        """Logistic sigmoid: ``1 / (1 + exp((x - midpoint) / width))``.
+
+        Maps values to (0, 1). For IC50 scoring (lower is better),
+        Vaxrank uses ``midpoint=350, width=150``::
+
+            Affinity.logistic(midpoint=350, width=150)
+        """
+        return _LogisticExpr(self, midpoint, width)
+
     # -- arithmetic --
 
     def __add__(self, other):
@@ -191,6 +201,27 @@ class _NormExpr(Expr):
         return _gauss_cdf((val - self.mean) / self.std)
 
 
+class _LogisticExpr(Expr):
+    """Logistic sigmoid of an inner expression."""
+    __slots__ = ("inner", "midpoint", "width")
+
+    def __init__(self, inner, midpoint, width):
+        self.inner = inner
+        self.midpoint = float(midpoint)
+        self.width = float(width)
+
+    def evaluate(self, group_df):
+        val = self.inner.evaluate(group_df)
+        if val is None or (isinstance(val, float) and math.isnan(val)):
+            return float("nan")
+        if self.width == 0:
+            return float("nan")
+        try:
+            return 1.0 / (1.0 + math.exp((val - self.midpoint) / self.width))
+        except OverflowError:
+            return 0.0
+
+
 class _UnaryOp(Expr):
     """Apply a unary function to an inner expression."""
     __slots__ = ("inner", "fn")
@@ -248,6 +279,47 @@ def _method_not_found_error(kind_name, method, available):
         suggestions = [next(a for a in available if a.lower() == c) for c in close]
         msg += f". Did you mean: {suggestions}?"
     return ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Column — reference any DataFrame column in an expression
+# ---------------------------------------------------------------------------
+
+
+class Column(Expr):
+    """Reference an arbitrary column in the predictions DataFrame.
+
+    Reads the value from the first row of the group (peptide-level columns
+    are constant across kind rows within a group).
+
+    Use for peptide properties, variant metadata, or any custom annotation::
+
+        Column("hydrophobicity") >= -0.5
+        Column("n_alt_reads").sqrt()
+        0.5 * Affinity.score - 0.2 * Column("cysteine_count")
+    """
+
+    __slots__ = ("col_name",)
+
+    def __init__(self, col_name: str):
+        self.col_name = col_name
+
+    def evaluate(self, group_df):
+        if group_df.empty:
+            return float("nan")
+        if self.col_name not in group_df.columns:
+            available = sorted(group_df.columns)
+            close = get_close_matches(self.col_name, available, n=3, cutoff=0.6)
+            msg = f"Column {self.col_name!r} not found in DataFrame."
+            if close:
+                msg += f" Did you mean: {close}?"
+            else:
+                msg += f" Available: {available}"
+            raise ValueError(msg)
+        val = group_df.iloc[0][self.col_name]
+        if val is None or (isinstance(val, float) and math.isnan(val)):
+            return float("nan")
+        return float(val)
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +391,12 @@ class Field(Expr):
     # -- filter comparisons (only valid on Field, not compound Expr) --
 
     def __le__(self, threshold):
+        if self.field.startswith("wt_"):
+            raise TypeError(
+                "WT fields can't be used in filters directly. "
+                "Use WT() in ranking expressions instead, e.g.: "
+                "rank_by=[Affinity.score - WT(Affinity).score]"
+            )
         if self.field == "value":
             return EpitopeFilter(kind=self.kind, max_value=threshold, method=self.method)
         if self.field == "percentile_rank":
@@ -328,6 +406,12 @@ class Field(Expr):
         raise ValueError(f"Cannot apply <= to field {self.field!r}")
 
     def __ge__(self, threshold):
+        if self.field.startswith("wt_"):
+            raise TypeError(
+                "WT fields can't be used in filters directly. "
+                "Use WT() in ranking expressions instead, e.g.: "
+                "rank_by=[Affinity.score - WT(Affinity).score]"
+            )
         if self.field == "score":
             return EpitopeFilter(kind=self.kind, min_score=threshold, method=self.method)
         if self.field == "value":
@@ -411,6 +495,9 @@ class KindAccessor:
     def norm(self, mean=0.0, std=1.0):
         return self.value.norm(mean, std)
 
+    def logistic(self, midpoint=0.0, width=1.0):
+        return self.value.logistic(midpoint, width)
+
     def clip(self, lo=None, hi=None):
         return self.value.clip(lo, hi)
 
@@ -465,6 +552,111 @@ Processing = KindAccessor(Kind.antigen_processing)
 
 
 # ---------------------------------------------------------------------------
+# WT — wildtype comparison wrapper
+# ---------------------------------------------------------------------------
+
+
+class WT:
+    """Wrap a KindAccessor to read wildtype prediction columns.
+
+    The ``add_wildtype_predictions()`` step populates ``wt_value``,
+    ``wt_score``, and ``wt_percentile_rank`` columns alongside the
+    mutant values.  ``WT()`` reads those instead::
+
+        WT(Affinity).value                        # WT IC50
+        WT(Affinity["netmhcpan"]).score           # qualified WT
+        Affinity.score - WT(Affinity).score       # differential binding
+        WT(Affinity) <= 500                        # filter on WT value
+
+    When WT columns don't exist (non-variant inputs), evaluates to NaN.
+    """
+
+    __slots__ = ("_accessor",)
+
+    def __init__(self, accessor: KindAccessor):
+        if not isinstance(accessor, KindAccessor):
+            raise TypeError(
+                f"WT() expects a KindAccessor (e.g. Affinity, "
+                f"Presentation), got {type(accessor).__name__}"
+            )
+        self._accessor = accessor
+
+    def __getitem__(self, method: str) -> "WT":
+        return WT(self._accessor[method])
+
+    @property
+    def value(self) -> Field:
+        return Field(self._accessor.kind, "wt_value", method=self._accessor.method)
+
+    @property
+    def rank(self) -> Field:
+        return Field(self._accessor.kind, "wt_percentile_rank", method=self._accessor.method)
+
+    @property
+    def score(self) -> Field:
+        return Field(self._accessor.kind, "wt_score", method=self._accessor.method)
+
+    def _filter_error(self):
+        raise TypeError(
+            "WT fields can't be used in filters directly. "
+            "Use WT() in ranking expressions instead, e.g.: "
+            "rank_by=[Affinity.score - WT(Affinity).score]"
+        )
+
+    def __le__(self, other):
+        self._filter_error()
+
+    def __lt__(self, other):
+        self._filter_error()
+
+    def __ge__(self, other):
+        self._filter_error()
+
+    def __gt__(self, other):
+        self._filter_error()
+
+    # Delegate Expr methods to .value for use in ranking expressions
+    def norm(self, mean=0.0, std=1.0):
+        return self.value.norm(mean, std)
+
+    def logistic(self, midpoint=0.0, width=1.0):
+        return self.value.logistic(midpoint, width)
+
+    def clip(self, lo=None, hi=None):
+        return self.value.clip(lo, hi)
+
+    def __neg__(self):
+        return -self.value
+
+    def __abs__(self):
+        return abs(self.value)
+
+    def __add__(self, other):
+        return self.value + other
+
+    def __radd__(self, other):
+        return other + self.value
+
+    def __sub__(self, other):
+        return self.value - other
+
+    def __rsub__(self, other):
+        return other - self.value
+
+    def __mul__(self, other):
+        return self.value * other
+
+    def __rmul__(self, other):
+        return other * self.value
+
+    def __truediv__(self, other):
+        return self.value / other
+
+    def __rtruediv__(self, other):
+        return other / self.value
+
+
+# ---------------------------------------------------------------------------
 # Filter / strategy dataclasses with operator support
 # ---------------------------------------------------------------------------
 
@@ -497,6 +689,30 @@ class EpitopeFilter:
         return _combine(self, other, require_all=True)
 
     def rank_by(self, *exprs: Expr) -> RankingStrategy:
+        return RankingStrategy(filters=[self], sort_by=list(exprs))
+
+
+@dataclass(frozen=True)
+class ColumnFilter:
+    """A filter criterion on an arbitrary DataFrame column.
+
+    Created via CLI ``column(name) <= threshold`` or programmatically::
+
+        ColumnFilter("cysteine_count", max_value=2)
+        ColumnFilter("hydrophobicity", min_value=-0.5)
+    """
+
+    col_name: str
+    max_value: Optional[float] = None
+    min_value: Optional[float] = None
+
+    def __or__(self, other):
+        return _combine(self, other, require_all=False)
+
+    def __and__(self, other):
+        return _combine(self, other, require_all=True)
+
+    def rank_by(self, *exprs: Expr) -> "RankingStrategy":
         return RankingStrategy(filters=[self], sort_by=list(exprs))
 
 
@@ -624,6 +840,21 @@ def _group_passes(group_df, strategy):
         if isinstance(item, RankingStrategy):
             # Nested sub-strategy — recurse
             results.append(_group_passes(group_df, item))
+        elif isinstance(item, ColumnFilter):
+            # Column-level filter — check first row
+            if group_df.empty or item.col_name not in group_df.columns:
+                results.append(False)
+                continue
+            val = group_df.iloc[0][item.col_name]
+            if val is None or (isinstance(val, float) and np.isnan(val)):
+                results.append(False)
+                continue
+            passed = True
+            if item.max_value is not None and val > item.max_value:
+                passed = False
+            if item.min_value is not None and val < item.min_value:
+                passed = False
+            results.append(passed)
         else:
             # EpitopeFilter
             kind_rows = group_df[group_df["kind"] == item.kind.value]
@@ -782,6 +1013,14 @@ def _resolve_field(name):
     )
 
 
+def _parse_column_ref(text):
+    """Check if text is a column(name) reference. Returns name or None."""
+    text = text.strip()
+    if text.startswith("column(") and text.endswith(")"):
+        return text[7:-1].strip()
+    return None
+
+
 def parse_filter(text):
     """Parse a single filter expression from a string.
 
@@ -795,16 +1034,28 @@ def parse_filter(text):
         "el.rank <= 2"
         "netmhcpan_affinity <= 500"
         "mhcflurry_el.rank <= 2"
+        "column(cysteine_count) <= 2"
+        "column(hydrophobicity) >= -0.5"
 
-    Returns an :class:`EpitopeFilter`.
+    Returns an :class:`EpitopeFilter` or :class:`ColumnFilter`.
     """
-    # Strip parentheses and whitespace
-    text = text.strip().strip("()")
+    # Strip parentheses and whitespace (but not column() parens)
+    text = text.strip()
+    if not text.startswith("column("):
+        text = text.strip("()")
     for op_str, op_name in [("<=", "le"), (">=", "ge"), ("<", "lt"), (">", "gt")]:
         if op_str in text:
             lhs, rhs = text.split(op_str, 1)
             lhs = lhs.strip()
             threshold = float(rhs.strip())
+
+            # Check for column(name) syntax
+            col_name = _parse_column_ref(lhs)
+            if col_name is not None:
+                if op_name in ("le", "lt"):
+                    return ColumnFilter(col_name=col_name, max_value=threshold)
+                else:
+                    return ColumnFilter(col_name=col_name, min_value=threshold)
 
             if "." in lhs:
                 kind_str, field_str = lhs.rsplit(".", 1)

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -319,7 +319,14 @@ class Column(Expr):
         val = group_df.iloc[0][self.col_name]
         if val is None or (isinstance(val, float) and math.isnan(val)):
             return float("nan")
-        return float(val)
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            raise TypeError(
+                f"Column {self.col_name!r} contains non-numeric value "
+                f"{val!r} ({type(val).__name__}). "
+                f"Only numeric columns can be used in ranking expressions."
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -566,7 +573,10 @@ class WT:
         WT(Affinity).value                        # WT IC50
         WT(Affinity["netmhcpan"]).score           # qualified WT
         Affinity.score - WT(Affinity).score       # differential binding
-        WT(Affinity) <= 500                        # filter on WT value
+        WT(Affinity).logistic(350, 150)           # WT scoring
+
+    WT is for ranking expressions, not filters. Use
+    ``rank_by=[Affinity.score - WT(Affinity).score]``.
 
     When WT columns don't exist (non-variant inputs), evaluates to NaN.
     """
@@ -1017,7 +1027,15 @@ def _parse_column_ref(text):
     """Check if text is a column(name) reference. Returns name or None."""
     text = text.strip()
     if text.startswith("column(") and text.endswith(")"):
-        return text[7:-1].strip()
+        name = text[7:-1].strip()
+        if not name:
+            raise ValueError("column() requires a column name, e.g. column(charge)")
+        if "(" in name or ")" in name:
+            raise ValueError(
+                f"Invalid column name {name!r} — must be a plain name, "
+                f"e.g. column(charge)"
+            )
+        return name
     return None
 
 


### PR DESCRIPTION
## Intent

Extend the ranking/filtering DSL to support the signals needed for Vaxrank-style composite scoring and general immunogenicity/manufacturability analysis. After this PR, users can express:

```python
score = (
    0.4 * Affinity["netmhcpan"].logistic(350, 150)
    + 0.3 * Presentation["mhcflurry"].score
    - 0.1 * Column("cysteine_count")
    - 0.1 * abs(Column("charge"))
    + 0.1 * (Affinity.score - WT(Affinity).score)  # differential binding
)
```

## Changes

### 1. `.logistic(midpoint, width)` on Expr

Logistic sigmoid transform: `1 / (1 + exp((x - midpoint) / width))`. Vaxrank uses `midpoint=350, width=150` for IC50→score conversion. Same pattern as existing `.norm()`.

### 2. `Column("name")` — arbitrary DataFrame column access

New `Expr` subclass that reads any column from the group DataFrame. This is the key unlock: external signals (read counts, expression, peptide properties, custom annotations) become first-class ranking signals without special-casing each one.

```python
Column("hydrophobicity") >= -0.5
Column("n_alt_reads").sqrt()
```

CLI: `column(name)` in filter/ranking strings. Errors with available columns when column is missing.

### 3. `WT(accessor)` — wildtype comparison wrapper

Wraps a `KindAccessor` to read wildtype prediction columns (`wt_value`, `wt_score`, `wt_percentile_rank`) instead of the mutant columns. Avoids duplicating every field on KindAccessor.

```python
WT(Affinity).value                        # WT IC50
WT(Affinity["netmhcpan"]).score           # qualified WT
Affinity.score - WT(Affinity).score       # differential
```

Works with method qualification — same `prediction_method_name` filtering as the mutant side. When WT columns don't exist (non-variant inputs), evaluates to NaN.

### 4. `topiary.properties` — peptide property columns

New module computing amino acid properties directly on the peptide column using vectorized pandas string operations (fast enough for proteome-scale):

```python
from topiary.properties import add_peptide_properties

df = add_peptide_properties(df, groups=["manufacturability"])
```

**Named groups:**
- `"core"`: charge, hydrophobicity, aromaticity, molecular_weight
- `"manufacturability"`: core + cysteine_count, instability_index, max_7mer_hydrophobicity, cterm_7mer_hydrophobicity, difficult_nterm, difficult_cterm, asp_pro_bonds
- `"immunogenicity"`: core + tcr_charge, tcr_aromaticity, tcr_hydrophobicity

Computation uses pandas `str.count()`, `str[n]`, `apply()` with lookup dicts — no external dependencies.

Properties accessible in DSL via `Column("charge")`, `Column("cysteine_count")`, etc.

## Not in this PR

- `add_wildtype_predictions()` function (the step that actually runs WT predictions and populates the `wt_*` columns) — separate PR, depends on predictor refactoring
- Evaluator performance refactor (vectorized filter/sort) — separate PR