### PR TITLE
Release 4.8.0: expression DSL v2, scoped contexts, docs overhaul

### DIFF
--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -34,7 +34,7 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 
-__version__ = "4.7.1"
+__version__ = "4.8.0"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
## Summary

Rolls up all changes since 4.7.0 into a single release.

### Expression DSL v2 (PR #103)
- **Scoped contexts**: `wt.affinity.score`, `shuffled.affinity.score`, `self.affinity.score` — reserved keywords replace the old `WT()` wrapper
- **`len`**: peptide length from precomputed column, works with scopes (`wt.len`)
- **`count('C')`**: dynamic amino acid counting from peptide string, works with scopes (`wt.count('KR')`)
- **`__repr__` round-trips**: all expression objects serialize to parseable strings
- **`Scope` class**: `wt`, `shuffled`, `self_scope` module-level instances for Python API
- **Parser**: `wt`, `shuffled`, `self` are reserved context keywords
- **Removed**: `WT` class (clean break, no backward compat)

### CLI expression parity (PR #101, included in #103)
- `parse_expr()` — full recursive-descent parser for `--rank-by` expressions
- All transforms, aggregations, arithmetic, method qualification work from CLI strings
- Fixed `_build_ranking_strategy` routing for dotted expressions
- Switched to `predictors_from_args` (mhctools >= 3.4.0)

### Docs overhaul
- README rewritten for cohesion: removed siloed sections, integrated examples showing DSL features
- Removed all "Python-only" claims — everything works via CLI strings
- Removed fictional advanced example (referenced non-existent `predict_column`)
- Consolidated predictor tables, updated for mhctools 3.4.0 models
- Updated deploy.sh and RELEASING.md

### Design docs
- `docs/expression-semantics.md` — full specification of scope/prefix model, grammar, internal representation
- Expression data design: RNA expression, variant evidence (isovar), single-cell data as first-class DSL fields
- Isovar integration path: peptide source + evidence annotations

### Tests
- 540 tests (was 397), all passing on Python 3.10/3.11/3.12

## Test plan
- [x] 540 tests pass locally
- [ ] CI passes