### PR TITLE
[codex] Support mhctools 3.7+ kind constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 4.9.0
 
-- Require `mhctools>=3.5.0`.
+- Require `mhctools>=3.7.0`.
 - Rename CLI sorting flags to `--sort-by` and `--sort-direction`.
 - Add Python API `sort_by=` and `.sort_by(...)`, while keeping `rank_by` as a compatibility alias.
 - Treat comma-separated `--sort-by` keys as lexicographic tie breakers, with fallthrough on missing values.
-- Document upstream `mhctools 3.5.0` support for multi-predictor CLI invocations and the updated NetChop/Pepsickle behavior.
+- Document upstream `mhctools 3.7.0+` support for multi-predictor CLI invocations, the simplified `Kind` API, and the updated NetChop/Pepsickle behavior.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Predict which peptides from protein sequences will be presented by MHC molecules
 pip install topiary
 ```
 
-Topiary `4.9.0` and later require `mhctools>=3.5.0`.
+Topiary `4.9.0` and later require `mhctools>=3.7.0`.
 
 For variant annotation and gene lookups, download Ensembl reference data:
 
@@ -449,13 +449,14 @@ Specify one or more predictors with `--mhc-predictor` and alleles with `--mhc-al
 
 All predictors come from [mhctools](https://github.com/openvax/mhctools).
 
-With `mhctools 3.5.0`, upstream predictor parsing now supports multiple
+With `mhctools 3.7.0+`, upstream predictor parsing supports multiple
 predictors in one CLI invocation, so commands like
 `--mhc-predictor netmhcpan42 bigmhc-el` are supported directly. Topiary keeps
 its higher-level `--filter-by` / `--sort-by` DSL on top of that lower-level
-predictor interface. NetChop and Pepsickle behavior also follows the upstream
-`mhctools 3.5.0` changes: improved NetChop error handling and Pepsickle's
-epitope-focused model selection.
+predictor interface. Topiary's ranking/filtering DSL is also compatible with
+the simplified `mhctools 3.7.0+` kind constants API. NetChop and Pepsickle
+behavior follows the upstream changes as well: improved NetChop error handling
+and Pepsickle's epitope-focused model selection.
 
 | CLI name | Predicts |
 |----------|----------|

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.0.0
-mhctools>=3.5.0
+mhctools>=3.7.0
 varcode>=0.3.17
 gtfparse>=0.0.4
 mhcnames

--- a/tests/test_cli_ranking.py
+++ b/tests/test_cli_ranking.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 
+from topiary.cli import args as cli_args
 from topiary.cli.args import create_arg_parser, _build_ranking_strategy
 from topiary.ranking import (
     Expr,
@@ -39,6 +40,16 @@ def test_sort_by_simple_affinity_kind_name_uses_raw_value():
     assert isinstance(strategy.sort_by[0], Field)
     assert repr(strategy.sort_by[0]) == "affinity.value"
     assert strategy.sort_direction == "auto"
+
+
+def test_sort_by_string_style_affinity_kind_uses_raw_value(monkeypatch):
+    monkeypatch.setattr(
+        cli_args,
+        "_resolve_qualified_kind",
+        lambda text: ("pMHC_affinity", None),
+    )
+    expr = cli_args._parse_sort_expr("ba")
+    assert repr(expr) == "affinity.value"
 
 
 def test_sort_by_simple_presentation_kind_name_uses_score():

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -14,7 +14,9 @@ from topiary.ranking import (
     Field,
     KindAccessor,
     RankingStrategy,
+    _build_kind_aliases,
     _gauss_cdf,
+    _iter_known_kinds,
     apply_ranking_strategy,
     parse_filter,
     parse_ranking,
@@ -138,6 +140,53 @@ def test_custom_kind_accessor():
     custom = KindAccessor(Kind.tap_transport)
     f = custom.score >= 0.3
     assert f.kind == Kind.tap_transport
+
+
+def test_field_supports_string_style_kind_constants():
+    df = pd.DataFrame([
+        {
+            "source_sequence_name": "var1",
+            "peptide": "SIINFEKL",
+            "peptide_offset": 0,
+            "allele": "A",
+            "kind": "pMHC_affinity",
+            "value": 85.3,
+            "score": 0.8,
+            "percentile_rank": 0.4,
+        }
+    ])
+    field = Field("pMHC_affinity", "value")
+    assert field.evaluate(df) == 85.3
+    assert repr(field) == "affinity.value"
+
+
+def test_iter_known_kinds_supports_string_constant_kind_class():
+    class FakeKind:
+        pMHC_affinity = "pMHC_affinity"
+        pMHC_presentation = "pMHC_presentation"
+        antigen_processing = "antigen_processing"
+        tap_transport = "tap_transport"
+
+    assert _iter_known_kinds(FakeKind) == [
+        "pMHC_affinity",
+        "pMHC_presentation",
+        "antigen_processing",
+        "tap_transport",
+    ]
+
+
+def test_build_kind_aliases_supports_string_constant_kind_class():
+    class FakeKind:
+        pMHC_affinity = "pMHC_affinity"
+        pMHC_presentation = "pMHC_presentation"
+        antigen_processing = "antigen_processing"
+
+    aliases = _build_kind_aliases(FakeKind)
+    assert aliases["pmhc_affinity"] == "pMHC_affinity"
+    assert aliases["affinity"] == "pMHC_affinity"
+    assert aliases["ba"] == "pMHC_affinity"
+    assert aliases["el"] == "pMHC_presentation"
+    assert aliases["antigen_processing"] == "antigen_processing"
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -51,11 +51,13 @@ from ..sources import (
 )
 from ..predictor import TopiaryPredictor
 from ..ranking import (
+    Affinity,
     ColumnFilter,
     EpitopeFilter,
     ExprFilter,
     KindAccessor,
     RankingStrategy,
+    _kind_matches,
     _resolve_qualified_kind,
     affinity_filter,
     parse_expr,
@@ -321,7 +323,7 @@ def _parse_sort_expr(text):
     if _looks_like_plain_kind_name(text):
         kind, method = _resolve_qualified_kind(text)
         accessor = KindAccessor(kind, method=method)
-        if kind.name == "pMHC_affinity":
+        if _kind_matches(kind, Affinity.kind):
             return accessor.value
         return accessor.score
 

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -35,6 +35,72 @@ from mhctools import Kind
 
 
 # ---------------------------------------------------------------------------
+# mhctools Kind compatibility
+# ---------------------------------------------------------------------------
+
+
+def _kind_name(kind):
+    """Return the canonical mhctools kind name.
+
+    Supports both enum-style kinds (``Kind.pMHC_affinity.name``) and the
+    string constants used by mhctools 3.7.0+.
+    """
+    return getattr(kind, "name", str(kind))
+
+
+def _kind_value(kind):
+    """Return the DataFrame ``kind`` value for a kind constant."""
+    return getattr(kind, "value", kind)
+
+
+def _kind_short_name(kind):
+    """Return the DSL short name for a kind."""
+    return _kind_name(kind).lower().replace("pmhc_", "")
+
+
+def _kind_matches(left, right):
+    """Check whether two kind constants refer to the same prediction kind."""
+    return _kind_value(left) == _kind_value(right)
+
+
+def _iter_known_kinds(kind_source=Kind):
+    """Enumerate mhctools kind constants across enum and string-class APIs."""
+    try:
+        candidates = list(kind_source)
+    except TypeError:
+        candidates = [
+            value
+            for name, value in vars(kind_source).items()
+            if not name.startswith("_") and isinstance(value, str)
+        ]
+
+    seen = set()
+    kinds = []
+    for kind in candidates:
+        name = _kind_name(kind)
+        if name in seen:
+            continue
+        seen.add(name)
+        kinds.append(kind)
+    return kinds
+
+
+def _build_kind_aliases(kind_source=Kind):
+    """Build parser aliases for the currently installed mhctools Kind API."""
+    aliases = {}
+    for kind in _iter_known_kinds(kind_source):
+        name = _kind_name(kind).lower()
+        aliases[name] = kind
+        aliases[_kind_short_name(kind)] = kind
+    # Extra convenience aliases
+    aliases["el"] = kind_source.pMHC_presentation
+    aliases["ba"] = kind_source.pMHC_affinity
+    aliases["aff"] = kind_source.pMHC_affinity
+    aliases["ic50"] = kind_source.pMHC_affinity
+    return aliases
+
+
+# ---------------------------------------------------------------------------
 # Expression tree — composable, evaluable against a group DataFrame
 # ---------------------------------------------------------------------------
 
@@ -561,7 +627,7 @@ class Field(Expr):
 
     __slots__ = ("kind", "field", "method", "scope")
 
-    def __init__(self, kind: Kind, field: str, method: Optional[str] = None,
+    def __init__(self, kind, field: str, method: Optional[str] = None,
                  scope: str = ""):
         self.kind = kind
         self.field = field
@@ -571,7 +637,7 @@ class Field(Expr):
     def evaluate(self, group_df):
         if group_df.empty or "kind" not in group_df.columns:
             return float("nan")
-        kind_rows = group_df[group_df["kind"] == self.kind.value]
+        kind_rows = group_df[group_df["kind"] == _kind_value(self.kind)]
         if kind_rows.empty:
             return float("nan")
         col = "prediction_method_name"
@@ -584,14 +650,14 @@ class Field(Expr):
                 if matched.empty:
                     available = sorted(kind_rows[col].dropna().unique())
                     raise _method_not_found_error(
-                        self.kind.name, self.method, available
+                        _kind_name(self.kind), self.method, available
                     )
                 kind_rows = matched
             # If column doesn't exist, keep all rows (legacy data)
         elif col in kind_rows.columns:
             methods = kind_rows[col].dropna().unique()
             if len(methods) > 1:
-                kind_name = self.kind.name
+                kind_name = _kind_name(self.kind)
                 method_list = ", ".join(sorted(methods))
                 raise ValueError(
                     f"Ambiguous: multiple models produce {kind_name} "
@@ -610,7 +676,7 @@ class Field(Expr):
         return float(val)
 
     def __repr__(self):
-        kind_name = self.kind.name.lower().replace("pmhc_", "")
+        kind_name = _kind_short_name(self.kind)
         # Map internal field names to DSL names
         if self.field == "percentile_rank":
             field_str = "rank"
@@ -696,7 +762,7 @@ class KindAccessor:
 
     __slots__ = ("kind", "method", "scope")
 
-    def __init__(self, kind: Kind, method: Optional[str] = None,
+    def __init__(self, kind, method: Optional[str] = None,
                  scope: str = ""):
         self.kind = kind
         self.method = method
@@ -960,7 +1026,7 @@ class EpitopeFilter:
         Affinity["netmhcpan"] <= 500  # only filters NetMHCpan rows
     """
 
-    kind: Kind
+    kind: object
     max_value: Optional[float] = None
     min_value: Optional[float] = None
     max_percentile_rank: Optional[float] = None
@@ -1157,7 +1223,7 @@ def _method_matches(row, method):
 
 
 def _row_passes_filter(row, filt):
-    if row["kind"] != filt.kind.value:
+    if row["kind"] != _kind_value(filt.kind):
         return False
     if not _method_matches(row, filt.method):
         return False
@@ -1209,7 +1275,7 @@ def _group_passes(group_df, strategy):
             results.append(passed)
         else:
             # EpitopeFilter
-            kind_rows = group_df[group_df["kind"] == item.kind.value]
+            kind_rows = group_df[group_df["kind"] == _kind_value(item.kind)]
             if item.method is not None and not kind_rows.empty:
                 col = "prediction_method_name"
                 if col in kind_rows.columns:
@@ -1224,7 +1290,7 @@ def _group_passes(group_df, strategy):
                             kind_rows[col].dropna().unique()
                         )
                         raise _method_not_found_error(
-                            item.kind.name, item.method, available
+                            _kind_name(item.kind), item.method, available
                         )
                     kind_rows = matched
             if kind_rows.empty:
@@ -1246,7 +1312,7 @@ def _infer_sort_direction(expr):
     if isinstance(expr, Field):
         if expr.field == "percentile_rank":
             return "asc"
-        if expr.kind == Kind.pMHC_affinity and expr.field == "value":
+        if _kind_matches(expr.kind, Kind.pMHC_affinity) and expr.field == "value":
             return "asc"
     return "desc"
 
@@ -1388,17 +1454,7 @@ def apply_ranking_strategy(df, strategy):
 # ---------------------------------------------------------------------------
 
 # Lowercase aliases for Kind names and short names
-_KIND_ALIASES = {}
-for _k in Kind:
-    _KIND_ALIASES[_k.name.lower()] = _k
-    # short aliases: "affinity" -> pMHC_affinity, "presentation" -> pMHC_presentation
-    short = _k.name.lower().replace("pmhc_", "")
-    _KIND_ALIASES[short] = _k
-# Extra convenience aliases
-_KIND_ALIASES["el"] = Kind.pMHC_presentation
-_KIND_ALIASES["ba"] = Kind.pMHC_affinity
-_KIND_ALIASES["aff"] = Kind.pMHC_affinity
-_KIND_ALIASES["ic50"] = Kind.pMHC_affinity
+_KIND_ALIASES = _build_kind_aliases()
 
 _FIELD_ALIASES = {
     "value": "value", "val": "value", "ic50": "value",
@@ -1409,7 +1465,7 @@ _FIELD_ALIASES = {
 
 
 def _resolve_kind(name):
-    """Resolve a kind alias to a Kind enum value.
+    """Resolve a kind alias to an mhctools kind constant.
 
     Accepts plain kind names (``"affinity"``, ``"ba"``) or
     tool-qualified names (``"netmhcpan_affinity"``).


### PR DESCRIPTION
## Summary

Make Topiary compatible with `mhctools 3.7.0+` and raise the dependency floor accordingly.

This patch removes the ranking DSL's remaining assumptions that `mhctools.Kind` is an iterable enum with `.name` / `.value` members. Topiary now normalizes kind identifiers internally so it works both with older enum-style kinds and with the simplified string constants used by `mhctools 3.7.0+`.

### What changed

- normalize kind handling in `topiary.ranking` via compatibility helpers
- stop relying on `Kind` iteration to build DSL alias tables
- stop reading `.name` / `.value` directly in ranking and CLI sort parsing
- add regression coverage for string-style kind constants
- bump `mhctools` requirement to `>=3.7.0`
- update README / changelog notes to describe the new minimum version and compatibility

## Why

`mhctools 3.7.0` changes `Kind` from an enum-like type to a class of string constants:

- `Kind.pMHC_affinity == "pMHC_affinity"`
- `Kind` is no longer iterable

Topiary still depended on enum-style behavior in a few places, which could break import-time alias construction and `--sort-by` / ranking evaluation under the new release.

## Validation

- `python -m pytest tests/test_cli_ranking.py tests/test_ranking.py tests/test_coverage_gaps.py tests/test_args_outputs.py -q`
  - `324 passed`
- Verified the real `mhctools 3.7.0` API in a temporary overlay:
  - `Kind.pMHC_affinity` is a plain `str`
  - iterating `Kind` raises `TypeError`
- `PYTHONPATH=/tmp/mhctools370-overlay:$PYTHONPATH python -m pytest -q`
  - `590 passed in 60.44s`

## Notes

This PR keeps the current `4.9.0` release line intact and makes the unreleased build safe to deploy with the new mhctools release.
