### PR TITLE
Add IO with comment metadata and wide/long conversion

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -49,6 +49,51 @@ def test_no_models_raises():
         TopiaryPredictor()
 
 
+# ---------------------------------------------------------------------------
+# String model names
+# ---------------------------------------------------------------------------
+
+
+def test_model_name_string_lowercase():
+    """Can create predictor with lowercase string model name."""
+    predictor = TopiaryPredictor(
+        models="randombindingpredictor", alleles=["A0201"],
+    )
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+    assert len(df) > 0
+
+
+def test_model_name_string_mixed_case():
+    """Case-insensitive model name matching."""
+    predictor = TopiaryPredictor(
+        models="RandomBindingPredictor", alleles=["A0201"],
+    )
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+    assert len(df) > 0
+
+
+def test_model_name_string_mhcflurry():
+    """MHCflurry can be referenced by string name."""
+    predictor = TopiaryPredictor(
+        models="mhcflurry", alleles=["A0201"],
+    )
+    assert len(predictor.models) == 1
+
+
+def test_model_name_string_list():
+    """List of string model names."""
+    predictor = TopiaryPredictor(
+        models=["randombindingpredictor", "randombindingpredictor"],
+        alleles=["A0201"],
+    )
+    assert len(predictor.models) == 2
+
+
+def test_model_name_string_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown model name"):
+        TopiaryPredictor(models="nonexistent_model", alleles=["A0201"])
+
+
 def test_mhc_model_backward_compat_property():
     predictor = TopiaryPredictor(
         mhc_model=RandomBindingPredictor(alleles=["A0201"]),

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -73,11 +73,11 @@ def test_model_name_string_mixed_case():
 
 
 def test_model_name_string_mhcflurry():
-    """MHCflurry can be referenced by string name."""
-    predictor = TopiaryPredictor(
-        models="mhcflurry", alleles=["A0201"],
-    )
-    assert len(predictor.models) == 1
+    """MHCflurry class can be resolved by string name."""
+    from topiary.predictor import _resolve_model_name
+    from mhctools import MHCflurry
+    cls = _resolve_model_name("mhcflurry")
+    assert cls is MHCflurry
 
 
 def test_model_name_string_list():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -30,17 +30,13 @@ class TestParseCommentBlock:
             "#form=long\n",
             "#model:netmhcpan=4.1b\n",
             "#model:mhcflurry=2.1.1\n",
-            "#filter_by=affinity <= 500\n",
-            "#sort_by=presentation.score\n",
             "peptide\tallele\n",
         ]
         meta, n = _parse_comment_block(lines)
-        assert n == 6
+        assert n == 4
         assert meta.topiary_version == "4.11.0"
         assert meta.form == "long"
         assert meta.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
-        assert meta.filter_by == "affinity <= 500"
-        assert meta.sort_by == "presentation.score"
 
     def test_unknown_keys_in_extra(self):
         lines = [
@@ -99,15 +95,11 @@ class TestFormatCommentBlock:
             topiary_version="4.11.0",
             form="long",
             models={"netmhcpan": "4.1b"},
-            filter_by="affinity <= 500",
-            sort_by="presentation.score",
         )
         block = _format_comment_block(meta)
         assert "#topiary_version=4.11.0" in block
         assert "#form=long" in block
         assert "#model:netmhcpan=4.1b" in block
-        assert "#filter_by=affinity <= 500" in block
-        assert "#sort_by=presentation.score" in block
 
     def test_empty_metadata(self):
         meta = Metadata()
@@ -124,8 +116,6 @@ class TestFormatCommentBlock:
             topiary_version="4.11.0",
             form="wide",
             models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
-            filter_by="affinity <= 500 | presentation.rank <= 2",
-            sort_by="presentation.score",
             extra={"source": "lens-v1.9"},
         )
         block = _format_comment_block(meta)
@@ -134,8 +124,6 @@ class TestFormatCommentBlock:
         assert parsed.topiary_version == meta.topiary_version
         assert parsed.form == meta.form
         assert dict(parsed.models) == dict(meta.models)
-        assert parsed.filter_by == meta.filter_by
-        assert parsed.sort_by == meta.sort_by
         assert dict(parsed.extra) == dict(meta.extra)
 
 
@@ -196,16 +184,13 @@ class TestReadWriteTSV:
     def test_metadata_preserved(self, tmp_path):
         df = _sample_long_df()
         meta = Metadata(
-            filter_by="affinity <= 500",
-            sort_by="presentation.score",
-            extra={"source": "test"},
+            extra={"source": "test", "patient": "PT01"},
         )
         path = tmp_path / "out.tsv"
         to_tsv(df, path, metadata=meta)
         _, meta2 = read_tsv(path)
-        assert meta2.filter_by == "affinity <= 500"
-        assert meta2.sort_by == "presentation.score"
         assert meta2.extra.get("source") == "test"
+        assert meta2.extra.get("patient") == "PT01"
 
     def test_model_versions_auto_extracted(self, tmp_path):
         df = _sample_long_df()
@@ -264,8 +249,6 @@ class TestEdgeCases:
             topiary_version="4.11.0",
             form="wide",
             models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
-            filter_by="affinity <= 500 | presentation.rank <= 2",
-            sort_by="presentation.score",
             extra={"source": "lens-v1.9", "patient": "PT01"},
         )
         df = pd.DataFrame({"peptide": ["A"], "netmhcpan_affinity_value": [100]})
@@ -275,8 +258,6 @@ class TestEdgeCases:
         assert meta2.topiary_version == "4.11.0"
         assert meta2.form == "wide"
         assert meta2.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
-        assert meta2.filter_by == "affinity <= 500 | presentation.rank <= 2"
-        assert meta2.sort_by == "presentation.score"
         assert meta2.extra == {"source": "lens-v1.9", "patient": "PT01"}
 
     def test_pandas_read_csv_with_comment_hash(self, tmp_path):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,5 @@
 """Tests for topiary.io — read/write with comment-block metadata."""
 
-import math
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -281,3 +279,139 @@ class TestEdgeCases:
                 assert not line.startswith(",")
                 assert not line.startswith("\t,")
                 break
+
+
+# ---------------------------------------------------------------------------
+# Full round-trip integration tests with real predictor
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripIntegration:
+    """End-to-end: predict → to_wide → to_tsv → read_tsv → from_wide → verify."""
+
+    def test_predict_to_wide_tsv_roundtrip(self, tmp_path):
+        from mhctools import RandomBindingPredictor
+        from topiary import TopiaryPredictor
+        from topiary.wide import to_wide, from_wide
+
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"],
+        )
+        long_orig = predictor.predict_from_named_sequences(
+            {"prot": "MASIINFEKLGGGLLLAAA"}
+        )
+        assert len(long_orig) > 0
+
+        # Long → wide
+        wide = to_wide(long_orig)
+        assert "kind" not in wide.columns
+
+        # Wide → TSV → read back
+        path = tmp_path / "roundtrip.wide.tsv"
+        to_tsv(wide, path)
+        wide_read, meta = read_tsv(path)
+        assert meta.form == "wide"
+        assert len(wide_read) == len(wide)
+
+        # Read back → long
+        long_back = from_wide(wide_read, metadata=meta)
+        assert "kind" in long_back.columns
+        assert len(long_back) == len(long_orig)
+
+        # Values round-trip correctly
+        orig_values = sorted(long_orig["value"].dropna().tolist())
+        back_values = sorted(long_back["value"].dropna().tolist())
+        assert orig_values == pytest.approx(back_values)
+
+    def test_predict_long_tsv_roundtrip(self, tmp_path):
+        from mhctools import RandomBindingPredictor
+        from topiary import TopiaryPredictor
+
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"],
+        )
+        long_orig = predictor.predict_from_named_sequences(
+            {"prot": "MASIINFEKLGGGLLLAAA"}
+        )
+
+        # Long → TSV → read back
+        path = tmp_path / "roundtrip.tsv"
+        to_tsv(long_orig, path)
+        long_read, meta = read_tsv(path)
+        assert meta.form == "long"
+        assert len(long_read) == len(long_orig)
+        assert list(long_read["peptide"]) == list(long_orig["peptide"])
+
+    def test_predict_wide_csv_roundtrip(self, tmp_path):
+        from mhctools import RandomBindingPredictor
+        from topiary import TopiaryPredictor
+        from topiary.wide import to_wide, from_wide
+
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201", "B0702"],
+        )
+        long_orig = predictor.predict_from_named_sequences(
+            {"braf": "MASIINFEKLGGG", "tp53": "MRKKLLQQREEY"}
+        )
+        wide = to_wide(long_orig)
+
+        path = tmp_path / "roundtrip.wide.csv"
+        to_csv(wide, path)
+        wide_read, meta = read_csv(path)
+        long_back = from_wide(wide_read, metadata=meta)
+
+        assert set(long_back["kind"].unique()) == set(long_orig["kind"].unique())
+        assert len(long_back) == len(long_orig)
+
+    def test_from_wide_to_wide_roundtrip(self, tmp_path):
+        """Reverse direction: from_wide then to_wide should be identity."""
+        from topiary.wide import to_wide, from_wide
+
+        wide_orig = pd.DataFrame({
+            "peptide": ["SIINFEKL", "ELAGIGILT"],
+            "allele": ["HLA-A*02:01", "HLA-A*02:01"],
+            "source_sequence_name": ["prot1", "prot1"],
+            "netmhcpan_affinity_value": [120.0, 5000.0],
+            "netmhcpan_affinity_score": [0.85, 0.3],
+            "netmhcpan_affinity_rank": [0.5, 15.0],
+        })
+        long = from_wide(wide_orig)
+        wide_back = to_wide(long)
+
+        assert "netmhcpan_affinity_value" in wide_back.columns
+        assert len(wide_back) == 2
+        vals = sorted(wide_back["netmhcpan_affinity_value"].tolist())
+        assert vals == pytest.approx([120.0, 5000.0])
+
+    def test_sample_name_survives_roundtrip(self):
+        """sample_name column from mhctools should survive wide/long."""
+        from topiary.wide import to_wide, from_wide
+
+        df = pd.DataFrame([
+            dict(
+                peptide="SIINFEKL", allele="HLA-A*02:01",
+                sample_name="patient_01",
+                kind="pMHC_affinity", score=0.85, value=120.0,
+                percentile_rank=0.5, affinity=120.0,
+                prediction_method_name="netmhcpan", predictor_version="4.1b",
+            ),
+        ])
+        wide = to_wide(df)
+        assert "sample_name" in wide.columns
+        long = from_wide(wide)
+        assert "sample_name" in long.columns
+        assert long.iloc[0]["sample_name"] == "patient_01"
+
+    def test_model_versions_in_metadata_after_write(self, tmp_path):
+        """Model versions auto-extracted on write, available on read."""
+        from mhctools import RandomBindingPredictor
+        from topiary import TopiaryPredictor
+
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"],
+        )
+        df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+        path = tmp_path / "models.tsv"
+        to_tsv(df, path)
+        _, meta = read_tsv(path)
+        assert len(meta.models) > 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,302 @@
+"""Tests for topiary.io — read/write with comment-block metadata."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary.io import (
+    Metadata,
+    _format_comment_block,
+    _parse_comment_block,
+    read_csv,
+    read_tsv,
+    to_csv,
+    to_tsv,
+)
+from topiary.wide import to_wide
+
+
+# ---------------------------------------------------------------------------
+# Comment block parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseCommentBlock:
+    def test_well_formed(self):
+        lines = [
+            "#topiary_version=4.11.0\n",
+            "#form=long\n",
+            "#model:netmhcpan=4.1b\n",
+            "#model:mhcflurry=2.1.1\n",
+            "#filter_by=affinity <= 500\n",
+            "#sort_by=presentation.score\n",
+            "peptide\tallele\n",
+        ]
+        meta, n = _parse_comment_block(lines)
+        assert n == 6
+        assert meta.topiary_version == "4.11.0"
+        assert meta.form == "long"
+        assert meta.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
+        assert meta.filter_by == "affinity <= 500"
+        assert meta.sort_by == "presentation.score"
+
+    def test_unknown_keys_in_extra(self):
+        lines = [
+            "#topiary_version=4.11.0\n",
+            "#custom_key=custom_value\n",
+            "#source=lens-v1.9\n",
+            "peptide\n",
+        ]
+        meta, n = _parse_comment_block(lines)
+        assert n == 3
+        assert meta.extra == {"custom_key": "custom_value", "source": "lens-v1.9"}
+
+    def test_no_comments(self):
+        lines = ["peptide\tallele\n", "SIINFEKL\tHLA-A*02:01\n"]
+        meta, n = _parse_comment_block(lines)
+        assert n == 0
+        assert meta.topiary_version is None
+        assert meta.models == {}
+
+    def test_empty_lines(self):
+        meta, n = _parse_comment_block([])
+        assert n == 0
+
+    def test_malformed_comment_skipped(self):
+        lines = [
+            "#topiary_version=4.11.0\n",
+            "#no-equals-sign\n",
+            "#form=wide\n",
+            "data\n",
+        ]
+        meta, n = _parse_comment_block(lines)
+        assert n == 3
+        assert meta.topiary_version == "4.11.0"
+        assert meta.form == "wide"
+
+    def test_model_entries(self):
+        lines = [
+            "#model:netmhcpan=4.1b\n",
+            "#model:mhcflurry=2.1.1\n",
+            "#model:netmhcstabpan=1.0\n",
+            "data\n",
+        ]
+        meta, _ = _parse_comment_block(lines)
+        assert len(meta.models) == 3
+        assert meta.models["netmhcstabpan"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Comment block formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCommentBlock:
+    def test_full_metadata(self):
+        meta = Metadata(
+            topiary_version="4.11.0",
+            form="long",
+            models={"netmhcpan": "4.1b"},
+            filter_by="affinity <= 500",
+            sort_by="presentation.score",
+        )
+        block = _format_comment_block(meta)
+        assert "#topiary_version=4.11.0" in block
+        assert "#form=long" in block
+        assert "#model:netmhcpan=4.1b" in block
+        assert "#filter_by=affinity <= 500" in block
+        assert "#sort_by=presentation.score" in block
+
+    def test_empty_metadata(self):
+        meta = Metadata()
+        block = _format_comment_block(meta)
+        assert block == ""
+
+    def test_extra_keys_preserved(self):
+        meta = Metadata(extra={"source": "lens-v1.9"})
+        block = _format_comment_block(meta)
+        assert "#source=lens-v1.9" in block
+
+    def test_format_parse_roundtrip(self):
+        meta = Metadata(
+            topiary_version="4.11.0",
+            form="wide",
+            models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
+            filter_by="affinity <= 500 | presentation.rank <= 2",
+            sort_by="presentation.score",
+            extra={"source": "lens-v1.9"},
+        )
+        block = _format_comment_block(meta)
+        lines = [line + "\n" for line in block.split("\n")] + ["data\n"]
+        parsed, _ = _parse_comment_block(lines)
+        assert parsed.topiary_version == meta.topiary_version
+        assert parsed.form == meta.form
+        assert dict(parsed.models) == dict(meta.models)
+        assert parsed.filter_by == meta.filter_by
+        assert parsed.sort_by == meta.sort_by
+        assert dict(parsed.extra) == dict(meta.extra)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _sample_long_df():
+    return pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_affinity", score=0.85, value=120.0,
+            percentile_rank=0.5, affinity=120.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+        dict(
+            peptide="ELAGIGILT", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=10, peptide_length=9,
+            kind="pMHC_affinity", score=0.3, value=5000.0,
+            percentile_rank=15.0, affinity=5000.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Read/write round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadWriteTSV:
+    def test_long_form_roundtrip(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "out.tsv"
+        to_tsv(df, path)
+        df2, meta = read_tsv(path)
+        assert meta.form == "long"
+        assert meta.topiary_version is not None
+        assert meta.models.get("netmhcpan") == "4.1b"
+        assert len(df2) == len(df)
+        assert list(df2["peptide"]) == list(df["peptide"])
+        assert df2.iloc[0]["value"] == pytest.approx(120.0)
+
+    def test_wide_form_roundtrip(self, tmp_path):
+        df = _sample_long_df()
+        wide = to_wide(df)
+        path = tmp_path / "out.wide.tsv"
+        to_tsv(wide, path)
+        df2, meta = read_tsv(path)
+        assert meta.form == "wide"
+        assert "netmhcpan_affinity_value" in df2.columns
+        assert len(df2) == len(wide)
+
+    def test_metadata_preserved(self, tmp_path):
+        df = _sample_long_df()
+        meta = Metadata(
+            filter_by="affinity <= 500",
+            sort_by="presentation.score",
+            extra={"source": "test"},
+        )
+        path = tmp_path / "out.tsv"
+        to_tsv(df, path, metadata=meta)
+        _, meta2 = read_tsv(path)
+        assert meta2.filter_by == "affinity <= 500"
+        assert meta2.sort_by == "presentation.score"
+        assert meta2.extra.get("source") == "test"
+
+    def test_model_versions_auto_extracted(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "out.tsv"
+        to_tsv(df, path)
+        _, meta = read_tsv(path)
+        assert meta.models.get("netmhcpan") == "4.1b"
+
+
+class TestReadWriteCSV:
+    def test_csv_roundtrip(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "out.csv"
+        to_csv(df, path)
+        df2, meta = read_csv(path)
+        assert meta.form == "long"
+        assert len(df2) == len(df)
+        assert df2.iloc[0]["value"] == pytest.approx(120.0)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_file_without_comments(self, tmp_path):
+        path = tmp_path / "plain.tsv"
+        df = pd.DataFrame({"peptide": ["SIINFEKL"], "allele": ["A"]})
+        df.to_csv(path, sep="\t", index=False)
+        df2, meta = read_tsv(path)
+        assert meta.topiary_version is None
+        assert meta.models == {}
+        assert len(df2) == 1
+
+    def test_empty_df_roundtrip(self, tmp_path):
+        df = pd.DataFrame(columns=["peptide", "allele", "kind"])
+        path = tmp_path / "empty.tsv"
+        to_tsv(df, path)
+        df2, meta = read_tsv(path)
+        assert len(df2) == 0
+        assert meta.form == "long"
+
+    def test_header_only_file(self, tmp_path):
+        path = tmp_path / "header_only.tsv"
+        with open(path, "w") as f:
+            f.write("#topiary_version=4.11.0\n")
+            f.write("#form=long\n")
+            f.write("peptide\tallele\tkind\n")
+        df, meta = read_tsv(path)
+        assert len(df) == 0
+        assert meta.topiary_version == "4.11.0"
+
+    def test_all_metadata_fields(self, tmp_path):
+        meta = Metadata(
+            topiary_version="4.11.0",
+            form="wide",
+            models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
+            filter_by="affinity <= 500 | presentation.rank <= 2",
+            sort_by="presentation.score",
+            extra={"source": "lens-v1.9", "patient": "PT01"},
+        )
+        df = pd.DataFrame({"peptide": ["A"], "netmhcpan_affinity_value": [100]})
+        path = tmp_path / "full.tsv"
+        to_tsv(df, path, metadata=meta)
+        _, meta2 = read_tsv(path)
+        assert meta2.topiary_version == "4.11.0"
+        assert meta2.form == "wide"
+        assert meta2.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
+        assert meta2.filter_by == "affinity <= 500 | presentation.rank <= 2"
+        assert meta2.sort_by == "presentation.score"
+        assert meta2.extra == {"source": "lens-v1.9", "patient": "PT01"}
+
+    def test_pandas_read_csv_with_comment_hash(self, tmp_path):
+        """Standard pandas can still read our files (losing metadata)."""
+        df = _sample_long_df()
+        path = tmp_path / "compat.tsv"
+        to_tsv(df, path)
+        df2 = pd.read_csv(path, sep="\t", comment="#")
+        assert len(df2) == 2
+        assert "peptide" in df2.columns
+
+    def test_write_index_false_by_default(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "no_idx.tsv"
+        to_tsv(df, path)
+        with open(path) as f:
+            lines = f.readlines()
+        # First non-comment line is the header; should not start with ","
+        for line in lines:
+            if not line.startswith("#"):
+                assert not line.startswith(",")
+                assert not line.startswith("\t,")
+                break

--- a/tests/test_wide.py
+++ b/tests/test_wide.py
@@ -1,0 +1,429 @@
+"""Tests for topiary.wide — wide/long DataFrame conversion."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary.wide import (
+    PREDICTION_COLUMNS,
+    _parse_wide_column,
+    detect_form,
+    from_wide,
+    to_wide,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _long_df_single_model():
+    """Single model, single kind (affinity)."""
+    return pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1", n_flank="MAA", c_flank="GGG",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_affinity", score=0.85, value=120.0,
+            percentile_rank=0.5, affinity=120.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+        dict(
+            peptide="ELAGIGILT", allele="HLA-A*02:01",
+            source_sequence_name="prot1", n_flank="", c_flank="",
+            peptide_offset=10, peptide_length=9,
+            kind="pMHC_affinity", score=0.3, value=5000.0,
+            percentile_rank=15.0, affinity=5000.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+    ])
+
+
+def _long_df_multi_kind():
+    """Single model, two kinds (affinity + presentation)."""
+    return pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_affinity", score=0.85, value=120.0,
+            percentile_rank=0.5, affinity=120.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_presentation", score=0.92, value=0.95,
+            percentile_rank=0.3, affinity=np.nan,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+    ])
+
+
+def _long_df_multi_model():
+    """Two models, affinity kind."""
+    return pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_affinity", score=0.85, value=120.0,
+            percentile_rank=0.5, affinity=120.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            peptide_offset=3, peptide_length=8,
+            kind="pMHC_affinity", score=0.9, value=85.0,
+            percentile_rank=0.3, affinity=85.0,
+            prediction_method_name="mhcflurry", predictor_version="2.1.1",
+        ),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# _parse_wide_column tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseWideColumn:
+    def test_simple_affinity(self):
+        assert _parse_wide_column("netmhcpan_affinity_value") == (
+            "netmhcpan", "affinity", "value"
+        )
+
+    def test_affinity_score(self):
+        assert _parse_wide_column("netmhcpan_affinity_score") == (
+            "netmhcpan", "affinity", "score"
+        )
+
+    def test_affinity_rank(self):
+        assert _parse_wide_column("mhcflurry_affinity_rank") == (
+            "mhcflurry", "affinity", "rank"
+        )
+
+    def test_presentation(self):
+        assert _parse_wide_column("mhcflurry_presentation_score") == (
+            "mhcflurry", "presentation", "score"
+        )
+
+    def test_antigen_processing(self):
+        assert _parse_wide_column("netmhcpan_antigen_processing_score") == (
+            "netmhcpan", "antigen_processing", "score"
+        )
+
+    def test_proteasome_cleavage(self):
+        assert _parse_wide_column("tool_proteasome_cleavage_rank") == (
+            "tool", "proteasome_cleavage", "rank"
+        )
+
+    def test_tap_transport(self):
+        assert _parse_wide_column("mhcflurry_tap_transport_value") == (
+            "mhcflurry", "tap_transport", "value"
+        )
+
+    def test_erap_trimming(self):
+        assert _parse_wide_column("mhcflurry_erap_trimming_score") == (
+            "mhcflurry", "erap_trimming", "score"
+        )
+
+    def test_immunogenicity(self):
+        assert _parse_wide_column("custom_immunogenicity_value") == (
+            "custom", "immunogenicity", "value"
+        )
+
+    def test_stability(self):
+        assert _parse_wide_column("netmhcstabpan_stability_value") == (
+            "netmhcstabpan", "stability", "value"
+        )
+
+    def test_model_with_underscores(self):
+        assert _parse_wide_column("net_mhc_pan_affinity_value") == (
+            "net_mhc_pan", "affinity", "value"
+        )
+
+    def test_versioned_model(self):
+        assert _parse_wide_column("netmhcpan_4.1b_affinity_value") == (
+            "netmhcpan_4.1b", "affinity", "value"
+        )
+
+    def test_not_a_prediction_col(self):
+        assert _parse_wide_column("gene_expression") is None
+
+    def test_peptide(self):
+        assert _parse_wide_column("peptide") is None
+
+    def test_allele(self):
+        assert _parse_wide_column("allele") is None
+
+    def test_unknown_kind(self):
+        assert _parse_wide_column("tool_bogus_kind_value") is None
+
+    def test_unknown_field(self):
+        assert _parse_wide_column("netmhcpan_affinity_median") is None
+
+    def test_empty_string(self):
+        assert _parse_wide_column("") is None
+
+    def test_single_word(self):
+        assert _parse_wide_column("affinity") is None
+
+
+# ---------------------------------------------------------------------------
+# detect_form tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectForm:
+    def test_long(self):
+        df = pd.DataFrame({"peptide": ["A"], "kind": ["pMHC_affinity"]})
+        assert detect_form(df) == "long"
+
+    def test_wide(self):
+        df = pd.DataFrame({
+            "peptide": ["A"],
+            "netmhcpan_affinity_value": [100.0],
+        })
+        assert detect_form(df) == "wide"
+
+    def test_unknown(self):
+        df = pd.DataFrame({"peptide": ["A"], "gene_name": ["BRAF"]})
+        assert detect_form(df) == "unknown"
+
+    def test_empty_long(self):
+        df = pd.DataFrame(columns=["peptide", "kind"])
+        assert detect_form(df) == "long"
+
+    def test_empty_wide(self):
+        df = pd.DataFrame(columns=["peptide", "mhcflurry_presentation_score"])
+        assert detect_form(df) == "wide"
+
+
+# ---------------------------------------------------------------------------
+# to_wide tests
+# ---------------------------------------------------------------------------
+
+
+class TestToWide:
+    def test_single_model_single_kind(self):
+        df = _long_df_single_model()
+        wide = to_wide(df)
+        assert "netmhcpan_affinity_value" in wide.columns
+        assert "netmhcpan_affinity_score" in wide.columns
+        assert "netmhcpan_affinity_rank" in wide.columns
+        assert "kind" not in wide.columns
+        assert "affinity" not in wide.columns
+        assert len(wide) == 2
+
+    def test_single_model_multi_kind(self):
+        df = _long_df_multi_kind()
+        wide = to_wide(df)
+        assert "netmhcpan_affinity_value" in wide.columns
+        assert "netmhcpan_presentation_value" in wide.columns
+        assert "netmhcpan_presentation_score" in wide.columns
+        # One row for the single peptide-allele group
+        assert len(wide) == 1
+
+    def test_multi_model(self):
+        df = _long_df_multi_model()
+        wide = to_wide(df)
+        assert "netmhcpan_affinity_value" in wide.columns
+        assert "mhcflurry_affinity_value" in wide.columns
+        assert len(wide) == 1
+
+    def test_multi_model_values_correct(self):
+        df = _long_df_multi_model()
+        wide = to_wide(df)
+        row = wide.iloc[0]
+        assert row["netmhcpan_affinity_value"] == 120.0
+        assert row["mhcflurry_affinity_value"] == 85.0
+
+    def test_multi_underscore_kind(self):
+        df = pd.DataFrame([dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            kind="antigen_processing", score=0.7, value=0.8,
+            percentile_rank=1.5,
+            prediction_method_name="mhcflurry", predictor_version="2.1.1",
+        )])
+        wide = to_wide(df)
+        assert "mhcflurry_antigen_processing_value" in wide.columns
+        assert "mhcflurry_antigen_processing_score" in wide.columns
+
+    def test_version_collision_warns(self):
+        df = pd.DataFrame([
+            dict(
+                peptide="SIINFEKL", allele="HLA-A*02:01",
+                kind="pMHC_affinity", score=0.8, value=120.0,
+                percentile_rank=0.5,
+                prediction_method_name="netmhcpan", predictor_version="4.1b",
+            ),
+            dict(
+                peptide="SIINFEKL", allele="HLA-A*02:01",
+                kind="pMHC_affinity", score=0.7, value=200.0,
+                percentile_rank=1.0,
+                prediction_method_name="netmhcpan", predictor_version="4.2",
+            ),
+        ])
+        with pytest.warns(UserWarning, match="Multiple predictor versions"):
+            wide = to_wide(df)
+        # Both versioned columns should exist
+        assert "netmhcpan_4.1b_affinity_value" in wide.columns
+        assert "netmhcpan_4.2_affinity_value" in wide.columns
+
+    def test_empty_df(self):
+        df = pd.DataFrame(columns=[
+            "peptide", "allele", "kind", "score", "value",
+            "percentile_rank", "prediction_method_name", "predictor_version",
+            "affinity",
+        ])
+        wide = to_wide(df)
+        assert len(wide) == 0
+        assert "peptide" in wide.columns
+
+    def test_affinity_column_dropped(self):
+        df = _long_df_single_model()
+        wide = to_wide(df)
+        assert "affinity" not in wide.columns
+
+    def test_extra_columns_preserved(self):
+        df = _long_df_single_model()
+        df["gene"] = "BRAF"
+        df["gene_tpm"] = 42.5
+        wide = to_wide(df)
+        assert "gene" in wide.columns
+        assert "gene_tpm" in wide.columns
+        assert wide.iloc[0]["gene"] == "BRAF"
+
+    def test_missing_kind_raises(self):
+        df = pd.DataFrame({"peptide": ["A"], "score": [0.5]})
+        with pytest.raises(ValueError, match="missing 'kind' column"):
+            to_wide(df)
+
+    def test_model_versions_in_attrs(self):
+        df = _long_df_multi_model()
+        wide = to_wide(df)
+        models = wide.attrs.get("topiary_models", {})
+        assert models.get("netmhcpan") == "4.1b"
+        assert models.get("mhcflurry") == "2.1.1"
+
+    def test_flanks_preserved(self):
+        df = _long_df_single_model()
+        wide = to_wide(df)
+        assert "n_flank" in wide.columns
+        assert "c_flank" in wide.columns
+        maa_rows = wide[wide["n_flank"] == "MAA"]
+        assert len(maa_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# from_wide tests
+# ---------------------------------------------------------------------------
+
+
+class TestFromWide:
+    def test_roundtrip_single_model(self):
+        orig = _long_df_single_model()
+        wide = to_wide(orig)
+        long = from_wide(wide)
+        assert "kind" in long.columns
+        assert "prediction_method_name" in long.columns
+        assert set(long["kind"].unique()) == {"pMHC_affinity"}
+        assert len(long) == 2
+        # Values round-trip correctly.
+        vals = sorted(long["value"].tolist())
+        assert vals == sorted(orig["value"].tolist())
+
+    def test_roundtrip_multi_kind(self):
+        orig = _long_df_multi_kind()
+        wide = to_wide(orig)
+        long = from_wide(wide)
+        assert set(long["kind"].unique()) == {"pMHC_affinity", "pMHC_presentation"}
+        # One peptide × 2 kinds = 2 rows.
+        assert len(long) == 2
+
+    def test_roundtrip_multi_model(self):
+        orig = _long_df_multi_model()
+        wide = to_wide(orig)
+        long = from_wide(wide)
+        assert set(long["prediction_method_name"].unique()) == {
+            "netmhcpan", "mhcflurry"
+        }
+        assert len(long) == 2
+
+    def test_affinity_reconstructed(self):
+        orig = _long_df_multi_kind()
+        wide = to_wide(orig)
+        long = from_wide(wide)
+        aff_rows = long[long["kind"] == "pMHC_affinity"]
+        non_aff_rows = long[long["kind"] != "pMHC_affinity"]
+        assert not aff_rows["affinity"].isna().any()
+        assert non_aff_rows["affinity"].isna().all()
+
+    def test_unknown_columns_preserved(self):
+        wide = pd.DataFrame({
+            "peptide": ["SIINFEKL"],
+            "allele": ["HLA-A*02:01"],
+            "gene_name": ["BRAF"],
+            "netmhcpan_affinity_value": [120.0],
+            "netmhcpan_affinity_score": [0.85],
+        })
+        long = from_wide(wide)
+        assert "gene_name" in long.columns
+        assert long.iloc[0]["gene_name"] == "BRAF"
+
+    def test_missing_field_becomes_nan(self):
+        wide = pd.DataFrame({
+            "peptide": ["SIINFEKL"],
+            "allele": ["HLA-A*02:01"],
+            "netmhcpan_affinity_value": [120.0],
+            "netmhcpan_affinity_score": [0.85],
+            # No netmhcpan_affinity_rank column
+        })
+        long = from_wide(wide)
+        assert "percentile_rank" in long.columns
+        assert pd.isna(long.iloc[0]["percentile_rank"])
+
+    def test_empty_wide_df(self):
+        wide = pd.DataFrame(columns=[
+            "peptide", "allele", "netmhcpan_affinity_value",
+        ])
+        long = from_wide(wide)
+        assert "kind" in long.columns
+        assert len(long) == 0
+
+    def test_with_metadata_versions(self):
+        from topiary.io import Metadata
+        wide = pd.DataFrame({
+            "peptide": ["SIINFEKL"],
+            "allele": ["HLA-A*02:01"],
+            "netmhcpan_affinity_value": [120.0],
+            "netmhcpan_affinity_score": [0.85],
+        })
+        meta = Metadata(models={"netmhcpan": "4.1b"})
+        long = from_wide(wide, metadata=meta)
+        assert long.iloc[0]["predictor_version"] == "4.1b"
+
+    def test_multi_underscore_kind(self):
+        wide = pd.DataFrame({
+            "peptide": ["SIINFEKL"],
+            "allele": ["HLA-A*02:01"],
+            "mhcflurry_antigen_processing_score": [0.7],
+            "mhcflurry_antigen_processing_value": [0.8],
+        })
+        long = from_wide(wide)
+        assert long.iloc[0]["kind"] == "antigen_processing"
+        assert long.iloc[0]["prediction_method_name"] == "mhcflurry"
+
+    def test_no_prediction_columns(self):
+        """Wide df with no prediction columns returns input + empty long cols."""
+        wide = pd.DataFrame({
+            "peptide": ["SIINFEKL"],
+            "allele": ["HLA-A*02:01"],
+            "gene_name": ["BRAF"],
+        })
+        long = from_wide(wide)
+        assert "kind" in long.columns
+        assert len(long) == 1

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -34,8 +34,10 @@ from .sequence_helpers import (
     contains_mutant_residues,
     protein_subsequences_around_mutations,
 )
+from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
+from .wide import detect_form, from_wide, to_wide
 
-__version__ = "4.10.0"
+__version__ = "4.11.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -64,4 +66,12 @@ __all__ = [
     "check_padding_around_mutation",
     "peptide_mutation_interval",
     "protein_subsequences_around_mutations",
+    "Metadata",
+    "read_csv",
+    "read_tsv",
+    "to_csv",
+    "to_tsv",
+    "detect_form",
+    "from_wide",
+    "to_wide",
 ]

--- a/topiary/io.py
+++ b/topiary/io.py
@@ -8,8 +8,6 @@ A topiary TSV/CSV file may begin with ``#key=value`` comment lines::
     #form=long
     #model:netmhcpan=4.1b
     #model:mhcflurry=2.1.1
-    #filter_by=affinity <= 500
-    #sort_by=presentation.score
     peptide\\tallele\\tkind\\t...
 
 Standard tools (``pd.read_csv(comment="#")``) skip these lines and read
@@ -148,8 +146,12 @@ def _write_delimited(df, path, sep, metadata, index):
             .first()
             .items()
         ):
-            if pd.notna(version) and str(version):
-                metadata.models[str(method).lower()] = str(version)
+            version_str = str(version).strip() if pd.notna(version) else ""
+            if version_str:
+                metadata.models[str(method)] = version_str
+            else:
+                # Record model even without version
+                metadata.models[str(method)] = ""
 
     comment_block = _format_comment_block(metadata)
 

--- a/topiary/io.py
+++ b/topiary/io.py
@@ -65,6 +65,18 @@ def _parse_comment_block(lines):
         else:
             meta.extra[key] = value
 
+    # Also parse bare #model:name lines (no =, version-less).
+    # These were skipped by the "=" check above, so re-scan.
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            break
+        content = stripped[1:]
+        if "=" not in content and content.startswith("model:"):
+            model_name = content[len("model:"):]
+            if model_name and model_name not in meta.models:
+                meta.models[model_name] = ""
+
     return meta, n
 
 
@@ -76,7 +88,10 @@ def _format_comment_block(meta):
     if meta.form:
         lines.append(f"#form={meta.form}")
     for model_name, version in meta.models.items():
-        lines.append(f"#model:{model_name}={version}")
+        if version:
+            lines.append(f"#model:{model_name}={version}")
+        else:
+            lines.append(f"#model:{model_name}")
     for key, value in meta.extra.items():
         lines.append(f"#{key}={value}")
     return "\n".join(lines)

--- a/topiary/io.py
+++ b/topiary/io.py
@@ -32,8 +32,6 @@ class Metadata:
     topiary_version: str = None
     form: str = None
     models: dict = dataclass_field(default_factory=OrderedDict)
-    filter_by: str = None
-    sort_by: str = None
     extra: dict = dataclass_field(default_factory=OrderedDict)
 
 
@@ -63,10 +61,6 @@ def _parse_comment_block(lines):
             meta.topiary_version = value
         elif key == "form":
             meta.form = value
-        elif key == "filter_by":
-            meta.filter_by = value
-        elif key == "sort_by":
-            meta.sort_by = value
         elif key.startswith("model:"):
             model_name = key[len("model:"):]
             meta.models[model_name] = value
@@ -85,10 +79,6 @@ def _format_comment_block(meta):
         lines.append(f"#form={meta.form}")
     for model_name, version in meta.models.items():
         lines.append(f"#model:{model_name}={version}")
-    if meta.filter_by:
-        lines.append(f"#filter_by={meta.filter_by}")
-    if meta.sort_by:
-        lines.append(f"#sort_by={meta.sort_by}")
     for key, value in meta.extra.items():
         lines.append(f"#{key}={value}")
     return "\n".join(lines)

--- a/topiary/io.py
+++ b/topiary/io.py
@@ -1,0 +1,179 @@
+"""Read and write Topiary DataFrames with comment-block metadata.
+
+File format
+-----------
+A topiary TSV/CSV file may begin with ``#key=value`` comment lines::
+
+    #topiary_version=4.11.0
+    #form=long
+    #model:netmhcpan=4.1b
+    #model:mhcflurry=2.1.1
+    #filter_by=affinity <= 500
+    #sort_by=presentation.score
+    peptide\\tallele\\tkind\\t...
+
+Standard tools (``pd.read_csv(comment="#")``) skip these lines and read
+the data normally.  Topiary's ``read_tsv`` / ``read_csv`` additionally
+parse the comment block into a :class:`Metadata` object.
+"""
+
+from collections import OrderedDict
+from dataclasses import dataclass, field as dataclass_field
+from io import StringIO
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class Metadata:
+    """Comment-block metadata for a topiary file."""
+
+    topiary_version: str = None
+    form: str = None
+    models: dict = dataclass_field(default_factory=OrderedDict)
+    filter_by: str = None
+    sort_by: str = None
+    extra: dict = dataclass_field(default_factory=OrderedDict)
+
+
+# -- Comment block parsing / formatting ------------------------------------
+
+
+def _parse_comment_block(lines):
+    """Parse ``#key=value`` lines into a Metadata object.
+
+    Returns (Metadata, n_comment_lines).
+    """
+    meta = Metadata()
+    n = 0
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            break
+        n += 1
+        content = stripped[1:]
+        if "=" not in content:
+            continue
+        key, _, value = content.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        if key == "topiary_version":
+            meta.topiary_version = value
+        elif key == "form":
+            meta.form = value
+        elif key == "filter_by":
+            meta.filter_by = value
+        elif key == "sort_by":
+            meta.sort_by = value
+        elif key.startswith("model:"):
+            model_name = key[len("model:"):]
+            meta.models[model_name] = value
+        else:
+            meta.extra[key] = value
+
+    return meta, n
+
+
+def _format_comment_block(meta):
+    """Format a Metadata object as ``#key=value`` lines."""
+    lines = []
+    if meta.topiary_version:
+        lines.append(f"#topiary_version={meta.topiary_version}")
+    if meta.form:
+        lines.append(f"#form={meta.form}")
+    for model_name, version in meta.models.items():
+        lines.append(f"#model:{model_name}={version}")
+    if meta.filter_by:
+        lines.append(f"#filter_by={meta.filter_by}")
+    if meta.sort_by:
+        lines.append(f"#sort_by={meta.sort_by}")
+    for key, value in meta.extra.items():
+        lines.append(f"#{key}={value}")
+    return "\n".join(lines)
+
+
+# -- Read ------------------------------------------------------------------
+
+
+def _read_delimited(path, sep):
+    path = Path(path)
+    with open(path) as f:
+        all_lines = f.readlines()
+
+    meta, n_comment = _parse_comment_block(all_lines)
+
+    data_text = "".join(all_lines[n_comment:])
+    if not data_text.strip():
+        return pd.DataFrame(), meta
+
+    df = pd.read_csv(StringIO(data_text), sep=sep)
+    return df, meta
+
+
+def read_tsv(path):
+    """Read a topiary TSV file with comment-block metadata.
+
+    Returns (DataFrame, Metadata).
+    """
+    return _read_delimited(path, sep="\t")
+
+
+def read_csv(path):
+    """Read a topiary CSV file with comment-block metadata.
+
+    Returns (DataFrame, Metadata).
+    """
+    return _read_delimited(path, sep=",")
+
+
+# -- Write -----------------------------------------------------------------
+
+
+def _write_delimited(df, path, sep, metadata, index):
+    from . import __version__
+    from .wide import detect_form
+
+    path = Path(path)
+
+    if metadata is None:
+        metadata = Metadata()
+
+    if not metadata.topiary_version:
+        metadata.topiary_version = __version__
+
+    if not metadata.form:
+        metadata.form = detect_form(df)
+
+    # Auto-extract model versions from long-form data.
+    if (
+        not metadata.models
+        and "prediction_method_name" in df.columns
+        and "predictor_version" in df.columns
+    ):
+        for method, version in (
+            df.dropna(subset=["prediction_method_name"])
+            .groupby("prediction_method_name")["predictor_version"]
+            .first()
+            .items()
+        ):
+            if pd.notna(version) and str(version):
+                metadata.models[str(method).lower()] = str(version)
+
+    comment_block = _format_comment_block(metadata)
+
+    with open(path, "w") as f:
+        if comment_block:
+            f.write(comment_block + "\n")
+        df.to_csv(f, sep=sep, index=index)
+
+
+def to_tsv(df, path, metadata=None, index=False):
+    """Write a topiary DataFrame to TSV with comment-block metadata."""
+    _write_delimited(df, path, sep="\t", metadata=metadata, index=index)
+
+
+def to_csv(df, path, metadata=None, index=False):
+    """Write a topiary DataFrame to CSV with comment-block metadata."""
+    _write_delimited(df, path, sep=",", metadata=metadata, index=index)

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -44,6 +44,33 @@ _JOIN_COLUMNS = {
 }
 
 
+def _resolve_model_name(name):
+    """Resolve a string model name to an mhctools predictor class.
+
+    Supports case-insensitive matching against mhctools class names,
+    e.g. ``"netmhcpan41"`` → ``NetMHCpan41``, ``"mhcflurry"`` → ``MHCflurry``.
+    """
+    import inspect
+    import mhctools
+
+    lookup = {}
+    for attr_name, obj in inspect.getmembers(mhctools):
+        if inspect.isclass(obj) and hasattr(obj, "predict_peptides_dataframe"):
+            lookup[attr_name.lower()] = obj
+
+    key = name.lower().replace("-", "").replace("_", "").replace(" ", "")
+    cls = lookup.get(key)
+    if cls is None:
+        # Try with underscores/hyphens preserved
+        cls = lookup.get(name.lower())
+    if cls is None:
+        available = sorted(lookup.keys())
+        raise ValueError(
+            f"Unknown model name {name!r}. Available: {available}"
+        )
+    return cls
+
+
 def _transcript_expression_dict_from_data(expression_data):
     """Extract a transcript_id -> expression dict from new-style expression data.
 
@@ -215,6 +242,9 @@ class TopiaryPredictor(object):
 
         self.models = []
         for m in raw_models:
+            if isinstance(m, str):
+                # String name — look up in mhctools
+                m = _resolve_model_name(m)
             if isinstance(m, type):
                 # It's a class — instantiate with alleles
                 if alleles is None:

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -44,12 +44,8 @@ _JOIN_COLUMNS = {
 }
 
 
-def _resolve_model_name(name):
-    """Resolve a string model name to an mhctools predictor class.
-
-    Supports case-insensitive matching against mhctools class names,
-    e.g. ``"netmhcpan41"`` → ``NetMHCpan41``, ``"mhcflurry"`` → ``MHCflurry``.
-    """
+def _build_model_lookup():
+    """Build a lowercase name → mhctools predictor class mapping."""
     import inspect
     import mhctools
 
@@ -57,14 +53,28 @@ def _resolve_model_name(name):
     for attr_name, obj in inspect.getmembers(mhctools):
         if inspect.isclass(obj) and hasattr(obj, "predict_peptides_dataframe"):
             lookup[attr_name.lower()] = obj
+    return lookup
+
+
+_MODEL_LOOKUP = None
+
+
+def _resolve_model_name(name):
+    """Resolve a string model name to an mhctools predictor class.
+
+    Supports case-insensitive matching against mhctools class names,
+    e.g. ``"netmhcpan41"`` → ``NetMHCpan41``, ``"mhcflurry"`` → ``MHCflurry``.
+    """
+    global _MODEL_LOOKUP
+    if _MODEL_LOOKUP is None:
+        _MODEL_LOOKUP = _build_model_lookup()
 
     key = name.lower().replace("-", "").replace("_", "").replace(" ", "")
-    cls = lookup.get(key)
+    cls = _MODEL_LOOKUP.get(key)
     if cls is None:
-        # Try with underscores/hyphens preserved
-        cls = lookup.get(name.lower())
+        cls = _MODEL_LOOKUP.get(name.lower())
     if cls is None:
-        available = sorted(lookup.keys())
+        available = sorted(_MODEL_LOOKUP.keys())
         raise ValueError(
             f"Unknown model name {name!r}. Available: {available}"
         )

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -147,9 +147,7 @@ def to_wide(df):
     else:
         work["_model_key"] = model_col
 
-    work["_kind_short"] = work["kind"].apply(
-        lambda k: _kind_short_name(k) if hasattr(k, "name") or isinstance(k, str) else str(k)
-    )
+    work["_kind_short"] = work["kind"].apply(_kind_short_name)
 
     # Build model→version metadata for .attrs.
     model_versions = {}
@@ -179,6 +177,17 @@ def to_wide(df):
         return work[group_cols].drop_duplicates().reset_index(drop=True)
 
     melted = pd.concat(records, ignore_index=True)
+
+    # Check for duplicates that would silently collapse in the pivot.
+    dup_check = melted.groupby(group_cols + ["_wide_col"]).size()
+    n_dupes = (dup_check > 1).sum()
+    if n_dupes > 0:
+        warnings.warn(
+            f"{n_dupes} duplicate (group, model, kind) entries found; "
+            "keeping first value",
+            UserWarning,
+            stacklevel=2,
+        )
 
     # Pivot: group keys as index, wide column names as columns.
     wide = melted.pivot_table(
@@ -270,9 +279,7 @@ def from_wide(df, metadata=None):
     result = pd.concat(long_rows, ignore_index=True)
 
     # Reconstruct the affinity convenience column.
-    is_affinity = result["kind"].apply(
-        lambda k: _kind_name(k) if hasattr(k, "name") else str(k)
-    ) == "pMHC_affinity"
+    is_affinity = result["kind"].apply(_kind_name) == "pMHC_affinity"
     result["affinity"] = np.where(is_affinity, result["value"], np.nan)
 
     return result

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -5,6 +5,7 @@ Wide form: one row per (peptide, allele, source), prediction columns become
 ``{model}_{kind}_{field}`` (e.g. ``netmhcpan_affinity_value``).
 """
 
+import functools
 import warnings
 
 import numpy as np
@@ -32,12 +33,13 @@ LONG_TO_WIDE_FIELD = {
 WIDE_TO_LONG_FIELD = {v: k for k, v in LONG_TO_WIDE_FIELD.items()}
 
 
+@functools.lru_cache(maxsize=1)
 def _known_kind_short_names():
     """Return known kind short names sorted longest-first (for suffix matching)."""
     names = set()
     for kind in _iter_known_kinds():
         names.add(_kind_short_name(kind))
-    return sorted(names, key=len, reverse=True)
+    return tuple(sorted(names, key=len, reverse=True))
 
 
 def _kind_short_to_canonical(short_name):
@@ -179,7 +181,10 @@ def to_wide(df):
     melted = pd.concat(records, ignore_index=True)
 
     # Check for duplicates that would silently collapse in the pivot.
-    dup_check = melted.groupby(group_cols + ["_wide_col"]).size()
+    # Fill NaN with sentinel to avoid pandas groupby NaN-skipping.
+    dup_cols = group_cols + ["_wide_col"]
+    dup_df = melted[dup_cols].fillna("__nan__")
+    dup_check = dup_df.groupby(dup_cols).size()
     n_dupes = (dup_check > 1).sum()
     if n_dupes > 0:
         warnings.warn(

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -1,0 +1,278 @@
+"""Wide/long DataFrame conversion for Topiary prediction DataFrames.
+
+Long form: one row per (peptide, allele, model, kind).
+Wide form: one row per (peptide, allele, source), prediction columns become
+``{model}_{kind}_{field}`` (e.g. ``netmhcpan_affinity_value``).
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from .ranking import _iter_known_kinds, _kind_name, _kind_short_name, _KIND_ALIASES
+
+# Columns that are prediction-specific and get pivoted in wide form.
+PREDICTION_COLUMNS = frozenset({
+    "kind", "score", "value", "percentile_rank",
+    "prediction_method_name", "predictor_version", "affinity",
+})
+
+# Wide-form field suffixes.
+WIDE_FIELDS = frozenset({"value", "score", "rank"})
+
+# Long column name → wide field suffix.
+LONG_TO_WIDE_FIELD = {
+    "value": "value",
+    "score": "score",
+    "percentile_rank": "rank",
+}
+
+# Wide field suffix → long column name.
+WIDE_TO_LONG_FIELD = {v: k for k, v in LONG_TO_WIDE_FIELD.items()}
+
+
+def _known_kind_short_names():
+    """Return known kind short names sorted longest-first (for suffix matching)."""
+    names = set()
+    for kind in _iter_known_kinds():
+        names.add(_kind_short_name(kind))
+    return sorted(names, key=len, reverse=True)
+
+
+def _kind_short_to_canonical(short_name):
+    """Map a short kind name back to the canonical mhctools kind name string."""
+    kind = _KIND_ALIASES.get(short_name)
+    if kind is None:
+        return short_name
+    return _kind_name(kind)
+
+
+def _parse_wide_column(col_name):
+    """Parse a wide-form column name into (model_key, kind_short, field).
+
+    Returns None if the column does not match the ``{model}_{kind}_{field}``
+    pattern where kind is a known prediction kind and field is one of
+    value/score/rank.
+    """
+    # Split off the rightmost segment as field candidate.
+    parts = col_name.rsplit("_", 1)
+    if len(parts) != 2:
+        return None
+    prefix, field = parts
+    if field not in WIDE_FIELDS:
+        return None
+
+    # Try matching against known kind short names, longest first, so
+    # multi-underscore kinds like "antigen_processing" match before
+    # shorter kinds.
+    for kind_short in _known_kind_short_names():
+        if prefix == kind_short:
+            # Kind-only column with no model prefix — unusual but valid
+            return (None, kind_short, field)
+        if prefix.endswith("_" + kind_short):
+            model_key = prefix[: -(len(kind_short) + 1)]
+            if model_key:
+                return (model_key, kind_short, field)
+
+    return None
+
+
+def detect_form(df):
+    """Detect whether a DataFrame is in long or wide form.
+
+    Returns ``"long"``, ``"wide"``, or ``"unknown"``.
+    """
+    if "kind" in df.columns:
+        return "long"
+    for col in df.columns:
+        if _parse_wide_column(col) is not None:
+            return "wide"
+    return "unknown"
+
+
+def to_wide(df):
+    """Convert a long-form prediction DataFrame to wide form.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Long-form DataFrame with a ``kind`` column.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Wide-form DataFrame where prediction columns become
+        ``{model}_{kind}_{field}`` columns.
+    """
+    if "kind" not in df.columns:
+        raise ValueError(
+            "DataFrame is not in long form: missing 'kind' column"
+        )
+
+    group_cols = [c for c in df.columns if c not in PREDICTION_COLUMNS]
+
+    if df.empty:
+        return df[group_cols].drop_duplicates().reset_index(drop=True)
+
+    # Determine model keys.  Include version only on collision.
+    version_collision = False
+    if "prediction_method_name" in df.columns and "predictor_version" in df.columns:
+        version_counts = (
+            df.dropna(subset=["prediction_method_name"])
+            .groupby("prediction_method_name")["predictor_version"]
+            .nunique()
+        )
+        if (version_counts > 1).any():
+            version_collision = True
+            colliding = version_counts[version_counts > 1].index.tolist()
+            warnings.warn(
+                f"Multiple predictor versions for {colliding}; "
+                "including version in wide column names",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    work = df.copy()
+
+    # Build model key per row.
+    if "prediction_method_name" in work.columns:
+        model_col = work["prediction_method_name"].fillna("unknown").astype(str)
+    else:
+        model_col = pd.Series("unknown", index=work.index)
+
+    if version_collision and "predictor_version" in work.columns:
+        version_col = work["predictor_version"].fillna("").astype(str)
+        work["_model_key"] = model_col + "_" + version_col
+    else:
+        work["_model_key"] = model_col
+
+    work["_kind_short"] = work["kind"].apply(
+        lambda k: _kind_short_name(k) if hasattr(k, "name") or isinstance(k, str) else str(k)
+    )
+
+    # Build model→version metadata for .attrs.
+    model_versions = {}
+    if "prediction_method_name" in df.columns and "predictor_version" in df.columns:
+        for method, version in (
+            df.dropna(subset=["prediction_method_name"])
+            .groupby("prediction_method_name")["predictor_version"]
+            .first()
+            .items()
+        ):
+            if pd.notna(version) and str(version):
+                model_versions[str(method)] = str(version)
+
+    # Melt each long field into wide column entries.
+    records = []
+    for long_field, wide_field in LONG_TO_WIDE_FIELD.items():
+        if long_field not in work.columns:
+            continue
+        temp = work[group_cols + ["_model_key", "_kind_short", long_field]].copy()
+        temp["_wide_col"] = (
+            temp["_model_key"] + "_" + temp["_kind_short"] + "_" + wide_field
+        )
+        temp = temp.rename(columns={long_field: "_wide_val"})
+        records.append(temp[group_cols + ["_wide_col", "_wide_val"]])
+
+    if not records:
+        return work[group_cols].drop_duplicates().reset_index(drop=True)
+
+    melted = pd.concat(records, ignore_index=True)
+
+    # Pivot: group keys as index, wide column names as columns.
+    wide = melted.pivot_table(
+        index=group_cols,
+        columns="_wide_col",
+        values="_wide_val",
+        aggfunc="first",
+    ).reset_index()
+    wide.columns.name = None
+
+    if model_versions:
+        wide.attrs["topiary_models"] = model_versions
+
+    return wide
+
+
+def from_wide(df, metadata=None):
+    """Convert a wide-form prediction DataFrame back to long form.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Wide-form DataFrame with ``{model}_{kind}_{field}`` columns.
+    metadata : topiary.io.Metadata, optional
+        If provided, model versions are used to populate
+        ``predictor_version``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Long-form DataFrame with ``kind``, ``score``, ``value``,
+        ``percentile_rank``, ``prediction_method_name``, and
+        ``predictor_version`` columns.
+    """
+    # Classify columns.
+    pred_mapping = {}  # (model_key, kind_short) → {field: col_name}
+    group_cols = []
+
+    for col in df.columns:
+        parsed = _parse_wide_column(col)
+        if parsed is not None:
+            model_key, kind_short, field = parsed
+            key = (model_key, kind_short)
+            pred_mapping.setdefault(key, {})[field] = col
+        else:
+            group_cols.append(col)
+
+    if not pred_mapping:
+        # No prediction columns found — return as-is with empty long columns.
+        result = df.copy()
+        for col in ["kind", "score", "value", "percentile_rank",
+                     "prediction_method_name", "predictor_version", "affinity"]:
+            if col not in result.columns:
+                result[col] = np.nan
+        return result
+
+    # Build version lookup from metadata.
+    version_lookup = {}
+    if metadata is not None and hasattr(metadata, "models"):
+        version_lookup = metadata.models or {}
+    # Also check .attrs if available.
+    if not version_lookup and hasattr(df, "attrs"):
+        version_lookup = df.attrs.get("topiary_models", {})
+
+    # For each group-key row, emit one long row per (model, kind).
+    group_df = df[group_cols]
+    long_rows = []
+
+    for mk_kind, field_map in pred_mapping.items():
+        model_key, kind_short = mk_kind
+        canonical_kind = _kind_short_to_canonical(kind_short)
+
+        chunk = group_df.copy()
+        chunk["kind"] = canonical_kind
+        chunk["prediction_method_name"] = model_key
+
+        # Resolve version from metadata.
+        version = version_lookup.get(model_key, np.nan)
+        chunk["predictor_version"] = version
+
+        for wide_field, long_col in WIDE_TO_LONG_FIELD.items():
+            if wide_field in field_map:
+                chunk[long_col] = df[field_map[wide_field]].values
+            else:
+                chunk[long_col] = np.nan
+
+        long_rows.append(chunk)
+
+    result = pd.concat(long_rows, ignore_index=True)
+
+    # Reconstruct the affinity convenience column.
+    is_affinity = result["kind"].apply(
+        lambda k: _kind_name(k) if hasattr(k, "name") else str(k)
+    ) == "pMHC_affinity"
+    result["affinity"] = np.where(is_affinity, result["value"], np.nan)
+
+    return result


### PR DESCRIPTION
## Summary
- New `topiary/wide.py`: `to_wide()`, `from_wide()`, `detect_form()` for converting between long form (one row per peptide-allele-kind) and wide form (prediction kinds as `{model}_{kind}_{field}` columns)
- New `topiary/io.py`: `read_tsv`/`read_csv` and `to_tsv`/`to_csv` with `#key=value` comment headers preserving model versions, filter/sort expressions, and form type
- Handles multi-underscore kind names (antigen_processing, proteasome_cleavage, etc.) via longest-suffix matching
- Standard `pd.read_csv(comment="#")` still works on output files
- Version collision detection: auto-includes version in wide column names when same model has multiple versions
- 67 new tests (713 total), all passing locally

## Test plan
- [x] 67 new tests pass (test_wide.py + test_io.py)
- [x] Full suite passes (713 tests)
- [ ] CI green on Python 3.10, 3.11, 3.12