### PR TITLE
Expand test suite and bump to 4.10.0

### DIFF
--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,208 @@
+"""Tests for previously untested CLI helper functions."""
+
+import os
+import warnings
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from topiary.cli.args import _apply_exclusion
+from topiary.cli.protein_changes import best_transcript, genome_from_args
+from topiary.cli.rna import (
+    rna_gene_expression_dict_from_args,
+    rna_transcript_expression_dict_from_args,
+)
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+# ---------------------------------------------------------------------------
+# _apply_exclusion
+# ---------------------------------------------------------------------------
+
+
+def _make_exclusion_args(**overrides):
+    defaults = dict(
+        exclude_fasta=None,
+        exclude_ensembl=False,
+        exclude_non_cta=False,
+        exclude_tissues=None,
+        exclude_mode="substring",
+        ensembl_release=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_apply_exclusion_non_df_returns_input():
+    result = _apply_exclusion([1, 2, 3], _make_exclusion_args())
+    assert result == [1, 2, 3]
+
+
+def test_apply_exclusion_empty_df_returns_empty():
+    df = pd.DataFrame({"peptide": []})
+    result = _apply_exclusion(df, _make_exclusion_args())
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+def test_apply_exclusion_no_flags_noop():
+    df = pd.DataFrame({"peptide": ["SIINFEKL", "ELAGIGILT"]})
+    result = _apply_exclusion(df, _make_exclusion_args())
+    assert len(result) == 2
+
+
+def test_apply_exclusion_with_fasta(tmp_path):
+    fasta_path = tmp_path / "ref.fasta"
+    fasta_path.write_text(">ref\nMASIINFEKLGGGLLL\n")
+    df = pd.DataFrame({"peptide": ["SIINFEKL", "XXXXXXXX"]})
+    args = _make_exclusion_args(exclude_fasta=[str(fasta_path)])
+    result = _apply_exclusion(df, args)
+    assert len(result) == 1
+    assert result.iloc[0]["peptide"] == "XXXXXXXX"
+
+
+def test_apply_exclusion_exact_mode(tmp_path):
+    fasta_path = tmp_path / "ref.fasta"
+    fasta_path.write_text(">ref\nSIINFEKL\n")
+    df = pd.DataFrame({"peptide": ["SIINFEKL", "SIINFEKLX"]})
+    args = _make_exclusion_args(
+        exclude_fasta=[str(fasta_path)], exclude_mode="exact"
+    )
+    result = _apply_exclusion(df, args)
+    # Exact mode: only "SIINFEKL" matches exactly
+    assert "SIINFEKLX" in result["peptide"].values
+
+
+# ---------------------------------------------------------------------------
+# genome_from_args
+# ---------------------------------------------------------------------------
+
+
+def test_genome_from_args_default():
+    from pyensembl import ensembl_grch38
+    args = SimpleNamespace(genome=None)
+    result = genome_from_args(args)
+    assert result is ensembl_grch38
+
+
+def test_genome_from_args_explicit():
+    args = SimpleNamespace(genome="GRCh38")
+    result = genome_from_args(args)
+    assert "38" in str(result.release) or result.reference_name == "GRCh38"
+
+
+# ---------------------------------------------------------------------------
+# best_transcript
+# ---------------------------------------------------------------------------
+
+
+def _mock_transcript(protein_len, seq_len, name):
+    return SimpleNamespace(
+        protein_sequence="M" * protein_len,
+        sequence="A" * seq_len,
+        name=name,
+    )
+
+
+def test_best_transcript_longest_protein_wins():
+    t1 = _mock_transcript(100, 500, "TX-001")
+    t2 = _mock_transcript(200, 400, "TX-002")
+    assert best_transcript([t1, t2]).name == "TX-002"
+
+
+def test_best_transcript_tiebreak_by_seq_length():
+    t1 = _mock_transcript(100, 500, "TX-001")
+    t2 = _mock_transcript(100, 600, "TX-002")
+    assert best_transcript([t1, t2]).name == "TX-002"
+
+
+def test_best_transcript_tiebreak_by_name():
+    t1 = _mock_transcript(100, 500, "EGFR-002")
+    t2 = _mock_transcript(100, 500, "EGFR-001")
+    assert best_transcript([t1, t2]).name == "EGFR-001"
+
+
+def test_best_transcript_single():
+    t = _mock_transcript(100, 500, "TX-001")
+    assert best_transcript([t]).name == "TX-001"
+
+
+def test_best_transcript_empty_raises():
+    with pytest.raises(AssertionError):
+        best_transcript([])
+
+
+# ---------------------------------------------------------------------------
+# rna_gene_expression_dict_from_args
+# ---------------------------------------------------------------------------
+
+
+def _make_rna_args(**overrides):
+    defaults = dict(
+        rna_gene_fpkm_tracking_file=None,
+        rna_transcript_fpkm_tracking_file=None,
+        rna_transcript_fpkm_gtf_file=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_rna_gene_expression_none():
+    result = rna_gene_expression_dict_from_args(_make_rna_args())
+    assert result is None
+
+
+def test_rna_gene_expression_with_file():
+    path = os.path.join(DATA_DIR, "genes.fpkm_tracking")
+    args = _make_rna_args(rna_gene_fpkm_tracking_file=path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = rna_gene_expression_dict_from_args(args)
+    assert isinstance(result, dict)
+    assert len(result) > 0
+
+
+def test_rna_gene_expression_deprecation_warning():
+    path = os.path.join(DATA_DIR, "genes.fpkm_tracking")
+    args = _make_rna_args(rna_gene_fpkm_tracking_file=path)
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        rna_gene_expression_dict_from_args(args)
+
+
+# ---------------------------------------------------------------------------
+# rna_transcript_expression_dict_from_args
+# ---------------------------------------------------------------------------
+
+
+def test_rna_transcript_expression_none():
+    result = rna_transcript_expression_dict_from_args(_make_rna_args())
+    assert result is None
+
+
+def test_rna_transcript_expression_cufflinks():
+    path = os.path.join(DATA_DIR, "isoforms.fpkm_tracking")
+    args = _make_rna_args(rna_transcript_fpkm_tracking_file=path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = rna_transcript_expression_dict_from_args(args)
+    assert isinstance(result, dict)
+    assert len(result) > 0
+
+
+def test_rna_transcript_expression_gtf():
+    path = os.path.join(DATA_DIR, "B16-StringTie-chr1-subset.gtf")
+    args = _make_rna_args(rna_transcript_fpkm_gtf_file=path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = rna_transcript_expression_dict_from_args(args)
+    assert isinstance(result, dict)
+    assert len(result) > 0
+
+
+def test_rna_transcript_expression_cufflinks_deprecation():
+    path = os.path.join(DATA_DIR, "isoforms.fpkm_tracking")
+    args = _make_rna_args(rna_transcript_fpkm_tracking_file=path)
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        rna_transcript_expression_dict_from_args(args)

--- a/tests/test_edge_case_fixtures.py
+++ b/tests/test_edge_case_fixtures.py
@@ -1,0 +1,157 @@
+"""Edge-case tests: empty files, malformed CSVs, missing columns."""
+
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import TopiaryPredictor
+from topiary.inputs import read_fasta, read_peptide_csv, read_peptide_fasta, read_sequence_csv
+
+
+def _tmpfile(content, suffix=".csv"):
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+# ---------------------------------------------------------------------------
+# Empty inputs
+# ---------------------------------------------------------------------------
+
+
+def test_predict_from_empty_dict():
+    predictor = TopiaryPredictor(models=RandomBindingPredictor, alleles=["A0201"])
+    df = predictor.predict_from_named_sequences({})
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 0
+
+
+def test_fasta_empty_file():
+    path = _tmpfile("", ".fasta")
+    try:
+        seqs = read_fasta(path)
+        assert len(seqs) == 0
+    finally:
+        os.unlink(path)
+
+
+def test_peptide_csv_header_only():
+    path = _tmpfile("name,peptide\n")
+    try:
+        seqs = read_peptide_csv(path)
+        assert len(seqs) == 0
+    finally:
+        os.unlink(path)
+
+
+def test_sequence_csv_header_only():
+    path = _tmpfile("name,sequence\n")
+    try:
+        seqs = read_sequence_csv(path)
+        assert len(seqs) == 0
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Malformed CSVs
+# ---------------------------------------------------------------------------
+
+
+def test_peptide_csv_wrong_column_name():
+    path = _tmpfile("name,pep\npep1,SIINFEKL\n")
+    try:
+        with pytest.raises((ValueError, KeyError)):
+            read_peptide_csv(path)
+    finally:
+        os.unlink(path)
+
+
+def test_sequence_csv_wrong_column_name():
+    path = _tmpfile("name,seq\nbraf,MASIINFEKL\n")
+    try:
+        with pytest.raises((ValueError, KeyError)):
+            read_sequence_csv(path)
+    finally:
+        os.unlink(path)
+
+
+def test_peptide_csv_extra_columns_ok():
+    path = _tmpfile("name,peptide,extra\npep1,SIINFEKL,foo\n")
+    try:
+        seqs = read_peptide_csv(path)
+        assert seqs == {"pep1": "SIINFEKL"}
+    finally:
+        os.unlink(path)
+
+
+def test_sequence_csv_empty_sequence():
+    """CSV with an empty sequence value should produce an empty or short entry."""
+    path = _tmpfile("name,sequence\nbraf,\n")
+    try:
+        seqs = read_sequence_csv(path)
+        # Should either have an empty string or skip it
+        assert isinstance(seqs, dict)
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# FASTA edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_fasta_multiple_sequences():
+    content = ">seq1\nAAAAAAA\n>seq2\nBBBBBBB\n>seq3\nCCCCCCC\n"
+    path = _tmpfile(content, ".fasta")
+    try:
+        seqs = read_fasta(path)
+        assert len(seqs) == 3
+    finally:
+        os.unlink(path)
+
+
+def test_fasta_multiline_sequence():
+    content = ">long\nAAAAA\nBBBBB\nCCCCC\n"
+    path = _tmpfile(content, ".fasta")
+    try:
+        seqs = read_fasta(path)
+        assert seqs["long"] == "AAAAABBBBBCCCCC"
+    finally:
+        os.unlink(path)
+
+
+def test_peptide_fasta_empty():
+    path = _tmpfile("", ".fasta")
+    try:
+        seqs = read_peptide_fasta(path)
+        assert len(seqs) == 0
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline with edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_single_peptide():
+    """Single short peptide through the full pipeline."""
+    predictor = TopiaryPredictor(
+        models=RandomBindingPredictor, alleles=["B3501"],
+    )
+    df = predictor.predict_from_named_sequences({"pep": "SIINFEKLAA"})
+    assert len(df) > 0
+
+
+def test_pipeline_very_long_sequence():
+    """Long sequence shouldn't crash."""
+    predictor = TopiaryPredictor(
+        models=RandomBindingPredictor, alleles=["A0201"],
+    )
+    df = predictor.predict_from_named_sequences({"long": "A" * 500})
+    assert len(df) > 0

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -31,27 +31,32 @@ ALLELES = ["A0201", "B0702"]
 # ---------------------------------------------------------------------------
 
 
-def test_peptide_csv_full_pipeline():
-    path = _tmpfile("name,peptide\npep1,SIINFEKLA\npep2,ELAGIGILT\npep3,AAAAAKVAA\n")
-    seqs = read_peptide_csv(path)
+@pytest.mark.parametrize("content,suffix,reader,alleles", [
+    ("name,peptide\npep1,SIINFEKLA\npep2,ELAGIGILT\npep3,AAAAAKVAA\n",
+     ".csv", read_peptide_csv, ALLELES),
+    (">braf\nMASIINFEKLGGGLLLAAA\n>tp53\nMRKKLLLQQQRRREEEYYY\n",
+     ".fasta", read_fasta, ALLELES),
+    (">pep1\nSIINFEKLA\n>pep2\nELAGIGILT\n",
+     ".fasta", read_peptide_fasta, ["A0201"]),
+    ("name,sequence\nbraf,MASIINFEKLGGGLLL\n",
+     ".csv", read_sequence_csv, ["A0201"]),
+], ids=["peptide_csv", "fasta", "peptide_fasta", "sequence_csv"])
+def test_input_format_full_pipeline(content, suffix, reader, alleles):
+    path = _tmpfile(content, suffix)
+    seqs = reader(path)
     os.unlink(path)
 
-    # No filter — this test checks schema, not filtering
     predictor = TopiaryPredictor(
-        models=[RandomBindingPredictor, RandomBindingPredictor],
-        alleles=ALLELES,
+        models=RandomBindingPredictor, alleles=alleles,
     )
     df = predictor.predict_from_named_sequences(seqs)
 
-    # Verify output schema
     for col in [
         "peptide", "kind", "score", "value", "affinity",
         "prediction_method_name", "source_sequence_name",
         "peptide_length", "peptide_offset",
     ]:
         assert col in df.columns, f"Missing column: {col}"
-
-    # Two models → results from both
     assert len(df) > 0
 
     # Affinity column: non-NaN for pMHC_affinity rows, NaN otherwise
@@ -63,41 +68,55 @@ def test_peptide_csv_full_pipeline():
         assert non_aff_rows["affinity"].isna().all()
 
 
-def test_fasta_full_pipeline():
+def test_fasta_source_names():
+    """FASTA reader preserves sequence names through the pipeline."""
     path = _tmpfile(">braf\nMASIINFEKLGGGLLLAAA\n>tp53\nMRKKLLLQQQRRREEEYYY\n", ".fasta")
     seqs = read_fasta(path)
     os.unlink(path)
 
-    predictor = TopiaryPredictor(
-        models=RandomBindingPredictor, alleles=ALLELES,
-    )
+    predictor = TopiaryPredictor(models=RandomBindingPredictor, alleles=ALLELES)
     df = predictor.predict_from_named_sequences(seqs)
-    assert len(df) > 0
     assert set(df["source_sequence_name"].unique()) == {"braf", "tp53"}
 
 
-def test_peptide_fasta_full_pipeline():
-    path = _tmpfile(">pep1\nSIINFEKLA\n>pep2\nELAGIGILT\n", ".fasta")
-    seqs = read_peptide_fasta(path)
-    os.unlink(path)
+# ---------------------------------------------------------------------------
+# End-to-end: mouse H-2 and Class II DQ alleles
+# ---------------------------------------------------------------------------
 
+
+def test_pipeline_mouse_h2_alleles():
+    """Mouse H-2 alleles work through the full pipeline."""
     predictor = TopiaryPredictor(
-        models=RandomBindingPredictor, alleles=["A0201"],
+        models=RandomBindingPredictor, alleles=["H-2-Kb", "H-2-Db"],
     )
-    df = predictor.predict_from_named_sequences(seqs)
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGGLLLAAA"})
     assert len(df) > 0
+    alleles_in_output = set(df["allele"].unique())
+    assert any("H-2" in a for a in alleles_in_output)
 
 
-def test_sequence_csv_full_pipeline():
-    path = _tmpfile("name,sequence\nbraf,MASIINFEKLGGGLLL\n")
-    seqs = read_sequence_csv(path)
-    os.unlink(path)
-
+def test_pipeline_class2_dq_allele():
+    """Class II DQ alleles work through the full pipeline."""
     predictor = TopiaryPredictor(
-        models=RandomBindingPredictor, alleles=["A0201"],
+        models=RandomBindingPredictor,
+        alleles=["HLA-DQA1*01:02-DQB1*06:02"],
     )
-    df = predictor.predict_from_named_sequences(seqs)
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGGLLLAAA"})
     assert len(df) > 0
+    alleles_in_output = set(df["allele"].unique())
+    assert any("DQ" in a for a in alleles_in_output)
+
+
+def test_pipeline_mixed_species_alleles():
+    """Mixed human and mouse alleles in one prediction."""
+    predictor = TopiaryPredictor(
+        models=RandomBindingPredictor,
+        alleles=["A0201", "H-2-Kb"],
+    )
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+    assert len(df) > 0
+    alleles = set(df["allele"].unique())
+    assert len(alleles) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ from topiary.sources import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-ALLELES = ["A0201"]
+ALLELES = ["A0301"]
 
 # Small set of genes for fast tests
 GENES = ["BRAF", "TP53"]

--- a/tests/test_predictor_internals.py
+++ b/tests/test_predictor_internals.py
@@ -1,0 +1,152 @@
+"""Direct unit tests for TopiaryPredictor private methods."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import TopiaryPredictor
+from topiary.predictor import _attach_expression_data
+
+
+# ---------------------------------------------------------------------------
+# _format_prediction_df
+# ---------------------------------------------------------------------------
+
+
+def _make_predictor():
+    return TopiaryPredictor(models=RandomBindingPredictor, alleles=["A0201"])
+
+
+def _raw_df(**overrides):
+    """Minimal DataFrame mimicking mhctools output before formatting."""
+    row = dict(
+        peptide="SIINFEKL",
+        allele="HLA-A*02:01",
+        kind="pMHC_affinity",
+        score=0.8,
+        value=120.0,
+        percentile_rank=0.5,
+        offset=10,
+        predictor_name="random",
+    )
+    row.update(overrides)
+    return pd.DataFrame([row])
+
+
+def test_format_renames_columns():
+    df = _raw_df()
+    result = _make_predictor()._format_prediction_df(df)
+    assert "peptide_offset" in result.columns
+    assert "prediction_method_name" in result.columns
+    assert "offset" not in result.columns
+    assert "predictor_name" not in result.columns
+
+
+def test_format_adds_peptide_length():
+    df = _raw_df(peptide="SIINFEKLAA")
+    result = _make_predictor()._format_prediction_df(df)
+    assert result.iloc[0]["peptide_length"] == 10
+
+
+def test_format_adds_source_sequence_name_if_missing():
+    df = _raw_df()
+    df = df.drop(columns=["source_sequence_name"], errors="ignore")
+    result = _make_predictor()._format_prediction_df(df)
+    assert "source_sequence_name" in result.columns
+
+
+def test_format_adds_peptide_offset_if_missing():
+    df = _raw_df()
+    df = df.drop(columns=["offset"], errors="ignore")
+    df = df.drop(columns=["peptide_offset"], errors="ignore")
+    result = _make_predictor()._format_prediction_df(df)
+    assert "peptide_offset" in result.columns
+    assert result.iloc[0]["peptide_offset"] == 0
+
+
+def test_format_affinity_for_affinity_kind():
+    df = _raw_df(kind="pMHC_affinity", value=85.0)
+    result = _make_predictor()._format_prediction_df(df)
+    assert result.iloc[0]["affinity"] == 85.0
+
+
+def test_format_affinity_nan_for_non_affinity_kind():
+    df = _raw_df(kind="pMHC_presentation", value=0.95)
+    result = _make_predictor()._format_prediction_df(df)
+    assert np.isnan(result.iloc[0]["affinity"])
+
+
+def test_format_preserves_existing_affinity():
+    df = _raw_df()
+    df["affinity"] = 999.0
+    result = _make_predictor()._format_prediction_df(df)
+    assert result.iloc[0]["affinity"] == 999.0
+
+
+def test_format_empty_df():
+    df = pd.DataFrame()
+    result = _make_predictor()._format_prediction_df(df)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# _attach_expression_data: additional edge cases
+# ---------------------------------------------------------------------------
+
+
+def _make_prediction_df():
+    return pd.DataFrame([
+        dict(
+            source_sequence_name="var1", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            gene_id="ENSG00000157764", transcript_id="ENST00000288602",
+            variant="chr7 g.140753336A>T",
+        ),
+    ])
+
+
+def test_attach_empty_expression_noop():
+    df = _make_prediction_df()
+    n_cols = len(df.columns)
+    result = _attach_expression_data(df, {"gene": [], "transcript": [], "variant": []})
+    assert len(result.columns) == n_cols
+
+
+def test_attach_duplicate_gene_ids_summed():
+    df = _make_prediction_df()
+    expr_df = pd.DataFrame({
+        "gene_id": ["ENSG00000157764", "ENSG00000157764"],
+        "TPM": [20.0, 22.5],
+    })
+    expr_data = {"gene": [("gene", "gene_id", expr_df)], "transcript": [], "variant": []}
+    result = _attach_expression_data(df, expr_data)
+    assert "gene_tpm" in result.columns
+    assert result.iloc[0]["gene_tpm"] == pytest.approx(42.5)
+
+
+def test_attach_prefix_lowercasing():
+    df = _make_prediction_df()
+    expr_df = pd.DataFrame({
+        "gene_id": ["ENSG00000157764"],
+        "TPM": [42.5],
+        "NumReads": [1000],
+    })
+    expr_data = {"gene": [("salmon", "gene_id", expr_df)], "transcript": [], "variant": []}
+    result = _attach_expression_data(df, expr_data)
+    assert "salmon_tpm" in result.columns
+    assert "salmon_numreads" in result.columns
+
+
+def test_attach_no_prefix():
+    """When name_prefix is None, columns keep original (lowercased) names."""
+    df = _make_prediction_df()
+    expr_df = pd.DataFrame({
+        "variant": ["chr7 g.140753336A>T"],
+        "num_alt_reads": [15],
+    })
+    expr_data = {"gene": [], "transcript": [], "variant": [(None, "variant", expr_df)]}
+    result = _attach_expression_data(df, expr_data)
+    assert "num_alt_reads" in result.columns

--- a/tests/test_sequence_helpers.py
+++ b/tests/test_sequence_helpers.py
@@ -1,0 +1,83 @@
+"""Direct unit tests for protein_subsequences_around_mutations()."""
+
+from topiary.sequence_helpers import protein_subsequences_around_mutations
+
+
+class _MockEffect:
+    """Hashable mock effect with the fields the function accesses."""
+    def __init__(self, protein_seq, start, end):
+        self.mutant_protein_sequence = protein_seq
+        self.aa_mutation_start_offset = start
+        self.aa_mutation_end_offset = end
+
+
+def _mock_effect(protein_seq, start, end):
+    return _MockEffect(protein_seq, start, end)
+
+
+def test_single_substitution_middle():
+    protein = "A" * 100
+    effect = _mock_effect(protein, 50, 51)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert offsets[effect] == 41  # max(0, 50-9)
+    assert subseqs[effect] == protein[41:60]  # min(100, 51+9) = 60
+
+
+def test_mutation_near_start():
+    protein = "M" * 50
+    effect = _mock_effect(protein, 2, 3)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert offsets[effect] == 0  # max(0, 2-9) clamped
+    assert subseqs[effect] == protein[0:12]  # min(50, 3+9) = 12
+
+
+def test_mutation_near_end():
+    protein = "G" * 20
+    effect = _mock_effect(protein, 18, 19)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert offsets[effect] == 9  # max(0, 18-9)
+    assert subseqs[effect] == protein[9:20]  # min(20, 19+9) = 20, clamped
+
+
+def test_stop_codon_trimming():
+    protein = "AAAAAAAAAAMAAAA*AAAA"  # stop at position 15
+    effect = _mock_effect(protein, 10, 11)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    # End is min(first_stop=15, 11+9=20) = 15
+    assert subseqs[effect] == protein[1:15]
+    assert "*" not in subseqs[effect]
+
+
+def test_silent_effect_skipped():
+    """Effects with mutant_protein_sequence=None are skipped."""
+    effect = _mock_effect(None, 10, 11)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert len(subseqs) == 0
+    assert len(offsets) == 0
+
+
+def test_multiple_effects():
+    protein_a = "A" * 50
+    protein_b = "B" * 50
+    e1 = _mock_effect(protein_a, 25, 26)
+    e2 = _mock_effect(protein_b, 10, 11)
+    subseqs, offsets = protein_subsequences_around_mutations([e1, e2], padding_around_mutation=9)
+    assert len(subseqs) == 2
+    assert e1 in subseqs
+    assert e2 in subseqs
+
+
+def test_deletion_zero_width():
+    """Deletion: start_offset == end_offset."""
+    protein = "A" * 40
+    effect = _mock_effect(protein, 20, 20)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert offsets[effect] == 11  # max(0, 20-9)
+    assert subseqs[effect] == protein[11:29]  # min(40, 20+9)
+
+
+def test_empty_string_protein_skipped():
+    """Empty string protein sequence is falsy, should be skipped."""
+    effect = _mock_effect("", 0, 0)
+    subseqs, offsets = protein_subsequences_around_mutations([effect], padding_around_mutation=9)
+    assert len(subseqs) == 0

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -80,11 +80,11 @@ def test_predictor_with_alleles_and_model_classes():
 
     predictor = TopiaryPredictor(
         models=[RandomBindingPredictor],
-        alleles=["A0201"],
+        alleles=["A*03:01"],
         filter=Affinity <= 500,
     )
     assert len(predictor.models) == 1
-    assert "HLA-A*02:01" in predictor.models[0].alleles
+    assert "HLA-A*03:01" in predictor.models[0].alleles
 
 
 def test_predictor_filter_and_sort_by_separate():
@@ -92,7 +92,7 @@ def test_predictor_filter_and_sort_by_separate():
     from topiary import TopiaryPredictor, Affinity, Presentation
 
     predictor = TopiaryPredictor(
-        models=RandomBindingPredictor(alleles=["A0201"]),
+        models=RandomBindingPredictor(alleles=["A*03:01"]),
         filter=Affinity <= 500,
         sort_by=[Presentation.score, Affinity.score],
     )

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -35,7 +35,7 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 
-__version__ = "4.9.0"
+__version__ = "4.10.0"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
## Summary
- Fill coverage gaps identified in test audit: add direct tests for `_apply_exclusion`, `genome_from_args`, `best_transcript`, RNA expression helpers, `protein_subsequences_around_mutations`, `_format_prediction_df`, and `_attach_expression_data`
- Add mouse H-2 and Class II DQ allele coverage to end-to-end tests
- Parameterize redundant input-format pipeline tests
- Add edge-case tests for empty/malformed inputs
- Vary default test alleles across files (A0301, A*03:01) to reduce HLA-A*02:01 monoculture
- Bump version to 4.10.0 (590 → 646 tests)

## Test plan
- [x] All 646 tests pass locally
- [ ] CI green on Python 3.10, 3.11, 3.12