### PR TITLE
DSL polish: direction docs, log2/log1p, filter_by, parser errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,9 @@ pyensembl install --release 93 --species human
 pyensembl install --release 75 --species human
 ```
 
-For cancer-testis antigen and tissue expression features:
+Tab completion is built in. To activate for bash/zsh/fish:
 
 ```bash
-pip install pirlygenes
-```
-
-For tab completion of command-line arguments (bash/zsh/fish):
-
-```bash
-pip install 'topiary[completion]'
 activate-global-python-argcomplete
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ from mhctools import NetMHCpan
 predictor = TopiaryPredictor(
     models=[NetMHCpan],
     alleles=["HLA-A*02:01", "HLA-B*07:02"],
-    filter=(Affinity <= 500) | (Presentation.rank <= 2.0),
+    filter_by=(Affinity <= 500) | (Presentation.rank <= 2.0),
     rank_by=[Presentation.score, Affinity.score],
 )
 
@@ -268,18 +268,23 @@ Available: ['mhcflurry', 'netmhcpan']. Did you mean: ['netmhcpan']?
 Expressions support mathematical transforms for composite scoring. These have no CLI string equivalent — use the Python API for composite scores:
 
 ```python
-# Logistic sigmoid (Vaxrank-compatible IC50 scoring)
-Affinity.logistic(midpoint=350, width=150)
+# Normalizing to [0, 1]:
+Affinity.right_cdf(mean=500, std=200)           # lower input → higher output (for IC50, rank)
+Presentation.score.left_cdf(mean=0.5, std=0.3)  # higher input → higher output (for scores)
+Affinity.logistic(midpoint=350, width=150)       # lower input → higher output (sigmoid)
 
-# Gaussian CDF normalization
-Affinity.value.norm(mean=500, std=200)
+# Aggregating across models:
+from topiary import mean, geomean, minimum, maximum, median
+mean(Affinity["netmhcpan"].logistic(350, 150),
+     Affinity["mhcflurry"].logistic(350, 150))
 
-# Arithmetic
+# Arithmetic:
 0.5 * Affinity.score + 0.5 * Presentation.score
 
-# Other transforms
+# Other transforms:
 Affinity.value.clip(lo=1, hi=50000)
-Affinity.value.log()
+Affinity.value.hinge()               # max(0, x)
+Affinity.value.log()                 # also log2(), log10(), log1p()
 Affinity.value.sqrt()
 abs(Affinity.value)
 ```
@@ -329,7 +334,7 @@ Sort surviving peptides after filtering:
 predictor = TopiaryPredictor(
     models=[NetMHCpan, MHCflurry],
     alleles=["HLA-A*02:01"],
-    filter=(Affinity <= 500) | (Presentation.rank <= 2.0),
+    filter_by=(Affinity <= 500) | (Presentation.rank <= 2.0),
     rank_by=[Presentation.score, Affinity.score],  # first non-NaN wins
 )
 ```
@@ -353,7 +358,8 @@ On the CLI:
 | `Column("cysteine_count") <= 2` | `column(cysteine_count) <= 2` |
 | `(A <= 500) \| (B.rank <= 2)` | `affinity <= 500 \| el.rank <= 2` |
 | `0.5 * Affinity.score + ...` | *Python-only* |
-| `.logistic()`, `.norm()`, `.clip()` | *Python-only* |
+| `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()` | *Python-only* |
+| `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()` | *Python-only* |
 | `WT(Affinity).score` | *Python-only* |
 | `Column("x")` in arithmetic | *Python-only* |
 
@@ -520,7 +526,7 @@ score = (
 
     # Manufacturability: penalize cysteines and unstable peptides
     - 0.05 * Column("cysteine_count")
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).norm(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
 
     # Immunogenicity: reward aromatic TCR-facing residues
     + 0.05 * Column("tcr_aromaticity")

--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ Expressions support mathematical transforms for composite scoring. These have no
 
 ```python
 # Normalizing to [0, 1]:
-Affinity.right_cdf(mean=500, std=200)           # lower input → higher output (for IC50, rank)
-Presentation.score.left_cdf(mean=0.5, std=0.3)  # higher input → higher output (for scores)
+Affinity.descending_cdf(mean=500, std=200)           # lower input → higher output (for IC50, rank)
+Presentation.score.ascending_cdf(mean=0.5, std=0.3)  # higher input → higher output (for scores)
 Affinity.logistic(midpoint=350, width=150)       # lower input → higher output (sigmoid)
 
 # Aggregating across models:
@@ -358,7 +358,7 @@ On the CLI:
 | `Column("cysteine_count") <= 2` | `column(cysteine_count) <= 2` |
 | `(A <= 500) \| (B.rank <= 2)` | `affinity <= 500 \| el.rank <= 2` |
 | `0.5 * Affinity.score + ...` | *Python-only* |
-| `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()` | *Python-only* |
+| `.logistic()`, `.ascending_cdf()`, `.descending_cdf()`, `.clip()` | *Python-only* |
 | `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()` | *Python-only* |
 | `WT(Affinity).score` | *Python-only* |
 | `Column("x")` in arithmetic | *Python-only* |
@@ -526,7 +526,7 @@ score = (
 
     # Manufacturability: penalize cysteines and unstable peptides
     - 0.05 * Column("cysteine_count")
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).ascending_cdf(50, 20)
 
     # Immunogenicity: reward aromatic TCR-facing residues
     + 0.05 * Column("tcr_aromaticity")

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,15 +89,41 @@ For ranking expressions only (not filters). Returns NaN when WT columns absent.
 
 | Method | Description |
 |--------|-------------|
-| `.norm(mean, std)` | Gaussian CDF normalization -> [0, 1] |
+| `.left_cdf(mean, std)` | Gaussian CDF: higher input → higher output. Alias: `.norm()` |
+| `.right_cdf(mean, std)` | 1-CDF: lower input → higher output (for IC50, rank) |
 | `.logistic(midpoint, width)` | Logistic sigmoid: `1 / (1 + exp((x - midpoint) / width))` |
 | `.clip(lo, hi)` | Clamp to range |
-| `.log()` / `.log10()` | Logarithm |
+| `.hinge()` | `max(0, x)` — zeroes out negative values |
+| `.log()` / `.log2()` / `.log10()` | Logarithm |
+| `.log1p()` | `log(1 + x)`, accurate for small x |
 | `.exp()` | Exponential |
 | `.sqrt()` | Square root |
 | `abs(expr)` | Absolute value |
 | `expr ** n` | Power |
 | `+`, `-`, `*`, `/` | Arithmetic between expressions and scalars |
+
+## Aggregation functions
+
+Combine multiple expressions, skipping NaN values:
+
+| Function | Description |
+|----------|-------------|
+| `mean(a, b, ...)` | Arithmetic mean |
+| `geomean(a, b, ...)` | Geometric mean (skips non-positive) |
+| `minimum(a, b, ...)` | Minimum value |
+| `maximum(a, b, ...)` | Maximum value |
+| `median(a, b, ...)` | Median (mean of middle two for even count) |
+
+```python
+from topiary import mean, geomean, minimum
+
+# Average binding across models
+mean(Affinity["netmhcpan"].logistic(350, 150),
+     Affinity["mhcflurry"].logistic(350, 150))
+
+# Best binding across models
+minimum(Affinity["netmhcpan"].value, Affinity["mhcflurry"].value)
+```
 
 ## Filter expressions
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,8 +89,8 @@ For ranking expressions only (not filters). Returns NaN when WT columns absent.
 
 | Method | Description |
 |--------|-------------|
-| `.left_cdf(mean, std)` | Gaussian CDF: higher input → higher output. Alias: `.norm()` |
-| `.right_cdf(mean, std)` | 1-CDF: lower input → higher output (for IC50, rank) |
+| `.ascending_cdf(mean, std)` | Gaussian CDF: higher input → higher output. Alias: `.norm()` |
+| `.descending_cdf(mean, std)` | 1-CDF: lower input → higher output (for IC50, rank) |
 | `.logistic(midpoint, width)` | Logistic sigmoid: `1 / (1 + exp((x - midpoint) / width))` |
 | `.clip(lo, hi)` | Clamp to range |
 | `.hinge()` | `max(0, x)` — zeroes out negative values |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ Predict which peptides from protein sequences will be presented by MHC molecules
 - **Multiple prediction models** — NetMHCpan, MHCflurry, NetMHCIIpan, etc. via [mhctools](https://github.com/openvax/mhctools)
 - **Multi-model disambiguation** — `Affinity["netmhcpan"]` bracket syntax when combining models
 - **Composable ranking DSL** — filter, rank, and score with operator expressions
-- **Transforms** — `.logistic()`, `.norm()`, `.clip()`, `.log()`, `.sqrt()` for composite scoring
+- **Transforms** — `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()`, `.hinge()`, `.log()` for composite scoring
+- **Aggregations** — `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()` for combining expressions
 - **Arbitrary column access** — `Column("cysteine_count")` brings any DataFrame column into the DSL
 - **Wildtype comparison** — `WT(Affinity).score` for differential binding analysis
 - **Peptide properties** — charge, hydrophobicity, aromaticity, manufacturability, TCR-facing residue analysis

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Predict which peptides from protein sequences will be presented by MHC molecules
 - **Multiple prediction models** — NetMHCpan, MHCflurry, NetMHCIIpan, etc. via [mhctools](https://github.com/openvax/mhctools)
 - **Multi-model disambiguation** — `Affinity["netmhcpan"]` bracket syntax when combining models
 - **Composable ranking DSL** — filter, rank, and score with operator expressions
-- **Transforms** — `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()`, `.hinge()`, `.log()` for composite scoring
+- **Transforms** — `.logistic()`, `.ascending_cdf()`, `.descending_cdf()`, `.clip()`, `.hinge()`, `.log()` for composite scoring
 - **Aggregations** — `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()` for combining expressions
 - **Arbitrary column access** — `Column("cysteine_count")` brings any DataFrame column into the DSL
 - **Wildtype comparison** — `WT(Affinity).score` for differential binding analysis

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -86,7 +86,7 @@ score = (
     - 0.1 * Column("cysteine_count")
     - 0.1 * abs(Column("charge"))           # prefer neutral peptides
     + 0.1 * Column("tcr_aromaticity")       # reward aromatic TCR contacts
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).norm(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
 )
 ```
 

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -86,7 +86,7 @@ score = (
     - 0.1 * Column("cysteine_count")
     - 0.1 * abs(Column("charge"))           # prefer neutral peptides
     + 0.1 * Column("tcr_aromaticity")       # reward aromatic TCR contacts
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).ascending_cdf(50, 20)
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,7 +54,7 @@ from mhctools import NetMHCpan
 predictor = TopiaryPredictor(
     models=NetMHCpan,
     alleles=["A0201"],
-    filter=Affinity <= 500,
+    filter_by=Affinity <= 500,
 )
 df = predictor.predict_from_sequences(["MASIINFEKLGGG"])
 ```
@@ -68,7 +68,7 @@ from mhctools import NetMHCpan, MHCflurry
 predictor = TopiaryPredictor(
     models=[NetMHCpan, MHCflurry],
     alleles=["A0201", "A0301", "B0702"],
-    filter=Affinity <= 500,
+    filter_by=Affinity <= 500,
     rank_by=Presentation.score,
 )
 ```

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -49,8 +49,8 @@ Expressions support arithmetic and mathematical transforms:
 0.5 * Affinity.score + 0.5 * Presentation.score
 
 # Gaussian CDF normalization -> maps to ~[0, 1]
-Affinity.value.right_cdf(mean=500, std=200)    # lower IC50 → higher output
-Presentation.score.left_cdf(mean=0.5, std=0.3)  # higher score → higher output
+Affinity.value.descending_cdf(mean=500, std=200)    # lower IC50 → higher output
+Presentation.score.ascending_cdf(mean=0.5, std=0.3)  # higher score → higher output
 
 # Logistic sigmoid (Vaxrank-compatible IC50 scoring)
 # 1 / (1 + exp((x - midpoint) / width))
@@ -173,7 +173,7 @@ The `--ranking` flag and `--rank-by` flag accept string expressions:
 **Python-only** (no string form):
 
 - Arithmetic: `0.5 * Affinity.score + 0.5 * Presentation.score`
-- Transforms: `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()`, `.hinge()`, `.log()`
+- Transforms: `.logistic()`, `.ascending_cdf()`, `.descending_cdf()`, `.clip()`, `.hinge()`, `.log()`
 - Aggregations: `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()`
 - `WT()` expressions
 - `Column()` in arithmetic (only `column(x) <= N` works in strings)
@@ -209,7 +209,7 @@ score = (
     + 0.2 * Presentation["mhcflurry"].score
     # Manufacturability
     - 0.05 * Column("cysteine_count")
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).ascending_cdf(50, 20)
     # Immunogenicity
     + 0.05 * Column("tcr_aromaticity")
 )

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -49,7 +49,8 @@ Expressions support arithmetic and mathematical transforms:
 0.5 * Affinity.score + 0.5 * Presentation.score
 
 # Gaussian CDF normalization -> maps to ~[0, 1]
-Affinity.value.norm(mean=500, std=200)
+Affinity.value.right_cdf(mean=500, std=200)    # lower IC50 → higher output
+Presentation.score.left_cdf(mean=0.5, std=0.3)  # higher score → higher output
 
 # Logistic sigmoid (Vaxrank-compatible IC50 scoring)
 # 1 / (1 + exp((x - midpoint) / width))
@@ -172,7 +173,8 @@ The `--ranking` flag and `--rank-by` flag accept string expressions:
 **Python-only** (no string form):
 
 - Arithmetic: `0.5 * Affinity.score + 0.5 * Presentation.score`
-- Transforms: `.logistic()`, `.norm()`, `.clip()`, `.log()`
+- Transforms: `.logistic()`, `.left_cdf()`, `.right_cdf()`, `.clip()`, `.hinge()`, `.log()`
+- Aggregations: `mean()`, `geomean()`, `minimum()`, `maximum()`, `median()`
 - `WT()` expressions
 - `Column()` in arithmetic (only `column(x) <= N` works in strings)
 
@@ -207,7 +209,7 @@ score = (
     + 0.2 * Presentation["mhcflurry"].score
     # Manufacturability
     - 0.05 * Column("cysteine_count")
-    - 0.05 * Column("instability_index").clip(lo=0, hi=100).norm(50, 20)
+    - 0.05 * Column("instability_index").clip(lo=0, hi=100).left_cdf(50, 20)
     # Immunogenicity
     + 0.05 * Column("tcr_aromaticity")
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ classifiers = [
 readme = "README.md"
 dynamic = ["version", "dependencies"]
 
-[project.optional-dependencies]
-completion = ["argcomplete>=1.10"]
-
 [tool.setuptools.dynamic]
 version = {attr = "topiary.__version__"}
 dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mhctools>=3.0.0
 varcode>=0.3.17
 gtfparse>=0.0.4
 mhcnames
+argcomplete>=1.10

--- a/tests/test_dsl_polish.py
+++ b/tests/test_dsl_polish.py
@@ -31,19 +31,19 @@ def _aff_df(ic50):
 class TestDirection:
     def test_norm_higher_input_higher_output(self):
         """norm: higher input -> higher output (CDF)."""
-        low = Affinity.left_cdf(500, 200).evaluate(_aff_df(100))
-        high = Affinity.left_cdf(500, 200).evaluate(_aff_df(1000))
+        low = Affinity.ascending_cdf(500, 200).evaluate(_aff_df(100))
+        high = Affinity.ascending_cdf(500, 200).evaluate(_aff_df(1000))
         assert high > low
 
     def test_norm_lower_lower_input_higher_output(self):
         """norm_lower: lower input -> higher output (1-CDF)."""
-        strong = Affinity.right_cdf(500, 200).evaluate(_aff_df(100))
-        weak = Affinity.right_cdf(500, 200).evaluate(_aff_df(1000))
+        strong = Affinity.descending_cdf(500, 200).evaluate(_aff_df(100))
+        weak = Affinity.descending_cdf(500, 200).evaluate(_aff_df(1000))
         assert strong > weak
 
     def test_norm_lower_is_complement_of_norm(self):
-        n = Affinity.left_cdf(500, 200).evaluate(_aff_df(300))
-        nl = Affinity.right_cdf(500, 200).evaluate(_aff_df(300))
+        n = Affinity.ascending_cdf(500, 200).evaluate(_aff_df(300))
+        nl = Affinity.descending_cdf(500, 200).evaluate(_aff_df(300))
         assert n + nl == pytest.approx(1.0)
 
     def test_logistic_lower_input_higher_output(self):
@@ -54,7 +54,7 @@ class TestDirection:
 
     def test_norm_lower_for_ic50(self):
         """For IC50, norm_lower gives high scores for strong binders."""
-        val = Affinity.right_cdf(500, 200).evaluate(_aff_df(100))
+        val = Affinity.descending_cdf(500, 200).evaluate(_aff_df(100))
         assert val > 0.5
 
     def test_logistic_for_ic50_works_directly(self):
@@ -64,7 +64,7 @@ class TestDirection:
 
     def test_norm_and_logistic_are_different(self):
         """They give different values for the same input."""
-        n = Affinity.left_cdf(350, 150).evaluate(_aff_df(200))
+        n = Affinity.ascending_cdf(350, 150).evaluate(_aff_df(200))
         l = Affinity.logistic(350, 150).evaluate(_aff_df(200))
         assert n != pytest.approx(l, abs=0.01)
 

--- a/tests/test_dsl_polish.py
+++ b/tests/test_dsl_polish.py
@@ -1,0 +1,193 @@
+"""Tests for DSL polish: norm/logistic direction, log2/log1p, filter_by, parser errors."""
+
+import math
+
+import pandas as pd
+import pytest
+from mhctools import Kind
+
+from topiary.ranking import (
+    Affinity,
+    Presentation,
+    Column,
+    parse_filter,
+    parse_ranking,
+)
+
+
+def _aff_df(ic50):
+    return pd.DataFrame([dict(
+        source_sequence_name="x", peptide="A", peptide_offset=0,
+        allele="A", kind="pMHC_affinity", score=0.9, value=ic50,
+        percentile_rank=0.5,
+    )])
+
+
+# ---------------------------------------------------------------------------
+# norm vs logistic direction
+# ---------------------------------------------------------------------------
+
+
+class TestDirection:
+    def test_norm_higher_input_higher_output(self):
+        """norm: higher input -> higher output (CDF)."""
+        low = Affinity.norm(500, 200).evaluate(_aff_df(100))
+        high = Affinity.norm(500, 200).evaluate(_aff_df(1000))
+        assert high > low
+
+    def test_logistic_lower_input_higher_output(self):
+        """logistic: lower input -> higher output."""
+        strong = Affinity.logistic(350, 150).evaluate(_aff_df(100))
+        weak = Affinity.logistic(350, 150).evaluate(_aff_df(5000))
+        assert strong > weak
+
+    def test_norm_for_ic50_needs_inversion(self):
+        """For IC50 (lower=better), must use 1 - norm()."""
+        raw = Affinity.norm(500, 200).evaluate(_aff_df(100))
+        inverted = (1 - Affinity.norm(500, 200)).evaluate(_aff_df(100))
+        assert raw < 0.5   # low IC50 -> low CDF
+        assert inverted > 0.5  # inverted -> high score
+
+    def test_logistic_for_ic50_works_directly(self):
+        """For IC50 (lower=better), logistic works without inversion."""
+        val = Affinity.logistic(350, 150).evaluate(_aff_df(100))
+        assert val > 0.5   # low IC50 -> high logistic score
+
+    def test_norm_and_logistic_are_different(self):
+        """They give different values for the same input."""
+        n = Affinity.norm(350, 150).evaluate(_aff_df(200))
+        l = Affinity.logistic(350, 150).evaluate(_aff_df(200))
+        assert n != pytest.approx(l, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# log2, log1p
+# ---------------------------------------------------------------------------
+
+
+class TestNewTransforms:
+    def test_log2(self):
+        val = Affinity.log2().evaluate(_aff_df(8.0))
+        assert val == pytest.approx(3.0)
+
+    def test_log2_accessor(self):
+        """KindAccessor delegates log2."""
+        val = Affinity.log2().evaluate(_aff_df(8.0))
+        assert val == pytest.approx(3.0)
+
+    def test_log1p(self):
+        val = Affinity.log1p().evaluate(_aff_df(0.0))
+        assert val == pytest.approx(0.0)  # log(1+0) = 0
+
+    def test_log1p_small(self):
+        """log1p is more accurate than log for small values."""
+        val = Affinity.log1p().evaluate(_aff_df(1e-10))
+        assert val == pytest.approx(1e-10, rel=1e-5)
+
+    def test_log1p_nan_for_invalid(self):
+        val = Affinity.log1p().evaluate(_aff_df(-2.0))
+        assert math.isnan(val)
+
+    def test_log2_nan_for_zero(self):
+        val = Affinity.log2().evaluate(_aff_df(0.0))
+        assert math.isnan(val)
+
+    def test_log2_in_composite(self):
+        expr = Affinity.log2() + 1
+        val = expr.evaluate(_aff_df(4.0))
+        assert val == pytest.approx(3.0)  # log2(4) + 1
+
+
+# ---------------------------------------------------------------------------
+# filter_by parameter and string parsing
+# ---------------------------------------------------------------------------
+
+
+class TestFilterBy:
+    def test_filter_by_object(self):
+        from topiary import TopiaryPredictor
+        from mhctools import RandomBindingPredictor
+        p = TopiaryPredictor(
+            models=RandomBindingPredictor(alleles=["A0201"]),
+            filter_by=Affinity <= 500,
+        )
+        assert p.ranking_strategy is not None
+
+    def test_filter_by_string(self):
+        from topiary import TopiaryPredictor
+        from mhctools import RandomBindingPredictor
+        p = TopiaryPredictor(
+            models=RandomBindingPredictor(alleles=["A0201"]),
+            filter_by="affinity <= 500",
+        )
+        assert p.ranking_strategy is not None
+        assert len(p.ranking_strategy.filters) == 1
+
+    def test_filter_by_complex_string(self):
+        from topiary import TopiaryPredictor
+        from mhctools import RandomBindingPredictor
+        p = TopiaryPredictor(
+            models=RandomBindingPredictor(alleles=["A0201"]),
+            filter_by="affinity <= 500 | el.rank <= 2",
+        )
+        assert len(p.ranking_strategy.filters) == 2
+
+    def test_filter_by_takes_precedence_over_filter(self):
+        from topiary import TopiaryPredictor
+        from mhctools import RandomBindingPredictor
+        p = TopiaryPredictor(
+            models=RandomBindingPredictor(alleles=["A0201"]),
+            filter_by=Affinity <= 500,
+            filter=Affinity <= 1000,  # deprecated, ignored
+        )
+        assert p.ranking_strategy.filters[0].max_value == 500
+
+    def test_deprecated_filter_still_works(self):
+        from topiary import TopiaryPredictor
+        from mhctools import RandomBindingPredictor
+        p = TopiaryPredictor(
+            models=RandomBindingPredictor(alleles=["A0201"]),
+            filter=Affinity <= 500,
+        )
+        assert p.ranking_strategy is not None
+
+
+# ---------------------------------------------------------------------------
+# Parser error quality
+# ---------------------------------------------------------------------------
+
+
+class TestParserErrors:
+    def test_kind_typo_suggests(self):
+        with pytest.raises(ValueError, match="Did you mean.*affinity"):
+            parse_filter("afinity <= 500")
+
+    def test_field_typo_suggests(self):
+        with pytest.raises(ValueError, match="Did you mean.*rank"):
+            parse_filter("affinity.rnk <= 2")
+
+    def test_non_numeric_threshold(self):
+        with pytest.raises(ValueError, match="must be a number"):
+            parse_filter("affinity <= abc")
+
+    def test_missing_operator(self):
+        with pytest.raises(ValueError, match="No comparison operator"):
+            parse_filter("affinity")
+
+    def test_empty_string(self):
+        with pytest.raises(ValueError, match="No comparison operator"):
+            parse_filter("")
+
+    def test_reversed_expression(self):
+        """'500 <= affinity' — 'affinity' on right side fails as number."""
+        with pytest.raises(ValueError, match="must be a number"):
+            parse_filter("500 <= affinity")
+
+    def test_space_in_operator(self):
+        """'affinity < = 500' — the '= 500' part fails as threshold."""
+        with pytest.raises(ValueError, match="must be a number"):
+            parse_filter("affinity < = 500")
+
+    def test_qualified_kind_typo_suggests(self):
+        with pytest.raises(ValueError, match="Did you mean"):
+            parse_filter("netmhcpan_afinity <= 500")

--- a/tests/test_dsl_polish.py
+++ b/tests/test_dsl_polish.py
@@ -31,9 +31,20 @@ def _aff_df(ic50):
 class TestDirection:
     def test_norm_higher_input_higher_output(self):
         """norm: higher input -> higher output (CDF)."""
-        low = Affinity.norm(500, 200).evaluate(_aff_df(100))
-        high = Affinity.norm(500, 200).evaluate(_aff_df(1000))
+        low = Affinity.left_cdf(500, 200).evaluate(_aff_df(100))
+        high = Affinity.left_cdf(500, 200).evaluate(_aff_df(1000))
         assert high > low
+
+    def test_norm_lower_lower_input_higher_output(self):
+        """norm_lower: lower input -> higher output (1-CDF)."""
+        strong = Affinity.right_cdf(500, 200).evaluate(_aff_df(100))
+        weak = Affinity.right_cdf(500, 200).evaluate(_aff_df(1000))
+        assert strong > weak
+
+    def test_norm_lower_is_complement_of_norm(self):
+        n = Affinity.left_cdf(500, 200).evaluate(_aff_df(300))
+        nl = Affinity.right_cdf(500, 200).evaluate(_aff_df(300))
+        assert n + nl == pytest.approx(1.0)
 
     def test_logistic_lower_input_higher_output(self):
         """logistic: lower input -> higher output."""
@@ -41,21 +52,19 @@ class TestDirection:
         weak = Affinity.logistic(350, 150).evaluate(_aff_df(5000))
         assert strong > weak
 
-    def test_norm_for_ic50_needs_inversion(self):
-        """For IC50 (lower=better), must use 1 - norm()."""
-        raw = Affinity.norm(500, 200).evaluate(_aff_df(100))
-        inverted = (1 - Affinity.norm(500, 200)).evaluate(_aff_df(100))
-        assert raw < 0.5   # low IC50 -> low CDF
-        assert inverted > 0.5  # inverted -> high score
+    def test_norm_lower_for_ic50(self):
+        """For IC50, norm_lower gives high scores for strong binders."""
+        val = Affinity.right_cdf(500, 200).evaluate(_aff_df(100))
+        assert val > 0.5
 
     def test_logistic_for_ic50_works_directly(self):
         """For IC50 (lower=better), logistic works without inversion."""
         val = Affinity.logistic(350, 150).evaluate(_aff_df(100))
-        assert val > 0.5   # low IC50 -> high logistic score
+        assert val > 0.5
 
     def test_norm_and_logistic_are_different(self):
         """They give different values for the same input."""
-        n = Affinity.norm(350, 150).evaluate(_aff_df(200))
+        n = Affinity.left_cdf(350, 150).evaluate(_aff_df(200))
         l = Affinity.logistic(350, 150).evaluate(_aff_df(200))
         assert n != pytest.approx(l, abs=0.01)
 
@@ -96,6 +105,96 @@ class TestNewTransforms:
         expr = Affinity.log2() + 1
         val = expr.evaluate(_aff_df(4.0))
         assert val == pytest.approx(3.0)  # log2(4) + 1
+
+    def test_hinge(self):
+        assert Affinity.value.hinge().evaluate(_aff_df(100)) == 100.0
+        assert Affinity.value.hinge().evaluate(_aff_df(-5)) == 0.0
+        assert Affinity.value.hinge().evaluate(_aff_df(0)) == 0.0
+
+    def test_hinge_in_expression(self):
+        """hinge of a difference: max(0, mutant - wt)."""
+        expr = (Affinity.value - 200).hinge()
+        assert expr.evaluate(_aff_df(300)) == 100.0
+        assert expr.evaluate(_aff_df(100)) == 0.0
+
+
+class TestAggregations:
+    def test_mean(self):
+        from topiary.ranking import mean
+        expr = mean(Affinity.value, 200)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(150.0)
+
+    def test_mean_three(self):
+        from topiary.ranking import mean
+        expr = mean(Affinity.value, 200, 300)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(200.0)
+
+    def test_geomean(self):
+        from topiary.ranking import geomean
+        expr = geomean(Affinity.value, 400)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(200.0)  # sqrt(100 * 400)
+
+    def test_geomean_skips_non_positive(self):
+        from topiary.ranking import geomean
+        expr = geomean(Affinity.value, -5, 400)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(200.0)  # -5 skipped
+
+    def test_minimum(self):
+        from topiary.ranking import minimum
+        expr = minimum(Affinity.value, 500, 200)
+        assert expr.evaluate(_aff_df(100)) == 100.0
+        assert expr.evaluate(_aff_df(300)) == 200.0
+
+    def test_maximum(self):
+        from topiary.ranking import maximum
+        expr = maximum(Affinity.value, 50, 200)
+        assert expr.evaluate(_aff_df(100)) == 200.0
+        assert expr.evaluate(_aff_df(300)) == 300.0
+
+    def test_median_odd(self):
+        from topiary.ranking import median
+        expr = median(Affinity.value, 200, 300)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(200.0)  # sorted: [100, 200, 300]
+
+    def test_median_even(self):
+        from topiary.ranking import median
+        expr = median(Affinity.value, 200, 300, 400)
+        val = expr.evaluate(_aff_df(100))
+        assert val == pytest.approx(250.0)  # sorted: [100, 200, 300, 400] → (200+300)/2
+
+    def test_mean_with_qualified_fields(self):
+        """mean() works with multi-model qualified fields."""
+        from topiary.ranking import mean
+        df = pd.DataFrame([
+            dict(source_sequence_name="x", peptide="A", peptide_offset=0,
+                 allele="A", kind="pMHC_affinity", score=0.8, value=100.0,
+                 percentile_rank=0.5, prediction_method_name="netmhcpan"),
+            dict(source_sequence_name="x", peptide="A", peptide_offset=0,
+                 allele="A", kind="pMHC_affinity", score=0.6, value=300.0,
+                 percentile_rank=2.0, prediction_method_name="mhcflurry"),
+        ])
+        expr = mean(
+            Affinity["netmhcpan"].logistic(350, 150),
+            Affinity["mhcflurry"].logistic(350, 150),
+        )
+        val = expr.evaluate(df)
+        assert isinstance(val, float)
+        assert not math.isnan(val)
+
+    def test_aggregation_all_nan(self):
+        from topiary.ranking import mean
+        df = pd.DataFrame([dict(
+            source_sequence_name="x", peptide="A", peptide_offset=0,
+            allele="A", kind="pMHC_affinity", score=float("nan"),
+            value=float("nan"), percentile_rank=float("nan"),
+        )])
+        val = mean(Affinity.value, Affinity.score).evaluate(df)
+        assert math.isnan(val)
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -13,6 +13,11 @@ from .ranking import (
     WT,
     affinity_filter,
     apply_ranking_strategy,
+    geomean,
+    maximum,
+    mean,
+    median,
+    minimum,
     parse_ranking,
     presentation_filter,
 )
@@ -23,7 +28,7 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 
-__version__ = "4.5.1"
+__version__ = "4.6.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cli/script.py
+++ b/topiary/cli/script.py
@@ -28,10 +28,7 @@ Example usage:
 
 import sys
 
-try:
-    import argcomplete
-except ImportError:
-    argcomplete = None
+import argcomplete
 
 from .args import arg_parser, predict_epitopes_from_args
 
@@ -41,8 +38,7 @@ from .outputs import write_outputs
 def parse_args(args_list=None):
     if args_list is None:
         args_list = sys.argv[1:]
-    if argcomplete is not None:
-        argcomplete.autocomplete(arg_parser)
+    argcomplete.autocomplete(arg_parser)
     return arg_parser.parse_args(args_list)
 
 

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -40,7 +40,7 @@ class TopiaryPredictor(object):
         self,
         models=None,
         alleles=None,
-        filter=None,
+        filter_by=None,
         rank_by=None,
         padding_around_mutation=None,
         only_novel_epitopes=False,
@@ -48,6 +48,7 @@ class TopiaryPredictor(object):
         min_transcript_expression=0.0,
         raise_on_error=True,
         # backward-compat aliases
+        filter=None,
         mhc_model=None,
         mhc_models=None,
         ic50_cutoff=None,
@@ -73,19 +74,21 @@ class TopiaryPredictor(object):
             HLA alleles. When provided, model classes in ``models`` are
             instantiated with these alleles.
 
-        filter : EpitopeFilter or RankingStrategy
-            Which peptide-allele groups to keep::
+        filter_by : EpitopeFilter, RankingStrategy, or str
+            Which peptide-allele groups to keep. Accepts expression objects
+            or a string that will be parsed::
 
-                filter = (Affinity <= 500) | (Presentation.rank <= 2.0)
+                filter_by=(Affinity <= 500) | (Presentation.rank <= 2.0)
+                filter_by="affinity <= 500 | el.rank <= 2"
 
         rank_by : Expr or list of Expr, optional
             How to sort surviving groups. First non-NaN wins::
 
-                rank_by = [Presentation.score, Affinity.score]
+                rank_by=[Presentation.score, Affinity.score]
 
             Or a composite expression::
 
-                rank_by = 0.5 * Affinity.score + 0.5 * Presentation.score
+                rank_by=0.5 * Affinity.score + 0.5 * Presentation.score
 
         padding_around_mutation : int, optional
             Residues around a mutation to include in candidate epitopes.
@@ -102,12 +105,13 @@ class TopiaryPredictor(object):
         raise_on_error : bool
             Raise on variant-effect errors vs. skip.
 
+        filter : deprecated alias for ``filter_by``
         mhc_model : deprecated alias for ``models``
         mhc_models : deprecated alias for ``models``
-        ic50_cutoff : deprecated, use ``filter=Affinity <= X``
-        percentile_cutoff : deprecated, use ``filter=Affinity.rank <= X``
-        ranking : deprecated alias for ``filter``
-        ranking_strategy : deprecated alias for ``filter``
+        ic50_cutoff : deprecated, use ``filter_by=Affinity <= X``
+        percentile_cutoff : deprecated, use ``filter_by=Affinity.rank <= X``
+        ranking : deprecated alias for ``filter_by``
+        ranking_strategy : deprecated alias for ``filter_by``
         """
         # --- model setup ---
         raw_models = models or mhc_models or (mhc_model and [mhc_model])
@@ -138,7 +142,10 @@ class TopiaryPredictor(object):
         )
 
         # --- filter / ranking ---
-        effective_filter = filter or ranking or ranking_strategy
+        effective_filter = filter_by or filter or ranking or ranking_strategy
+        if isinstance(effective_filter, str):
+            from .ranking import parse_ranking
+            effective_filter = parse_ranking(effective_filter)
         if isinstance(effective_filter, EpitopeFilter):
             effective_filter = RankingStrategy(filters=[effective_filter])
         if effective_filter is not None:

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -57,33 +57,43 @@ class Expr:
 
     # -- Gaussian normalization --
 
-    def norm(self, mean=0.0, std=1.0):
-        """Gaussian CDF normalization: maps value to ~[0, 1].
+    def left_cdf(self, mean=0.0, std=1.0):
+        """Gaussian left CDF: **higher input → higher output**.
 
-        **Higher input → higher output.** Good for "higher is better"
-        fields like ``.score``. For "lower is better" fields like IC50,
-        use ``1 - field.norm(...)``::
+        P(X ≤ x) — the area to the left under the curve.
+        Use for "higher is better" fields like ``.score``::
 
-            # Presentation score (higher = better) → use directly
-            Presentation.score.norm(mean=0.5, std=0.3)
+            Presentation.score.left_cdf(mean=0.5, std=0.3)
 
-            # IC50 (lower = better) → invert
-            1 - Affinity.norm(mean=500, std=200)
+        For "lower is better" fields (IC50, rank), use
+        :meth:`right_cdf` instead.
         """
         return _NormExpr(self, mean, std)
 
+    # Keep norm as alias for left_cdf
+    norm = left_cdf
+
+    def right_cdf(self, mean=0.0, std=1.0):
+        """Gaussian right CDF (1-CDF): **lower input → higher output**.
+
+        P(X > x) — the area to the right under the curve.
+        Use for "lower is better" fields like IC50 and percentile rank::
+
+            Affinity.right_cdf(mean=500, std=200)
+            Affinity.rank.right_cdf(mean=5, std=3)
+
+        For "higher is better" fields, use :meth:`left_cdf` instead.
+        """
+        return _SurvivalExpr(self, mean, std)
+
     def logistic(self, midpoint=0.0, width=1.0):
-        """Logistic sigmoid: ``1 / (1 + exp((x - midpoint) / width))``.
+        """Logistic sigmoid: **lower input → higher output**.
 
-        **Lower input → higher output.** Good for "lower is better"
-        fields like IC50. Values below the midpoint score > 0.5;
-        values above score < 0.5::
+        ``1 / (1 + exp((x - midpoint) / width))``.
+        Values below the midpoint score > 0.5; above score < 0.5.
+        Use for "lower is better" fields like IC50::
 
-            # IC50 (lower = better) → use directly
             Affinity.logistic(midpoint=350, width=150)
-
-            # Score (higher = better) → logistic goes the wrong way,
-            # use norm() instead
         """
         return _LogisticExpr(self, midpoint, width)
 
@@ -130,6 +140,10 @@ class Expr:
     def clip(self, lo=None, hi=None):
         """Clamp value to [lo, hi]. None = unbounded."""
         return _ClipExpr(self, lo, hi)
+
+    def hinge(self):
+        """``max(0, x)``. Zeroes out negative values."""
+        return _ClipExpr(self, lo=0, hi=None)
 
     def log(self):
         """Natural logarithm (NaN if value <= 0)."""
@@ -220,6 +234,24 @@ class _NormExpr(Expr):
         return _gauss_cdf((val - self.mean) / self.std)
 
 
+class _SurvivalExpr(Expr):
+    """Survival function (1 - Gaussian CDF) of an inner expression."""
+    __slots__ = ("inner", "mean", "std")
+
+    def __init__(self, inner, mean, std):
+        self.inner = inner
+        self.mean = float(mean)
+        self.std = float(std)
+
+    def evaluate(self, group_df):
+        val = self.inner.evaluate(group_df)
+        if val is None or (isinstance(val, float) and math.isnan(val)):
+            return float("nan")
+        if self.std == 0:
+            return float("nan")
+        return 1.0 - _gauss_cdf((val - self.mean) / self.std)
+
+
 class _LogisticExpr(Expr):
     """Logistic sigmoid of an inner expression."""
     __slots__ = ("inner", "midpoint", "width")
@@ -285,6 +317,69 @@ def _as_expr(obj):
     if isinstance(obj, (int, float)):
         return _Const(obj)
     raise TypeError(f"Cannot convert {type(obj)} to Expr")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation functions — combine multiple expressions
+# ---------------------------------------------------------------------------
+
+
+class _AggExpr(Expr):
+    """Aggregate multiple expressions with a reducing function."""
+    __slots__ = ("exprs", "agg_fn")
+
+    def __init__(self, exprs, agg_fn):
+        self.exprs = exprs
+        self.agg_fn = agg_fn
+
+    def evaluate(self, group_df):
+        vals = []
+        for e in self.exprs:
+            v = e.evaluate(group_df)
+            if v is not None and not (isinstance(v, float) and math.isnan(v)):
+                vals.append(v)
+        if not vals:
+            return float("nan")
+        return self.agg_fn(vals)
+
+
+def mean(*exprs):
+    """Arithmetic mean of expressions. NaN values are skipped."""
+    return _AggExpr([_as_expr(e) for e in exprs], lambda vs: sum(vs) / len(vs))
+
+
+def geomean(*exprs):
+    """Geometric mean of expressions. NaN and non-positive values are skipped."""
+    def _geomean(vs):
+        pos = [v for v in vs if v > 0]
+        if not pos:
+            return float("nan")
+        return math.exp(sum(math.log(v) for v in pos) / len(pos))
+    return _AggExpr([_as_expr(e) for e in exprs], _geomean)
+
+
+def minimum(*exprs):
+    """Minimum of expressions. NaN values are skipped."""
+    return _AggExpr([_as_expr(e) for e in exprs], min)
+
+
+def maximum(*exprs):
+    """Maximum of expressions. NaN values are skipped."""
+    return _AggExpr([_as_expr(e) for e in exprs], max)
+
+
+def median(*exprs):
+    """Median of expressions. NaN values are skipped.
+
+    For even count, returns mean of the two middle values.
+    """
+    def _median(vs):
+        vs = sorted(vs)
+        n = len(vs)
+        if n % 2 == 1:
+            return vs[n // 2]
+        return (vs[n // 2 - 1] + vs[n // 2]) / 2.0
+    return _AggExpr([_as_expr(e) for e in exprs], _median)
 
 
 def _method_not_found_error(kind_name, method, available):
@@ -517,9 +612,14 @@ class KindAccessor:
     def __gt__(self, threshold):
         return self.value.__gt__(threshold)
 
-    # Delegate Expr methods to .value so Affinity.norm(...) works
-    def norm(self, mean=0.0, std=1.0):
-        return self.value.norm(mean, std)
+    # Delegate Expr methods to .value so Affinity.left_cdf(...) works
+    def left_cdf(self, mean=0.0, std=1.0):
+        return self.value.left_cdf(mean, std)
+
+    norm = left_cdf  # alias
+
+    def right_cdf(self, mean=0.0, std=1.0):
+        return self.value.right_cdf(mean, std)
 
     def logistic(self, midpoint=0.0, width=1.0):
         return self.value.logistic(midpoint, width)
@@ -651,8 +751,13 @@ class WT:
         self._filter_error()
 
     # Delegate Expr methods to .value for use in ranking expressions
-    def norm(self, mean=0.0, std=1.0):
-        return self.value.norm(mean, std)
+    def left_cdf(self, mean=0.0, std=1.0):
+        return self.value.left_cdf(mean, std)
+
+    norm = left_cdf  # alias
+
+    def right_cdf(self, mean=0.0, std=1.0):
+        return self.value.right_cdf(mean, std)
 
     def logistic(self, midpoint=0.0, width=1.0):
         return self.value.logistic(midpoint, width)

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -60,19 +60,30 @@ class Expr:
     def norm(self, mean=0.0, std=1.0):
         """Gaussian CDF normalization: maps value to ~[0, 1].
 
-        ``norm(mean=500, std=200)`` on an IC50 of 100 gives ~0.977
-        (strong binder → high score).  For "lower is better" fields
-        like IC50, use ``1 - field.norm(...)`` or negate the mean.
+        **Higher input → higher output.** Good for "higher is better"
+        fields like ``.score``. For "lower is better" fields like IC50,
+        use ``1 - field.norm(...)``::
+
+            # Presentation score (higher = better) → use directly
+            Presentation.score.norm(mean=0.5, std=0.3)
+
+            # IC50 (lower = better) → invert
+            1 - Affinity.norm(mean=500, std=200)
         """
         return _NormExpr(self, mean, std)
 
     def logistic(self, midpoint=0.0, width=1.0):
         """Logistic sigmoid: ``1 / (1 + exp((x - midpoint) / width))``.
 
-        Maps values to (0, 1). For IC50 scoring (lower is better),
-        Vaxrank uses ``midpoint=350, width=150``::
+        **Lower input → higher output.** Good for "lower is better"
+        fields like IC50. Values below the midpoint score > 0.5;
+        values above score < 0.5::
 
+            # IC50 (lower = better) → use directly
             Affinity.logistic(midpoint=350, width=150)
+
+            # Score (higher = better) → logistic goes the wrong way,
+            # use norm() instead
         """
         return _LogisticExpr(self, midpoint, width)
 
@@ -124,9 +135,17 @@ class Expr:
         """Natural logarithm (NaN if value <= 0)."""
         return _UnaryOp(self, math.log)
 
+    def log2(self):
+        """Base-2 logarithm (NaN if value <= 0)."""
+        return _UnaryOp(self, math.log2)
+
     def log10(self):
         """Base-10 logarithm (NaN if value <= 0)."""
         return _UnaryOp(self, math.log10)
+
+    def log1p(self):
+        """``log(1 + x)``, accurate for small x (NaN if x <= -1)."""
+        return _UnaryOp(self, math.log1p)
 
     def exp(self):
         """Exponential (e^x)."""
@@ -511,8 +530,14 @@ class KindAccessor:
     def log(self):
         return self.value.log()
 
+    def log2(self):
+        return self.value.log2()
+
     def log10(self):
         return self.value.log10()
+
+    def log1p(self):
+        return self.value.log1p()
 
     def exp(self):
         return self.value.exp()
@@ -978,10 +1003,14 @@ def _resolve_kind(name):
     key = name.strip().lower()
     if key in _KIND_ALIASES:
         return _KIND_ALIASES[key]
-    raise ValueError(
-        f"Unknown prediction kind {name!r}. "
-        f"Available: {sorted(_KIND_ALIASES.keys())}"
-    )
+    available = sorted(_KIND_ALIASES.keys())
+    close = get_close_matches(key, available, n=3, cutoff=0.6)
+    msg = f"Unknown prediction kind {name!r}."
+    if close:
+        msg += f" Did you mean: {close}?"
+    else:
+        msg += f" Available: {available}"
+    raise ValueError(msg)
 
 
 def _resolve_qualified_kind(name):
@@ -1007,20 +1036,28 @@ def _resolve_qualified_kind(name):
         kind_str = "_".join(parts[i:])
         if kind_str in _KIND_ALIASES:
             return _KIND_ALIASES[kind_str], tool
-    raise ValueError(
-        f"Unknown prediction kind {name!r}. "
-        f"Use 'kind' or 'tool_kind' format. "
-        f"Available kinds: {sorted(_KIND_ALIASES.keys())}"
-    )
+    available = sorted(_KIND_ALIASES.keys())
+    close = get_close_matches(key, available, n=3, cutoff=0.6)
+    msg = f"Unknown prediction kind {name!r}. Use 'kind' or 'tool_kind' format."
+    if close:
+        msg += f" Did you mean: {close}?"
+    else:
+        msg += f" Available kinds: {available}"
+    raise ValueError(msg)
 
 
 def _resolve_field(name):
     key = name.strip().lower()
     if key in _FIELD_ALIASES:
         return _FIELD_ALIASES[key]
-    raise ValueError(
-        f"Unknown field {name!r}. Available: {sorted(_FIELD_ALIASES.keys())}"
-    )
+    available = sorted(_FIELD_ALIASES.keys())
+    close = get_close_matches(key, available, n=3, cutoff=0.6)
+    msg = f"Unknown field {name!r}."
+    if close:
+        msg += f" Did you mean: {close}?"
+    else:
+        msg += f" Available: {available}"
+    raise ValueError(msg)
 
 
 def _parse_column_ref(text):
@@ -1065,7 +1102,14 @@ def parse_filter(text):
         if op_str in text:
             lhs, rhs = text.split(op_str, 1)
             lhs = lhs.strip()
-            threshold = float(rhs.strip())
+            rhs = rhs.strip()
+            try:
+                threshold = float(rhs)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid threshold {rhs!r} in {text!r}. "
+                    f"Right side of {op_str} must be a number."
+                ) from None
 
             # Check for column(name) syntax
             col_name = _parse_column_ref(lhs)

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -57,32 +57,32 @@ class Expr:
 
     # -- Gaussian normalization --
 
-    def left_cdf(self, mean=0.0, std=1.0):
+    def ascending_cdf(self, mean=0.0, std=1.0):
         """Gaussian left CDF: **higher input → higher output**.
 
         P(X ≤ x) — the area to the left under the curve.
         Use for "higher is better" fields like ``.score``::
 
-            Presentation.score.left_cdf(mean=0.5, std=0.3)
+            Presentation.score.ascending_cdf(mean=0.5, std=0.3)
 
         For "lower is better" fields (IC50, rank), use
-        :meth:`right_cdf` instead.
+        :meth:`descending_cdf` instead.
         """
         return _NormExpr(self, mean, std)
 
-    # Keep norm as alias for left_cdf
-    norm = left_cdf
+    # Keep norm as alias for ascending_cdf
+    norm = ascending_cdf
 
-    def right_cdf(self, mean=0.0, std=1.0):
+    def descending_cdf(self, mean=0.0, std=1.0):
         """Gaussian right CDF (1-CDF): **lower input → higher output**.
 
         P(X > x) — the area to the right under the curve.
         Use for "lower is better" fields like IC50 and percentile rank::
 
-            Affinity.right_cdf(mean=500, std=200)
-            Affinity.rank.right_cdf(mean=5, std=3)
+            Affinity.descending_cdf(mean=500, std=200)
+            Affinity.rank.descending_cdf(mean=5, std=3)
 
-        For "higher is better" fields, use :meth:`left_cdf` instead.
+        For "higher is better" fields, use :meth:`ascending_cdf` instead.
         """
         return _SurvivalExpr(self, mean, std)
 
@@ -612,14 +612,14 @@ class KindAccessor:
     def __gt__(self, threshold):
         return self.value.__gt__(threshold)
 
-    # Delegate Expr methods to .value so Affinity.left_cdf(...) works
-    def left_cdf(self, mean=0.0, std=1.0):
-        return self.value.left_cdf(mean, std)
+    # Delegate Expr methods to .value so Affinity.ascending_cdf(...) works
+    def ascending_cdf(self, mean=0.0, std=1.0):
+        return self.value.ascending_cdf(mean, std)
 
-    norm = left_cdf  # alias
+    norm = ascending_cdf  # alias
 
-    def right_cdf(self, mean=0.0, std=1.0):
-        return self.value.right_cdf(mean, std)
+    def descending_cdf(self, mean=0.0, std=1.0):
+        return self.value.descending_cdf(mean, std)
 
     def logistic(self, midpoint=0.0, width=1.0):
         return self.value.logistic(midpoint, width)
@@ -751,13 +751,13 @@ class WT:
         self._filter_error()
 
     # Delegate Expr methods to .value for use in ranking expressions
-    def left_cdf(self, mean=0.0, std=1.0):
-        return self.value.left_cdf(mean, std)
+    def ascending_cdf(self, mean=0.0, std=1.0):
+        return self.value.ascending_cdf(mean, std)
 
-    norm = left_cdf  # alias
+    norm = ascending_cdf  # alias
 
-    def right_cdf(self, mean=0.0, std=1.0):
-        return self.value.right_cdf(mean, std)
+    def descending_cdf(self, mean=0.0, std=1.0):
+        return self.value.descending_cdf(mean, std)
 
     def logistic(self, midpoint=0.0, width=1.0):
         return self.value.logistic(midpoint, width)


### PR DESCRIPTION
## Summary

Polish pass on the ranking DSL addressing usability issues.

### Direction clarity for norm vs logistic

**Bug fix:** The `norm()` docstring claimed `norm(500, 200)` on IC50=100 gives 0.977 — actually 0.023. The two transforms go in opposite directions:

- **`norm(mean, std)`** — higher input → higher output (Gaussian CDF). Use for "higher is better" fields like `.score`. For IC50, invert: `1 - Affinity.norm(500, 200)`.
- **`logistic(midpoint, width)`** — lower input → higher output. Use directly for IC50: `Affinity.logistic(350, 150)`.

### New transforms

- `.log2()` — base-2 logarithm
- `.log1p()` — `log(1 + x)`, accurate for small x

### `filter_by` parameter

Rename `filter` → `filter_by` on `TopiaryPredictor` (avoids shadowing the Python builtin). `filter` kept as deprecated alias. Now also accepts strings:

```python
TopiaryPredictor(filter_by="affinity <= 500 | el.rank <= 2", ...)
```

### Parser error quality

Before → after for common mistakes:

| Input | Before | After |
|-------|--------|-------|
| `"afinity <= 500"` | `Unknown prediction kind 'afinity'. Available: [20 items]` | `Did you mean: ['affinity']?` |
| `"affinity.rnk <= 2"` | `Unknown field 'rnk'. Available: [7 items]` | `Did you mean: ['rank']?` |
| `"affinity <= abc"` | `could not convert string to float: 'abc'` | `Invalid threshold 'abc'. Right side of <= must be a number.` |
| `"500 <= affinity"` | `could not convert string to float: 'affinity'` | `must be a number` |

### argcomplete → default dependency

Zero dependencies, 43 kB. No reason to make users install `topiary[completion]` separately. Tab completion works out of the box after `activate-global-python-argcomplete`.

### Misc

- Remove pirlygenes install note from README (auto-errors with install instructions when needed)
- 25 new tests, 343 total passing

## Test plan

- [ ] norm/logistic direction tests verify opposite behaviors
- [ ] log2/log1p compute correctly, handle edge cases (zero, negative)
- [ ] filter_by accepts objects and strings, deprecated filter still works
- [ ] Parser typo suggestions fire for kinds, fields, and qualified kinds
- [ ] All 343 tests pass