### PR TITLE
Add TopiaryResult wrapper with provenance tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 4.12.0
+
+**Breaking changes:**
+
+- `topiary.read_tsv` and `topiary.read_csv` now return a `TopiaryResult`
+  instead of an `(DataFrame, Metadata)` tuple. Callers using tuple
+  unpacking must migrate: `df, meta = read_tsv(path)` →
+  `result = read_tsv(path); df, meta = result.df, result.metadata`.
+
+**New features:**
+
+- `TopiaryResult` class bundling a predictions DataFrame with provenance
+  (model versions, source files, form, filter/sort history).  Delegates
+  common DataFrame operations (`len`, `iter`, `columns`, `shape`, `head`,
+  `iterrows`, etc.) so most existing DataFrame-style code continues to
+  work.  Provides `to_wide()`, `to_long()`, `to_tsv()`, `to_csv()`,
+  `filter_by()`, `sort_by()`.
+- `topiary.concat([r1, r2, ...])` merges `TopiaryResult`s, unioning
+  models (warns on version conflicts), concatenating sources, and
+  preserving filter/sort history only if all inputs agree.
+- `read_tsv` / `read_csv` accept a `tag=` kwarg to label the source of
+  the loaded rows; defaults to the filename.  Auto-populates a `source`
+  column on the DataFrame.
+- `Metadata` gains a `sources: list[str]` field; the comment block
+  supports multiple `#source=...` lines.
+
+**Deprecations (to be removed in 5.0 alongside the DSL refactor,
+[#111](https://github.com/openvax/topiary/issues/111)):**
+
+- `EpitopeFilter`, `ColumnFilter`, `ExprFilter`, `RankingStrategy`
+  will be replaced with a unified `Comparison` / `BoolOp` DSL tree.
+  Their `to_expr_string()` and `to_ast_string()` methods, added in
+  this release, are a stopgap for round-tripping filter metadata.
+
 ## 4.9.0
 
 - Require `mhctools>=3.7.0`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Topiary
 
-Topiary predicts, filters, and ranks MHC-presented peptides from any antigen source. It wraps multiple binding predictors (NetMHCpan, MHCflurry, etc.) with a composable filtering and ranking DSL, expression-aware prioritization, and wide/long serialization.
+Topiary predicts, filters, and ranks MHC-presented peptides from any antigen source. It wraps [mhctools](https://github.com/openvax/mhctools) binding predictors (NetMHCpan, MHCflurry, etc.) with a composable filtering and ranking DSL, expression-aware prioritization, and wide/long serialization.
 
 Applications include personalized cancer vaccine design, viral epitope mapping, and characterizing T-cell responses.
 
@@ -17,8 +17,6 @@ Applications include personalized cancer vaccine design, viral epitope mapping, 
 ```bash
 pip install topiary
 ```
-
-Topiary `4.9.0` and later require `mhctools>=3.7.0`.
 
 For variant annotation and gene lookups, download Ensembl reference data:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "topiary"
 requires-python = ">=3.9"
 authors = [{name = "Alex Rubinsteyn"}, {name = "Tavi Nathanson"}]
-description = "Predict cancer epitopes from cancer sequence data"
+description = "Predict, filter, and rank MHC-presented peptides from any antigen source"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -73,8 +73,15 @@ def test_model_name_string_mixed_case():
 
 
 def test_model_name_string_mhcflurry():
-    """MHCflurry class can be resolved by string name."""
-    from topiary.predictor import _resolve_model_name
+    """MHCflurry class can be resolved by string name.
+
+    Skips when mhctools does not expose MHCflurry via getmembers (e.g. CI
+    environments without the mhcflurry package or its model downloads).
+    """
+    from topiary.predictor import _build_model_lookup, _resolve_model_name
+    lookup = _build_model_lookup()
+    if "mhcflurry" not in lookup:
+        pytest.skip("MHCflurry not discoverable in this mhctools install")
     from mhctools import MHCflurry
     cls = _resolve_model_name("mhcflurry")
     assert cls is MHCflurry

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -40,12 +40,22 @@ class TestParseCommentBlock:
         lines = [
             "#topiary_version=4.11.0\n",
             "#custom_key=custom_value\n",
-            "#source=lens-v1.9\n",
+            "#other_key=other_value\n",
             "peptide\n",
         ]
         meta, n = _parse_comment_block(lines)
         assert n == 3
-        assert meta.extra == {"custom_key": "custom_value", "source": "lens-v1.9"}
+        assert meta.extra == {"custom_key": "custom_value", "other_key": "other_value"}
+
+    def test_source_lines(self):
+        lines = [
+            "#source=patient01.tsv\n",
+            "#source=patient02.tsv\n",
+            "peptide\n",
+        ]
+        meta, n = _parse_comment_block(lines)
+        assert n == 2
+        assert meta.sources == ["patient01.tsv", "patient02.tsv"]
 
     def test_no_comments(self):
         lines = ["peptide\tallele\n", "SIINFEKL\tHLA-A*02:01\n"]
@@ -105,16 +115,23 @@ class TestFormatCommentBlock:
         assert block == ""
 
     def test_extra_keys_preserved(self):
-        meta = Metadata(extra={"source": "lens-v1.9"})
+        meta = Metadata(extra={"custom_key": "custom_value"})
         block = _format_comment_block(meta)
-        assert "#source=lens-v1.9" in block
+        assert "#custom_key=custom_value" in block
+
+    def test_sources_formatted(self):
+        meta = Metadata(sources=["patient01.tsv", "patient02.tsv"])
+        block = _format_comment_block(meta)
+        assert "#source=patient01.tsv" in block
+        assert "#source=patient02.tsv" in block
 
     def test_format_parse_roundtrip(self):
         meta = Metadata(
             topiary_version="4.11.0",
             form="wide",
             models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
-            extra={"source": "lens-v1.9"},
+            sources=["lens-v1.9.tsv"],
+            extra={"custom_key": "custom_value"},
         )
         block = _format_comment_block(meta)
         lines = [line + "\n" for line in block.split("\n")] + ["data\n"]
@@ -122,6 +139,7 @@ class TestFormatCommentBlock:
         assert parsed.topiary_version == meta.topiary_version
         assert parsed.form == meta.form
         assert dict(parsed.models) == dict(meta.models)
+        assert parsed.sources == meta.sources
         assert dict(parsed.extra) == dict(meta.extra)
 
 
@@ -161,7 +179,8 @@ class TestReadWriteTSV:
         df = _sample_long_df()
         path = tmp_path / "out.tsv"
         to_tsv(df, path)
-        df2, meta = read_tsv(path)
+        result = read_tsv(path)
+        df2, meta = result.df, result.metadata
         assert meta.form == "long"
         assert meta.topiary_version is not None
         assert meta.models.get("netmhcpan") == "4.1b"
@@ -174,7 +193,8 @@ class TestReadWriteTSV:
         wide = to_wide(df)
         path = tmp_path / "out.wide.tsv"
         to_tsv(wide, path)
-        df2, meta = read_tsv(path)
+        result = read_tsv(path)
+        df2, meta = result.df, result.metadata
         assert meta.form == "wide"
         assert "netmhcpan_affinity_value" in df2.columns
         assert len(df2) == len(wide)
@@ -182,19 +202,20 @@ class TestReadWriteTSV:
     def test_metadata_preserved(self, tmp_path):
         df = _sample_long_df()
         meta = Metadata(
-            extra={"source": "test", "patient": "PT01"},
+            sources=["test_cohort"],
+            extra={"patient": "PT01"},
         )
         path = tmp_path / "out.tsv"
         to_tsv(df, path, metadata=meta)
-        _, meta2 = read_tsv(path)
-        assert meta2.extra.get("source") == "test"
+        meta2 = read_tsv(path).metadata
+        assert "test_cohort" in meta2.sources
         assert meta2.extra.get("patient") == "PT01"
 
     def test_model_versions_auto_extracted(self, tmp_path):
         df = _sample_long_df()
         path = tmp_path / "out.tsv"
         to_tsv(df, path)
-        _, meta = read_tsv(path)
+        meta = read_tsv(path).metadata
         assert meta.models.get("netmhcpan") == "4.1b"
 
 
@@ -203,7 +224,8 @@ class TestReadWriteCSV:
         df = _sample_long_df()
         path = tmp_path / "out.csv"
         to_csv(df, path)
-        df2, meta = read_csv(path)
+        result = read_csv(path)
+        df2, meta = result.df, result.metadata
         assert meta.form == "long"
         assert len(df2) == len(df)
         assert df2.iloc[0]["value"] == pytest.approx(120.0)
@@ -219,7 +241,8 @@ class TestEdgeCases:
         path = tmp_path / "plain.tsv"
         df = pd.DataFrame({"peptide": ["SIINFEKL"], "allele": ["A"]})
         df.to_csv(path, sep="\t", index=False)
-        df2, meta = read_tsv(path)
+        result = read_tsv(path)
+        df2, meta = result.df, result.metadata
         assert meta.topiary_version is None
         assert meta.models == {}
         assert len(df2) == 1
@@ -228,7 +251,8 @@ class TestEdgeCases:
         df = pd.DataFrame(columns=["peptide", "allele", "kind"])
         path = tmp_path / "empty.tsv"
         to_tsv(df, path)
-        df2, meta = read_tsv(path)
+        result = read_tsv(path)
+        df2, meta = result.df, result.metadata
         assert len(df2) == 0
         assert meta.form == "long"
 
@@ -238,7 +262,8 @@ class TestEdgeCases:
             f.write("#topiary_version=4.11.0\n")
             f.write("#form=long\n")
             f.write("peptide\tallele\tkind\n")
-        df, meta = read_tsv(path)
+        result = read_tsv(path)
+        df, meta = result.df, result.metadata
         assert len(df) == 0
         assert meta.topiary_version == "4.11.0"
 
@@ -247,16 +272,20 @@ class TestEdgeCases:
             topiary_version="4.11.0",
             form="wide",
             models={"netmhcpan": "4.1b", "mhcflurry": "2.1.1"},
-            extra={"source": "lens-v1.9", "patient": "PT01"},
+            sources=["lens-v1.9.tsv"],
+            extra={"patient": "PT01"},
         )
         df = pd.DataFrame({"peptide": ["A"], "netmhcpan_affinity_value": [100]})
         path = tmp_path / "full.tsv"
         to_tsv(df, path, metadata=meta)
-        _, meta2 = read_tsv(path)
+        result = read_tsv(path)
+        meta2 = result.metadata
         assert meta2.topiary_version == "4.11.0"
         assert meta2.form == "wide"
         assert meta2.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
-        assert meta2.extra == {"source": "lens-v1.9", "patient": "PT01"}
+        # The read function appends the filename to sources too
+        assert "lens-v1.9.tsv" in meta2.sources
+        assert meta2.extra == {"patient": "PT01"}
 
     def test_pandas_read_csv_with_comment_hash(self, tmp_path):
         """Standard pandas can still read our files (losing metadata)."""
@@ -309,7 +338,8 @@ class TestRoundTripIntegration:
         # Wide → TSV → read back
         path = tmp_path / "roundtrip.wide.tsv"
         to_tsv(wide, path)
-        wide_read, meta = read_tsv(path)
+        read_result = read_tsv(path)
+        wide_read, meta = read_result.df, read_result.metadata
         assert meta.form == "wide"
         assert len(wide_read) == len(wide)
 
@@ -337,7 +367,8 @@ class TestRoundTripIntegration:
         # Long → TSV → read back
         path = tmp_path / "roundtrip.tsv"
         to_tsv(long_orig, path)
-        long_read, meta = read_tsv(path)
+        read_result = read_tsv(path)
+        long_read, meta = read_result.df, read_result.metadata
         assert meta.form == "long"
         assert len(long_read) == len(long_orig)
         assert list(long_read["peptide"]) == list(long_orig["peptide"])
@@ -357,7 +388,8 @@ class TestRoundTripIntegration:
 
         path = tmp_path / "roundtrip.wide.csv"
         to_csv(wide, path)
-        wide_read, meta = read_csv(path)
+        read_result = read_csv(path)
+        wide_read, meta = read_result.df, read_result.metadata
         long_back = from_wide(wide_read, metadata=meta)
 
         assert set(long_back["kind"].unique()) == set(long_orig["kind"].unique())
@@ -413,5 +445,5 @@ class TestRoundTripIntegration:
         df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
         path = tmp_path / "models.tsv"
         to_tsv(df, path)
-        _, meta = read_tsv(path)
+        meta = read_tsv(path).metadata
         assert len(meta.models) > 0

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -323,6 +323,271 @@ class TestConcat:
 
 
 # ---------------------------------------------------------------------------
+# filter_by() method
+# ---------------------------------------------------------------------------
+
+
+def _multi_row_df():
+    """Long-form DataFrame with two peptides × two kinds each."""
+    rows = []
+    for peptide, affinity_val, pres_rank in [
+        ("SIINFEKL",  120.0,  0.3),
+        ("ELAGIGILT", 5000.0, 15.0),
+        ("AAAAAAAA",  300.0,  1.5),
+    ]:
+        for kind, value, score, rank in [
+            ("pMHC_affinity",     affinity_val, 0.8,  0.5),
+            ("pMHC_presentation", 0.9,          0.92, pres_rank),
+        ]:
+            rows.append(dict(
+                peptide=peptide,
+                allele="HLA-A*02:01",
+                source_sequence_name="prot1",
+                peptide_offset=0,
+                kind=kind,
+                score=score,
+                value=value,
+                percentile_rank=rank,
+                affinity=value if kind == "pMHC_affinity" else float("nan"),
+                prediction_method_name="netmhcpan",
+                predictor_version="4.1b",
+            ))
+    return pd.DataFrame(rows)
+
+
+class TestFilterBy:
+    def test_string_filter_reduces_rows(self):
+        r = TopiaryResult(_multi_row_df())
+        n_before = len(r)
+        filtered = r.filter_by("affinity <= 500")
+        assert len(filtered) < n_before
+        assert len(filtered) > 0
+
+    def test_string_filter_records_history(self):
+        r = TopiaryResult(_multi_row_df())
+        filtered = r.filter_by("affinity <= 500")
+        assert filtered.filter_by_str == "affinity <= 500"
+        assert filtered.filter_by_ast is not None
+
+    def test_filter_ands_with_existing(self):
+        r = TopiaryResult(_multi_row_df())
+        r2 = r.filter_by("affinity <= 1000")
+        r3 = r2.filter_by("presentation.rank <= 2")
+        # ANDed — both clauses in metadata
+        assert "affinity <= 1000" in r3.filter_by_str
+        assert "presentation.rank <= 2" in r3.filter_by_str
+        assert "&" in r3.filter_by_str
+
+    def test_dsl_object_filter(self):
+        from topiary import Affinity
+        r = TopiaryResult(_multi_row_df())
+        filtered = r.filter_by(Affinity <= 500)
+        assert len(filtered) < len(r)
+        # AST captured
+        assert filtered.filter_by_ast is not None
+        # String form round-trippable (recognizable DSL syntax)
+        assert "affinity" in filtered.filter_by_str.lower()
+
+    def test_dsl_object_and_string_equivalent(self):
+        from topiary import Affinity
+        df = _multi_row_df()
+        a = TopiaryResult(df).filter_by(Affinity <= 500)
+        b = TopiaryResult(df).filter_by("affinity <= 500")
+        assert len(a) == len(b)
+
+    def test_invalid_type_raises(self):
+        r = TopiaryResult(_multi_row_df())
+        with pytest.raises(TypeError, match="filter_by expects"):
+            r.filter_by(500)
+
+    def test_filter_on_empty_df_is_noop(self):
+        df = pd.DataFrame(columns=_multi_row_df().columns)
+        r = TopiaryResult(df)
+        filtered = r.filter_by("affinity <= 500")
+        assert filtered.empty
+        # History still recorded
+        assert filtered.filter_by_str == "affinity <= 500"
+
+    def test_filter_preserves_other_metadata(self):
+        r = TopiaryResult(
+            _multi_row_df(),
+            models={"netmhcpan": "4.1b"},
+            sources=["patient01"],
+        )
+        filtered = r.filter_by("affinity <= 500")
+        assert filtered.models == {"netmhcpan": "4.1b"}
+        assert filtered.sources == ["patient01"]
+
+    def test_filter_roundtrip_through_tsv(self, tmp_path):
+        r = TopiaryResult(_multi_row_df()).filter_by("affinity <= 500")
+        path = tmp_path / "filtered.tsv"
+        r.to_tsv(path)
+        r_back = read_tsv(path)
+        assert r_back.filter_by_str == r.filter_by_str
+
+    def test_filter_returns_new_result(self):
+        """filter_by must not mutate the original."""
+        r = TopiaryResult(_multi_row_df())
+        n_before = len(r)
+        _ = r.filter_by("affinity <= 500")
+        assert len(r) == n_before
+        assert r.filter_by_str is None
+
+
+# ---------------------------------------------------------------------------
+# sort_by() method
+# ---------------------------------------------------------------------------
+
+
+class TestSortBy:
+    def test_string_sort_reorders(self):
+        r = TopiaryResult(_multi_row_df())
+        sorted_r = r.sort_by("affinity.score")
+        # Can't easily check exact order without knowing DSL semantics,
+        # but the result should have same rows reordered.
+        assert len(sorted_r) == len(r)
+
+    def test_string_sort_records_history(self):
+        r = TopiaryResult(_multi_row_df())
+        sorted_r = r.sort_by("affinity.score")
+        assert sorted_r.sort_by_str == "affinity.score"
+        assert sorted_r.sort_by_ast is not None
+
+    def test_sort_replaces_history(self):
+        r = TopiaryResult(_multi_row_df())
+        r2 = r.sort_by("affinity.score")
+        r3 = r2.sort_by("presentation.score")
+        # sort_by REPLACES, doesn't combine
+        assert r3.sort_by_str == "presentation.score"
+
+    def test_dsl_object_sort(self):
+        from topiary import Presentation
+        r = TopiaryResult(_multi_row_df())
+        sorted_r = r.sort_by(Presentation.score)
+        assert sorted_r.sort_by_str == "presentation.score"
+        assert sorted_r.sort_by_ast is not None
+
+    def test_invalid_type_raises(self):
+        r = TopiaryResult(_multi_row_df())
+        with pytest.raises(TypeError, match="sort_by expects"):
+            r.sort_by(42)
+
+    def test_sort_on_empty_df_is_noop(self):
+        df = pd.DataFrame(columns=_multi_row_df().columns)
+        r = TopiaryResult(df)
+        sorted_r = r.sort_by("affinity.score")
+        assert sorted_r.empty
+        assert sorted_r.sort_by_str == "affinity.score"
+
+    def test_sort_preserves_other_metadata(self):
+        r = TopiaryResult(
+            _multi_row_df(),
+            models={"netmhcpan": "4.1b"},
+            sources=["patient01"],
+            filter_by_str="affinity <= 1000",
+        )
+        sorted_r = r.sort_by("affinity.score")
+        assert sorted_r.models == {"netmhcpan": "4.1b"}
+        assert sorted_r.sources == ["patient01"]
+        assert sorted_r.filter_by_str == "affinity <= 1000"
+
+    def test_sort_roundtrip_through_tsv(self, tmp_path):
+        r = TopiaryResult(_multi_row_df()).sort_by("affinity.score")
+        path = tmp_path / "sorted.tsv"
+        r.to_tsv(path)
+        r_back = read_tsv(path)
+        assert r_back.sort_by_str == r.sort_by_str
+
+    def test_sort_returns_new_result(self):
+        r = TopiaryResult(_multi_row_df())
+        _ = r.sort_by("affinity.score")
+        assert r.sort_by_str is None
+
+
+class TestFilterSortComposition:
+    def test_filter_then_sort(self):
+        r = (
+            TopiaryResult(_multi_row_df())
+            .filter_by("affinity <= 1000")
+            .sort_by("affinity.score")
+        )
+        assert r.filter_by_str == "affinity <= 1000"
+        assert r.sort_by_str == "affinity.score"
+
+    def test_sort_then_filter(self):
+        r = (
+            TopiaryResult(_multi_row_df())
+            .sort_by("affinity.score")
+            .filter_by("affinity <= 1000")
+        )
+        assert r.filter_by_str == "affinity <= 1000"
+        assert r.sort_by_str == "affinity.score"
+
+
+# ---------------------------------------------------------------------------
+# concat warnings for dropped filter/sort history
+# ---------------------------------------------------------------------------
+
+
+class TestConcatHistoryDrop:
+    def _make_r(self, value, source_tag, filter_str=None, sort_str=None):
+        df = pd.DataFrame([dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            kind="pMHC_affinity", score=0.8, value=value,
+            percentile_rank=0.5, affinity=value,
+            prediction_method_name="netmhcpan",
+            predictor_version="4.1b",
+            source=source_tag,
+        )])
+        return TopiaryResult(
+            df,
+            form="long",
+            models={"netmhcpan": "4.1b"},
+            sources=[source_tag],
+            filter_by_str=filter_str,
+            sort_by_str=sort_str,
+        )
+
+    def test_matching_filters_preserved_silently(self, recwarn):
+        r1 = self._make_r(100, "p1", filter_str="affinity <= 500")
+        r2 = self._make_r(200, "p2", filter_str="affinity <= 500")
+        combined = concat([r1, r2])
+        assert combined.filter_by_str == "affinity <= 500"
+        # No warning about filter/sort drop
+        filter_warnings = [w for w in recwarn.list if "Dropping" in str(w.message)]
+        assert not filter_warnings
+
+    def test_differing_filters_warn_and_drop(self):
+        r1 = self._make_r(100, "p1", filter_str="affinity <= 500")
+        r2 = self._make_r(200, "p2", filter_str="affinity <= 1000")
+        with pytest.warns(UserWarning, match="Dropping filter_by metadata"):
+            combined = concat([r1, r2])
+        assert combined.filter_by_str is None
+
+    def test_one_has_filter_one_doesnt_warns(self):
+        r1 = self._make_r(100, "p1", filter_str="affinity <= 500")
+        r2 = self._make_r(200, "p2", filter_str=None)
+        with pytest.warns(UserWarning, match="Dropping filter_by metadata"):
+            combined = concat([r1, r2])
+        assert combined.filter_by_str is None
+
+    def test_differing_sorts_warn_and_drop(self):
+        r1 = self._make_r(100, "p1", sort_str="affinity.score")
+        r2 = self._make_r(200, "p2", sort_str="presentation.score")
+        with pytest.warns(UserWarning, match="Dropping sort_by metadata"):
+            combined = concat([r1, r2])
+        assert combined.sort_by_str is None
+
+    def test_matching_sorts_preserved_silently(self, recwarn):
+        r1 = self._make_r(100, "p1", sort_str="affinity.score")
+        r2 = self._make_r(200, "p2", sort_str="affinity.score")
+        combined = concat([r1, r2])
+        assert combined.sort_by_str == "affinity.score"
+        sort_warnings = [w for w in recwarn.list if "Dropping sort_by" in str(w.message)]
+        assert not sort_warnings
+
+
+# ---------------------------------------------------------------------------
 # Real predictor integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,0 +1,345 @@
+"""Tests for topiary.result — TopiaryResult wrapper and concat()."""
+
+import pandas as pd
+import pytest
+
+from topiary import TopiaryResult, concat, read_tsv, to_tsv
+from topiary.io import Metadata
+
+
+def _sample_long_df():
+    return pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            kind="pMHC_affinity", score=0.85, value=120.0,
+            percentile_rank=0.5, affinity=120.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+        dict(
+            peptide="ELAGIGILT", allele="HLA-A*02:01",
+            source_sequence_name="prot1",
+            kind="pMHC_affinity", score=0.3, value=5000.0,
+            percentile_rank=15.0, affinity=5000.0,
+            prediction_method_name="netmhcpan", predictor_version="4.1b",
+        ),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Construction and properties
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_df_only(self):
+        df = _sample_long_df()
+        r = TopiaryResult(df)
+        assert r.form == "long"
+        assert len(r) == 2
+
+    def test_with_metadata(self):
+        df = _sample_long_df()
+        meta = Metadata(
+            models={"netmhcpan": "4.1b"},
+            sources=["patient01.tsv"],
+        )
+        r = TopiaryResult(df, meta)
+        assert r.models == {"netmhcpan": "4.1b"}
+        assert r.sources == ["patient01.tsv"]
+
+    def test_form_autodetected(self):
+        wide_df = pd.DataFrame({
+            "peptide": ["A"],
+            "netmhcpan_affinity_value": [100.0],
+        })
+        r = TopiaryResult(wide_df)
+        assert r.form == "wide"
+
+    def test_explicit_form_preserved(self):
+        df = _sample_long_df()
+        meta = Metadata(form="long")
+        r = TopiaryResult(df, meta)
+        assert r.form == "long"
+
+
+# ---------------------------------------------------------------------------
+# DataFrame delegation
+# ---------------------------------------------------------------------------
+
+
+class TestDelegation:
+    def test_len(self):
+        r = TopiaryResult(_sample_long_df())
+        assert len(r) == 2
+
+    def test_columns(self):
+        r = TopiaryResult(_sample_long_df())
+        assert "peptide" in r.columns
+
+    def test_getitem_column(self):
+        r = TopiaryResult(_sample_long_df())
+        peptides = r["peptide"]
+        assert list(peptides) == ["SIINFEKL", "ELAGIGILT"]
+
+    def test_getitem_returns_series_for_column(self):
+        r = TopiaryResult(_sample_long_df())
+        assert isinstance(r["peptide"], pd.Series)
+
+    def test_getitem_returns_result_for_multi_column(self):
+        r = TopiaryResult(_sample_long_df())
+        sub = r[["peptide", "allele"]]
+        assert isinstance(sub, TopiaryResult)
+        assert list(sub.columns) == ["peptide", "allele"]
+
+    def test_contains(self):
+        r = TopiaryResult(_sample_long_df())
+        assert "peptide" in r
+        assert "nonexistent" not in r
+
+    def test_iter_yields_columns(self):
+        r = TopiaryResult(_sample_long_df())
+        cols = list(r)
+        assert "peptide" in cols
+
+    def test_shape(self):
+        r = TopiaryResult(_sample_long_df())
+        assert r.shape[0] == 2
+        assert r.shape[1] == len(_sample_long_df().columns)
+
+    def test_empty(self):
+        r = TopiaryResult(pd.DataFrame())
+        assert r.empty
+
+    def test_head(self):
+        r = TopiaryResult(_sample_long_df())
+        top1 = r.head(1)
+        assert isinstance(top1, TopiaryResult)
+        assert len(top1) == 1
+
+    def test_iterrows(self):
+        r = TopiaryResult(_sample_long_df())
+        rows = list(r.iterrows())
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# Form conversion
+# ---------------------------------------------------------------------------
+
+
+class TestFormConversion:
+    def test_to_wide(self):
+        r = TopiaryResult(_sample_long_df())
+        wide = r.to_wide()
+        assert wide.form == "wide"
+        assert "netmhcpan_affinity_value" in wide.columns
+        assert "kind" not in wide.columns
+
+    def test_to_long_from_wide(self):
+        r = TopiaryResult(_sample_long_df())
+        wide = r.to_wide()
+        back = wide.to_long()
+        assert back.form == "long"
+        assert "kind" in back.columns
+
+    def test_form_conversion_preserves_metadata(self):
+        meta = Metadata(
+            models={"netmhcpan": "4.1b"},
+            sources=["patient01.tsv"],
+        )
+        r = TopiaryResult(_sample_long_df(), meta)
+        wide = r.to_wide()
+        assert wide.models == {"netmhcpan": "4.1b"}
+        assert wide.sources == ["patient01.tsv"]
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_to_tsv_from_result(self, tmp_path):
+        r = TopiaryResult(
+            _sample_long_df(),
+            Metadata(
+                models={"netmhcpan": "4.1b"},
+                sources=["test_cohort"],
+            ),
+        )
+        path = tmp_path / "out.tsv"
+        r.to_tsv(path)
+
+        r2 = read_tsv(path)
+        assert r2.form == "long"
+        assert r2.models.get("netmhcpan") == "4.1b"
+        assert "test_cohort" in r2.sources
+
+    def test_to_csv_from_result(self, tmp_path):
+        r = TopiaryResult(_sample_long_df())
+        path = tmp_path / "out.csv"
+        r.to_csv(path)
+        from topiary import read_csv
+        r2 = read_csv(path)
+        assert len(r2) == 2
+
+    def test_to_tsv_accepts_bare_df(self, tmp_path):
+        """Backward compat: to_tsv still works on a bare DataFrame."""
+        df = _sample_long_df()
+        path = tmp_path / "bare.tsv"
+        to_tsv(df, path)
+        r = read_tsv(path)
+        assert len(r) == 2
+
+
+# ---------------------------------------------------------------------------
+# Loader populates source
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderSource:
+    def test_source_column_added(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "mydata.tsv"
+        to_tsv(df, path)
+        r = read_tsv(path)
+        assert "source" in r.columns
+        assert (r["source"] == "mydata.tsv").all()
+
+    def test_tag_overrides_filename(self, tmp_path):
+        df = _sample_long_df()
+        path = tmp_path / "mydata.tsv"
+        to_tsv(df, path)
+        r = read_tsv(path, tag="patient01")
+        assert (r["source"] == "patient01").all()
+        assert "patient01" in r.sources
+
+    def test_source_column_not_overwritten(self, tmp_path):
+        df = _sample_long_df()
+        df["source"] = "manual_tag"
+        path = tmp_path / "mydata.tsv"
+        to_tsv(df, path)
+        r = read_tsv(path, tag="patient01")
+        # Existing source column preserved
+        assert (r["source"] == "manual_tag").all()
+
+
+# ---------------------------------------------------------------------------
+# concat()
+# ---------------------------------------------------------------------------
+
+
+class TestConcat:
+    def _make_r(self, value, source_tag, model_version="4.1b"):
+        df = pd.DataFrame([dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01",
+            kind="pMHC_affinity", score=0.8, value=value,
+            percentile_rank=0.5, affinity=value,
+            prediction_method_name="netmhcpan",
+            predictor_version=model_version,
+            source=source_tag,
+        )])
+        meta = Metadata(
+            form="long",
+            models={"netmhcpan": model_version},
+            sources=[source_tag],
+        )
+        return TopiaryResult(df, meta)
+
+    def test_concat_basic(self):
+        r1 = self._make_r(100.0, "patient01")
+        r2 = self._make_r(200.0, "patient02")
+        combined = concat([r1, r2])
+        assert len(combined) == 2
+
+    def test_concat_sources_merged(self):
+        r1 = self._make_r(100.0, "patient01")
+        r2 = self._make_r(200.0, "patient02")
+        combined = concat([r1, r2])
+        assert combined.sources == ["patient01", "patient02"]
+
+    def test_concat_preserves_source_column(self):
+        r1 = self._make_r(100.0, "patient01")
+        r2 = self._make_r(200.0, "patient02")
+        combined = concat([r1, r2])
+        assert set(combined["source"].unique()) == {"patient01", "patient02"}
+
+    def test_concat_models_union(self):
+        r1 = self._make_r(100.0, "p1", model_version="4.1b")
+        r2 = pd.DataFrame([dict(
+            peptide="X", allele="A",
+            kind="pMHC_presentation", score=0.5, value=0.5,
+            percentile_rank=1.0, affinity=float("nan"),
+            prediction_method_name="mhcflurry", predictor_version="2.1.1",
+            source="p2",
+        )])
+        r2 = TopiaryResult(r2, Metadata(form="long", models={"mhcflurry": "2.1.1"}, sources=["p2"]))
+        combined = concat([r1, r2])
+        assert combined.models == {"netmhcpan": "4.1b", "mhcflurry": "2.1.1"}
+
+    def test_concat_version_conflict_warns(self):
+        r1 = self._make_r(100.0, "p1", model_version="4.1b")
+        r2 = self._make_r(200.0, "p2", model_version="4.2")
+        with pytest.warns(UserWarning, match="conflicting versions"):
+            concat([r1, r2])
+
+    def test_concat_mixed_forms_raises(self):
+        r_long = self._make_r(100.0, "p1")
+        r_wide = TopiaryResult(
+            pd.DataFrame({
+                "peptide": ["A"],
+                "netmhcpan_affinity_value": [100.0],
+            }),
+        )
+        with pytest.raises(ValueError, match="different forms"):
+            concat([r_long, r_wide])
+
+    def test_concat_empty_list(self):
+        combined = concat([])
+        assert isinstance(combined, TopiaryResult)
+        assert len(combined) == 0
+
+    def test_concat_single(self):
+        r = self._make_r(100.0, "p1")
+        combined = concat([r])
+        assert len(combined) == 1
+
+    def test_concat_then_write_roundtrip(self, tmp_path):
+        """Concat + write + read preserves sources in comment block."""
+        r1 = self._make_r(100.0, "patient01")
+        r2 = self._make_r(200.0, "patient02")
+        combined = concat([r1, r2])
+
+        path = tmp_path / "merged.tsv"
+        combined.to_tsv(path)
+
+        r_back = read_tsv(path)
+        # Source column survives
+        assert set(r_back["source"].unique()) == {"patient01", "patient02"}
+        # Metadata sources include both original tags
+        for src in ["patient01", "patient02"]:
+            assert src in r_back.sources
+
+
+# ---------------------------------------------------------------------------
+# Real predictor integration
+# ---------------------------------------------------------------------------
+
+
+class TestPredictorIntegration:
+    def test_wrap_predictor_output(self):
+        from mhctools import RandomBindingPredictor
+        from topiary import TopiaryPredictor
+
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"],
+        )
+        df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+        r = TopiaryResult(df)
+        assert r.form == "long"
+        assert len(r) > 0
+
+        # Can convert, write, read back
+        wide = r.to_wide()
+        assert wide.form == "wide"

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -35,9 +35,10 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
+from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "4.11.2"
+__version__ = "4.12.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -74,4 +75,6 @@ __all__ = [
     "detect_form",
     "from_wide",
     "to_wide",
+    "TopiaryResult",
+    "concat",
 ]

--- a/topiary/io.py
+++ b/topiary/io.py
@@ -30,6 +30,9 @@ class Metadata:
     topiary_version: str = None
     form: str = None
     models: dict = dataclass_field(default_factory=OrderedDict)
+    sources: list = dataclass_field(default_factory=list)
+    filter_by: str = None
+    sort_by: str = None
     extra: dict = dataclass_field(default_factory=OrderedDict)
 
 
@@ -59,6 +62,12 @@ def _parse_comment_block(lines):
             meta.topiary_version = value
         elif key == "form":
             meta.form = value
+        elif key == "source":
+            meta.sources.append(value)
+        elif key == "filter_by":
+            meta.filter_by = value
+        elif key == "sort_by":
+            meta.sort_by = value
         elif key.startswith("model:"):
             model_name = key[len("model:"):]
             meta.models[model_name] = value
@@ -87,11 +96,17 @@ def _format_comment_block(meta):
         lines.append(f"#topiary_version={meta.topiary_version}")
     if meta.form:
         lines.append(f"#form={meta.form}")
+    for source in meta.sources:
+        lines.append(f"#source={source}")
     for model_name, version in meta.models.items():
         if version:
             lines.append(f"#model:{model_name}={version}")
         else:
             lines.append(f"#model:{model_name}")
+    if meta.filter_by:
+        lines.append(f"#filter_by={meta.filter_by}")
+    if meta.sort_by:
+        lines.append(f"#sort_by={meta.sort_by}")
     for key, value in meta.extra.items():
         lines.append(f"#{key}={value}")
     return "\n".join(lines)
@@ -100,7 +115,9 @@ def _format_comment_block(meta):
 # -- Read ------------------------------------------------------------------
 
 
-def _read_delimited(path, sep):
+def _read_delimited(path, sep, tag=None):
+    from .result import TopiaryResult
+
     path = Path(path)
     with open(path) as f:
         all_lines = f.readlines()
@@ -109,26 +126,53 @@ def _read_delimited(path, sep):
 
     data_text = "".join(all_lines[n_comment:])
     if not data_text.strip():
-        return pd.DataFrame(), meta
+        df = pd.DataFrame()
+    else:
+        df = pd.read_csv(StringIO(data_text), sep=sep)
 
-    df = pd.read_csv(StringIO(data_text), sep=sep)
-    return df, meta
+    # Record source (tag overrides filename).
+    source_label = tag if tag is not None else path.name
+    if source_label and source_label not in meta.sources:
+        meta.sources.append(source_label)
+
+    # Add a per-row source column if it's not already present.
+    if "source" not in df.columns and len(df) > 0:
+        df["source"] = source_label
+
+    return TopiaryResult(df, meta)
 
 
-def read_tsv(path):
+def read_tsv(path, tag=None):
     """Read a topiary TSV file with comment-block metadata.
 
-    Returns (DataFrame, Metadata).
+    Parameters
+    ----------
+    path : str or Path
+    tag : str, optional
+        Label for this file's rows.  Defaults to the filename.
+        Used to populate the ``source`` column and Metadata.sources.
+
+    Returns
+    -------
+    TopiaryResult
     """
-    return _read_delimited(path, sep="\t")
+    return _read_delimited(path, sep="\t", tag=tag)
 
 
-def read_csv(path):
+def read_csv(path, tag=None):
     """Read a topiary CSV file with comment-block metadata.
 
-    Returns (DataFrame, Metadata).
+    Parameters
+    ----------
+    path : str or Path
+    tag : str, optional
+        Label for this file's rows.  Defaults to the filename.
+
+    Returns
+    -------
+    TopiaryResult
     """
-    return _read_delimited(path, sep=",")
+    return _read_delimited(path, sep=",", tag=tag)
 
 
 # -- Write -----------------------------------------------------------------
@@ -137,6 +181,13 @@ def read_csv(path):
 def _write_delimited(df, path, sep, metadata, index):
     from . import __version__
     from .wide import detect_form
+
+    # Accept TopiaryResult too — pull out its df and metadata.
+    # Use duck typing to avoid a circular import.
+    if hasattr(df, "df") and hasattr(df, "metadata"):
+        if metadata is None:
+            metadata = df.metadata
+        df = df.df
 
     path = Path(path)
 

--- a/topiary/ranking.py
+++ b/topiary/ranking.py
@@ -250,6 +250,25 @@ class Expr:
     def __gt__(self, threshold):
         return self.__ge__(threshold)
 
+    # -- string serialization --
+
+    def to_expr_string(self):
+        """Parseable DSL expression string.
+
+        The result round-trips through :func:`parse_expr`:
+        ``parse_expr(e.to_expr_string())`` produces a functionally
+        equivalent Expr.
+        """
+        return repr(self)
+
+    def to_ast_string(self):
+        """Canonical structural AST string for debugging / hashing.
+
+        Unambiguous but not necessarily parseable back through
+        :func:`parse_expr`.  Override in subclasses.
+        """
+        return repr(self)
+
 
 class _Const(Expr):
     """A constant scalar value."""
@@ -266,6 +285,9 @@ class _Const(Expr):
         if v == int(v):
             return str(int(v))
         return repr(v)
+
+    def to_ast_string(self):
+        return f"Const({_fmt_num(self.val)})"
 
 
 def _fmt_num(v):
@@ -325,6 +347,10 @@ class _BinOp(Expr):
             right = f"({right})"
         return f"{left} {sym} {right}"
 
+    def to_ast_string(self):
+        sym = _OP_SYMBOLS.get(self.op, "?")
+        return f"BinOp({self.left.to_ast_string()}, {sym!r}, {self.right.to_ast_string()})"
+
 
 class _NormExpr(Expr):
     """Gaussian CDF normalization of an inner expression."""
@@ -346,6 +372,12 @@ class _NormExpr(Expr):
     def __repr__(self):
         return f"{repr(self.inner)}.ascending_cdf({_fmt_num(self.mean)}, {_fmt_num(self.std)})"
 
+    def to_ast_string(self):
+        return (
+            f"AscendingCDF({self.inner.to_ast_string()}, "
+            f"mean={_fmt_num(self.mean)}, std={_fmt_num(self.std)})"
+        )
+
 
 class _SurvivalExpr(Expr):
     """Survival function (1 - Gaussian CDF) of an inner expression."""
@@ -366,6 +398,12 @@ class _SurvivalExpr(Expr):
 
     def __repr__(self):
         return f"{repr(self.inner)}.descending_cdf({_fmt_num(self.mean)}, {_fmt_num(self.std)})"
+
+    def to_ast_string(self):
+        return (
+            f"DescendingCDF({self.inner.to_ast_string()}, "
+            f"mean={_fmt_num(self.mean)}, std={_fmt_num(self.std)})"
+        )
 
 
 class _LogisticExpr(Expr):
@@ -390,6 +428,12 @@ class _LogisticExpr(Expr):
 
     def __repr__(self):
         return f"{repr(self.inner)}.logistic({_fmt_num(self.midpoint)}, {_fmt_num(self.width)})"
+
+    def to_ast_string(self):
+        return (
+            f"Logistic({self.inner.to_ast_string()}, "
+            f"midpoint={_fmt_num(self.midpoint)}, width={_fmt_num(self.width)})"
+        )
 
 
 _UNARY_NAMES = {
@@ -424,6 +468,10 @@ class _UnaryOp(Expr):
             return f"{repr(self.inner)}.{name}()"
         return f"{repr(self.inner)}.<?>()"
 
+    def to_ast_string(self):
+        name = _UNARY_NAMES.get(self.fn, "<?>")
+        return f"UnaryOp({self.inner.to_ast_string()}, {name!r})"
+
 
 class _ClipExpr(Expr):
     """Clamp an inner expression to [lo, hi]."""
@@ -448,6 +496,12 @@ class _ClipExpr(Expr):
         if self.lo == 0 and self.hi is None:
             return f"{repr(self.inner)}.hinge()"
         return f"{repr(self.inner)}.clip({_fmt_num(self.lo)}, {_fmt_num(self.hi)})"
+
+    def to_ast_string(self):
+        return (
+            f"Clip({self.inner.to_ast_string()}, "
+            f"lo={_fmt_num(self.lo)}, hi={_fmt_num(self.hi)})"
+        )
 
 
 def _as_expr(obj):
@@ -485,6 +539,10 @@ class _AggExpr(Expr):
     def __repr__(self):
         args = ", ".join(repr(e) for e in self.exprs)
         return f"{self.name}({args})"
+
+    def to_ast_string(self):
+        args = ", ".join(e.to_ast_string() for e in self.exprs)
+        return f"Agg({self.name!r}, {args})"
 
 
 def mean(*exprs):
@@ -564,6 +622,9 @@ class Column(Expr):
 
     def __repr__(self):
         return f"column({self.col_name})"
+
+    def to_ast_string(self):
+        return f"Column({self.col_name!r})"
 
     def evaluate(self, group_df):
         if group_df.empty:
@@ -690,6 +751,15 @@ class Field(Expr):
         # Prepend scope prefix
         scope_str = self.scope.rstrip("_") + "." if self.scope else ""
         return f"{scope_str}{accessor}.{field_str}"
+
+    def to_ast_string(self):
+        kind_name = _kind_short_name(self.kind)
+        parts = [f"kind={kind_name}", f"field={self.field!r}"]
+        if self.method:
+            parts.append(f"method={self.method!r}")
+        if self.scope:
+            parts.append(f"scope={self.scope!r}")
+        return f"Field({', '.join(parts)})"
 
     # -- filter comparisons (only valid on unscoped Field) --
 
@@ -1047,6 +1117,44 @@ class EpitopeFilter:
     def rank_by(self, *exprs: Expr) -> RankingStrategy:
         return self.sort_by(*exprs)
 
+    def to_expr_string(self) -> str:
+        """Parseable DSL expression string.
+
+        Multiple thresholds on the same filter produce an ANDed expression.
+        """
+        kind = _kind_short_name(self.kind)
+        accessor = f"{kind}[{self.method!r}]" if self.method else kind
+        clauses = []
+        if self.max_value is not None:
+            clauses.append(f"{accessor}.value <= {_fmt_num(self.max_value)}")
+        if self.min_value is not None:
+            clauses.append(f"{accessor}.value >= {_fmt_num(self.min_value)}")
+        if self.max_percentile_rank is not None:
+            clauses.append(f"{accessor}.rank <= {_fmt_num(self.max_percentile_rank)}")
+        if self.min_percentile_rank is not None:
+            clauses.append(f"{accessor}.rank >= {_fmt_num(self.min_percentile_rank)}")
+        if self.max_score is not None:
+            clauses.append(f"{accessor}.score <= {_fmt_num(self.max_score)}")
+        if self.min_score is not None:
+            clauses.append(f"{accessor}.score >= {_fmt_num(self.min_score)}")
+        if not clauses:
+            return accessor
+        if len(clauses) == 1:
+            return clauses[0]
+        return " & ".join(f"({c})" for c in clauses)
+
+    def to_ast_string(self) -> str:
+        kind = _kind_short_name(self.kind)
+        parts = [f"kind={kind}"]
+        for attr in ("max_value", "min_value", "max_percentile_rank",
+                     "min_percentile_rank", "min_score", "max_score"):
+            v = getattr(self, attr)
+            if v is not None:
+                parts.append(f"{attr}={_fmt_num(v)}")
+        if self.method:
+            parts.append(f"method={self.method!r}")
+        return f"EpitopeFilter({', '.join(parts)})"
+
 
 @dataclass(frozen=True)
 class ColumnFilter:
@@ -1073,6 +1181,26 @@ class ColumnFilter:
 
     def rank_by(self, *exprs: Expr) -> "RankingStrategy":
         return self.sort_by(*exprs)
+
+    def to_expr_string(self) -> str:
+        clauses = []
+        if self.max_value is not None:
+            clauses.append(f"{self.col_name} <= {_fmt_num(self.max_value)}")
+        if self.min_value is not None:
+            clauses.append(f"{self.col_name} >= {_fmt_num(self.min_value)}")
+        if not clauses:
+            return self.col_name
+        if len(clauses) == 1:
+            return clauses[0]
+        return " & ".join(f"({c})" for c in clauses)
+
+    def to_ast_string(self) -> str:
+        parts = [f"col_name={self.col_name!r}"]
+        if self.max_value is not None:
+            parts.append(f"max_value={_fmt_num(self.max_value)}")
+        if self.min_value is not None:
+            parts.append(f"min_value={_fmt_num(self.min_value)}")
+        return f"ColumnFilter({', '.join(parts)})"
 
 
 @dataclass(frozen=True)
@@ -1101,6 +1229,30 @@ class ExprFilter:
 
     def rank_by(self, *exprs: Expr) -> "RankingStrategy":
         return self.sort_by(*exprs)
+
+    def to_expr_string(self) -> str:
+        # The DSL parser does not allow parentheses inside filter
+        # expressions, but <= / >= bind looser than arithmetic so we
+        # don't need them: "a + 1 <= 5" parses as "(a + 1) <= 5".
+        inner = self.expr.to_expr_string()
+        clauses = []
+        if self.max_value is not None:
+            clauses.append(f"{inner} <= {_fmt_num(self.max_value)}")
+        if self.min_value is not None:
+            clauses.append(f"{inner} >= {_fmt_num(self.min_value)}")
+        if not clauses:
+            return inner
+        if len(clauses) == 1:
+            return clauses[0]
+        return " & ".join(f"({c})" for c in clauses)
+
+    def to_ast_string(self) -> str:
+        parts = [f"expr={self.expr.to_ast_string()}"]
+        if self.max_value is not None:
+            parts.append(f"max_value={_fmt_num(self.max_value)}")
+        if self.min_value is not None:
+            parts.append(f"min_value={_fmt_num(self.min_value)}")
+        return f"ExprFilter({', '.join(parts)})"
 
 
 class SortSpec(list):
@@ -1156,6 +1308,52 @@ class RankingStrategy:
 
     def rank_by(self, *exprs: Expr) -> RankingStrategy:
         return self.sort_by(*exprs)
+
+    def to_expr_string(self) -> str:
+        """Filter portion as a parseable DSL expression string.
+
+        Sort expressions are not included (they have no inline DSL syntax;
+        pass ``sort_by`` to the caller separately).
+        """
+        if not self.filters:
+            return ""
+        parts = [_filter_child_to_expr(f, self.require_all) for f in self.filters]
+        op = " & " if self.require_all else " | "
+        return op.join(parts)
+
+    def to_ast_string(self) -> str:
+        filter_strs = [_filter_to_ast(f) for f in self.filters]
+        op = "AND" if self.require_all else "OR"
+        sort_strs = [e.to_ast_string() for e in list(self.sort_by)]
+        parts = [f"op={op!r}"]
+        if filter_strs:
+            parts.append(f"filters=[{', '.join(filter_strs)}]")
+        if sort_strs:
+            parts.append(f"sort_by=[{', '.join(sort_strs)}]")
+        return f"RankingStrategy({', '.join(parts)})"
+
+
+def _filter_child_to_expr(f, parent_require_all):
+    """Stringify a child filter inside a RankingStrategy, parenthesizing
+    when the child's own combinator differs from the parent's (so that
+    ``(A | B) & C`` doesn't flatten to ``A | B & C``)."""
+    s = _filter_to_expr(f)
+    if isinstance(f, RankingStrategy) and f.require_all != parent_require_all:
+        return f"({s})"
+    return s
+
+
+def _filter_to_expr(f):
+    """Dispatch to_expr_string for any filter-like object."""
+    if hasattr(f, "to_expr_string"):
+        return f.to_expr_string()
+    return repr(f)
+
+
+def _filter_to_ast(f):
+    if hasattr(f, "to_ast_string"):
+        return f.to_ast_string()
+    return repr(f)
 
 
 def _combine(left, right, require_all):

--- a/topiary/result.py
+++ b/topiary/result.py
@@ -1,0 +1,426 @@
+"""TopiaryResult: DataFrame + provenance and pipeline metadata.
+
+Carries all metadata fields directly (no nested ``.metadata`` indirection).
+Filter/sort state is stored in both string form (for serialization) and
+AST form (for programmatic use without re-parsing).
+"""
+
+import warnings
+from collections import OrderedDict
+
+import pandas as pd
+
+from .io import Metadata
+from .wide import detect_form
+
+
+class TopiaryResult:
+    """A prediction DataFrame bundled with its provenance and pipeline state.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The underlying prediction data.
+    topiary_version : str, optional
+    form : str, optional
+        "long" or "wide". Auto-detected from columns if not provided.
+    models : dict, optional
+        Model name → version string.
+    sources : list of str, optional
+        Files / tags that contributed rows.
+    filter_by_str : str, optional
+        Human-readable filter expression.
+    filter_by_ast : object, optional
+        Parsed filter (RankingStrategy, EpitopeFilter, etc.).
+    sort_by_str : str, optional
+    sort_by_ast : object, optional
+        Parsed sort Expr.
+    extra : dict, optional
+        Unknown comment-block keys, preserved on round-trip.
+    """
+
+    def __init__(
+        self,
+        df,
+        metadata=None,
+        *,
+        topiary_version=None,
+        form=None,
+        models=None,
+        sources=None,
+        filter_by_str=None,
+        filter_by_ast=None,
+        sort_by_str=None,
+        sort_by_ast=None,
+        extra=None,
+    ):
+        # Compat: accept a Metadata positionally and unpack its fields.
+        if metadata is not None:
+            topiary_version = topiary_version or metadata.topiary_version
+            form = form or metadata.form
+            models = models if models is not None else metadata.models
+            sources = sources if sources is not None else metadata.sources
+            filter_by_str = filter_by_str or getattr(metadata, "filter_by", None)
+            sort_by_str = sort_by_str or getattr(metadata, "sort_by", None)
+            extra = extra if extra is not None else metadata.extra
+
+        self.df = df
+        self.topiary_version = topiary_version
+        self.form = form or detect_form(df)
+        self.models = OrderedDict(models) if models else OrderedDict()
+        self.sources = list(sources) if sources else []
+        self.filter_by_str = filter_by_str
+        self.filter_by_ast = filter_by_ast
+        self.sort_by_str = sort_by_str
+        self.sort_by_ast = sort_by_ast
+        self.extra = OrderedDict(extra) if extra else OrderedDict()
+
+    # -- DataFrame delegation ---------------------------------------------
+
+    def __len__(self):
+        return len(self.df)
+
+    def __iter__(self):
+        return iter(self.df)
+
+    def __getitem__(self, key):
+        result = self.df[key]
+        if isinstance(result, pd.DataFrame):
+            return TopiaryResult(result, **self._field_kwargs())
+        return result
+
+    def __contains__(self, key):
+        return key in self.df
+
+    def __repr__(self):
+        n = len(self.df)
+        sources = ", ".join(self.sources) if self.sources else "<none>"
+        return f"<TopiaryResult form={self.form} rows={n} sources=[{sources}]>"
+
+    @property
+    def columns(self):
+        return self.df.columns
+
+    @property
+    def shape(self):
+        return self.df.shape
+
+    @property
+    def empty(self):
+        return self.df.empty
+
+    def head(self, n=5):
+        return TopiaryResult(self.df.head(n), **self._field_kwargs())
+
+    def tail(self, n=5):
+        return TopiaryResult(self.df.tail(n), **self._field_kwargs())
+
+    def iterrows(self):
+        return self.df.iterrows()
+
+    def itertuples(self, *args, **kwargs):
+        return self.df.itertuples(*args, **kwargs)
+
+    # -- Form conversion --------------------------------------------------
+
+    def to_wide(self):
+        from .wide import to_wide as _to_wide
+        wide_df = _to_wide(self.df)
+        kwargs = self._field_kwargs()
+        kwargs["form"] = "wide"
+        return TopiaryResult(wide_df, **kwargs)
+
+    def to_long(self):
+        from .wide import from_wide
+        long_df = from_wide(self.df, metadata=self._as_metadata())
+        kwargs = self._field_kwargs()
+        kwargs["form"] = "long"
+        return TopiaryResult(long_df, **kwargs)
+
+    # -- DSL operations ---------------------------------------------------
+
+    def filter_by(self, expr):
+        """Apply a filter expression. ANDs with any existing filter.
+
+        Parameters
+        ----------
+        expr : str or DSL filter object
+            A string like ``"affinity <= 500"`` or an object like
+            ``Affinity <= 500``.
+
+        Returns
+        -------
+        TopiaryResult
+            New result with rows filtered and filter_by_str / filter_by_ast
+            updated (ANDed with any previous filter).
+        """
+        from .ranking import (
+            parse_ranking, apply_ranking_strategy,
+            RankingStrategy, EpitopeFilter, ColumnFilter, ExprFilter,
+        )
+
+        if isinstance(expr, str):
+            new_str = expr
+            new_ast = parse_ranking(expr)
+        elif isinstance(expr, (EpitopeFilter, ColumnFilter, ExprFilter, RankingStrategy)):
+            new_ast = expr
+            new_str = _dsl_filter_to_string(expr)
+        else:
+            raise TypeError(
+                f"filter_by expects a string or DSL filter object, "
+                f"got {type(expr).__name__}"
+            )
+
+        # Coerce to RankingStrategy for applying.
+        if isinstance(new_ast, (EpitopeFilter, ColumnFilter, ExprFilter)):
+            strategy = RankingStrategy(filters=[new_ast])
+        else:
+            strategy = new_ast
+
+        # Apply to df.
+        if self.df.empty:
+            filtered_df = self.df
+        else:
+            filtered_df = apply_ranking_strategy(self.df, strategy)
+
+        # Combine with existing filter.
+        if self.filter_by_ast is not None:
+            combined_ast = self.filter_by_ast & new_ast
+            combined_str = _combine_filter_str(self.filter_by_str, new_str)
+        else:
+            combined_ast = new_ast
+            combined_str = new_str
+
+        kwargs = self._field_kwargs()
+        kwargs["filter_by_str"] = combined_str
+        kwargs["filter_by_ast"] = combined_ast
+        return TopiaryResult(filtered_df, **kwargs)
+
+    def sort_by(self, expr):
+        """Sort rows by an expression. Replaces any previous sort.
+
+        Parameters
+        ----------
+        expr : str or Expr object
+            A string like ``"presentation.score"`` or an ``Expr`` object.
+
+        Returns
+        -------
+        TopiaryResult
+            New result with rows sorted and sort_by_str / sort_by_ast updated.
+        """
+        from .ranking import (
+            Expr, RankingStrategy, apply_ranking_strategy, parse_expr,
+        )
+
+        if isinstance(expr, str):
+            new_str = expr
+            new_ast = parse_expr(expr)
+        elif isinstance(expr, Expr):
+            new_ast = expr
+            new_str = repr(expr)
+        else:
+            raise TypeError(
+                f"sort_by expects a string or Expr object, "
+                f"got {type(expr).__name__}"
+            )
+
+        if self.df.empty:
+            sorted_df = self.df
+        else:
+            strategy = RankingStrategy(filters=[], sort_by=[new_ast])
+            sorted_df = apply_ranking_strategy(self.df, strategy)
+
+        kwargs = self._field_kwargs()
+        kwargs["sort_by_str"] = new_str
+        kwargs["sort_by_ast"] = new_ast
+        return TopiaryResult(sorted_df, **kwargs)
+
+    # -- Serialization -----------------------------------------------------
+
+    def to_tsv(self, path):
+        from .io import to_tsv as _to_tsv
+        _to_tsv(self.df, path, metadata=self._as_metadata())
+
+    def to_csv(self, path):
+        from .io import to_csv as _to_csv
+        _to_csv(self.df, path, metadata=self._as_metadata())
+
+    # -- Internal helpers --------------------------------------------------
+
+    def _field_kwargs(self):
+        """Return kwargs dict for reconstructing a copy."""
+        return dict(
+            topiary_version=self.topiary_version,
+            form=self.form,
+            models=OrderedDict(self.models),
+            sources=list(self.sources),
+            filter_by_str=self.filter_by_str,
+            filter_by_ast=self.filter_by_ast,
+            sort_by_str=self.sort_by_str,
+            sort_by_ast=self.sort_by_ast,
+            extra=OrderedDict(self.extra),
+        )
+
+    def _as_metadata(self):
+        """Build a Metadata for serialization / legacy APIs."""
+        return Metadata(
+            topiary_version=self.topiary_version,
+            form=self.form,
+            models=OrderedDict(self.models),
+            sources=list(self.sources),
+            filter_by=self.filter_by_str,
+            sort_by=self.sort_by_str,
+            extra=OrderedDict(self.extra),
+        )
+
+    # Backward-compat: tests and older code access `.metadata`.
+    @property
+    def metadata(self):
+        return self._as_metadata()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _combine_filter_str(old, new):
+    """Combine two filter expression strings with AND.
+
+    Parenthesizes both sides to handle cases where ``old`` or ``new``
+    contains ``|`` or other operators.
+    """
+    if not old:
+        return new
+    if not new:
+        return old
+    return f"({old}) & ({new})"
+
+
+def _dsl_filter_to_string(filt):
+    """Convert a DSL filter object into a parseable string.
+
+    Handles the common ``EpitopeFilter`` and ``RankingStrategy`` cases.
+    Falls back to ``repr()`` for unknown types (not guaranteed to round-trip).
+    """
+    from .ranking import (
+        EpitopeFilter, ColumnFilter, ExprFilter, RankingStrategy,
+        _kind_short_name,
+    )
+
+    if isinstance(filt, EpitopeFilter):
+        kind = _kind_short_name(filt.kind)
+        prefix = f"{kind}[{filt.method!r}]" if filt.method else kind
+        clauses = []
+        if filt.max_value is not None:
+            clauses.append(f"{prefix}.value <= {filt.max_value}")
+        if filt.min_value is not None:
+            clauses.append(f"{prefix}.value >= {filt.min_value}")
+        if filt.max_percentile_rank is not None:
+            clauses.append(f"{prefix}.rank <= {filt.max_percentile_rank}")
+        if filt.min_percentile_rank is not None:
+            clauses.append(f"{prefix}.rank >= {filt.min_percentile_rank}")
+        if filt.max_score is not None:
+            clauses.append(f"{prefix}.score <= {filt.max_score}")
+        if filt.min_score is not None:
+            clauses.append(f"{prefix}.score >= {filt.min_score}")
+        return " & ".join(clauses) if clauses else prefix
+
+    if isinstance(filt, RankingStrategy):
+        if not filt.filters:
+            return ""
+        sub_strs = [_dsl_filter_to_string(f) for f in filt.filters]
+        op = " & " if filt.require_all else " | "
+        return op.join(f"({s})" for s in sub_strs)
+
+    if isinstance(filt, (ColumnFilter, ExprFilter)):
+        return repr(filt)
+
+    return repr(filt)
+
+
+def concat(results):
+    """Concatenate TopiaryResults, preserving provenance.
+
+    Parameters
+    ----------
+    results : list of TopiaryResult
+        All must be in the same form (long or wide).
+
+    Returns
+    -------
+    TopiaryResult
+        DataFrames concatenated; metadata merged (sources concatenated,
+        models union with warning on version conflicts; filter_by / sort_by
+        preserved only if all inputs agree).
+    """
+    if not results:
+        return TopiaryResult(pd.DataFrame())
+
+    forms = {r.form for r in results}
+    if len(forms) > 1:
+        raise ValueError(
+            f"Cannot concat TopiaryResults in different forms: {forms}"
+        )
+    form = results[0].form
+
+    # Merge models with conflict detection.
+    merged_models = OrderedDict()
+    for r in results:
+        for model, version in r.models.items():
+            if model in merged_models and merged_models[model] != version:
+                warnings.warn(
+                    f"Model {model!r} has conflicting versions: "
+                    f"{merged_models[model]!r} vs {version!r}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                merged_models[model] = version
+
+    merged_sources = []
+    for r in results:
+        merged_sources.extend(r.sources)
+
+    merged_extra = OrderedDict()
+    for r in results:
+        merged_extra.update(r.extra)
+
+    topiary_version = None
+    for r in results:
+        if r.topiary_version:
+            topiary_version = r.topiary_version
+            break
+
+    # Preserve filter/sort only if all inputs agree.
+    filter_strs = {r.filter_by_str for r in results}
+    if len(filter_strs) == 1 and None not in filter_strs:
+        filter_by_str = next(iter(filter_strs))
+        filter_by_ast = results[0].filter_by_ast
+    else:
+        filter_by_str = None
+        filter_by_ast = None
+
+    sort_strs = {r.sort_by_str for r in results}
+    if len(sort_strs) == 1 and None not in sort_strs:
+        sort_by_str = next(iter(sort_strs))
+        sort_by_ast = results[0].sort_by_ast
+    else:
+        sort_by_str = None
+        sort_by_ast = None
+
+    df = pd.concat([r.df for r in results], ignore_index=True)
+
+    return TopiaryResult(
+        df,
+        topiary_version=topiary_version,
+        form=form,
+        models=merged_models,
+        sources=merged_sources,
+        filter_by_str=filter_by_str,
+        filter_by_ast=filter_by_ast,
+        sort_by_str=sort_by_str,
+        sort_by_ast=sort_by_ast,
+        extra=merged_extra,
+    )

--- a/topiary/result.py
+++ b/topiary/result.py
@@ -17,6 +17,17 @@ from .wide import detect_form
 class TopiaryResult:
     """A prediction DataFrame bundled with its provenance and pipeline state.
 
+    Delegates common DataFrame operations so most code that worked on a
+    bare DataFrame continues to work.  **Follows pandas conventions for
+    iteration / membership**:
+
+    - ``"peptide" in result`` checks whether ``"peptide"`` is a *column*,
+      not a row value.  Use ``"SIINFEKL" in result.df["peptide"].values``
+      for row-value membership.
+    - ``for x in result`` iterates column *names*, matching
+      ``for x in df``.  Use ``result.iterrows()`` or ``result.df.values``
+      for row iteration.
+
     Parameters
     ----------
     df : pandas.DataFrame
@@ -30,11 +41,15 @@ class TopiaryResult:
         Files / tags that contributed rows.
     filter_by_str : str, optional
         Human-readable filter expression.
-    filter_by_ast : object, optional
-        Parsed filter (RankingStrategy, EpitopeFilter, etc.).
+    filter_by_ast : DSL filter object, optional
+        Parsed filter. Currently a ``RankingStrategy``, ``EpitopeFilter``,
+        ``ColumnFilter``, or ``ExprFilter`` instance — whatever
+        :func:`topiary.ranking.parse_ranking` returns. Must support ``&``
+        for ANDing with additional filters via :meth:`filter_by`.
     sort_by_str : str, optional
-    sort_by_ast : object, optional
-        Parsed sort Expr.
+    sort_by_ast : Expr, optional
+        Parsed sort expression. Currently a ``topiary.ranking.Expr``
+        subclass.
     extra : dict, optional
         Unknown comment-block keys, preserved on round-trip.
     """
@@ -132,7 +147,7 @@ class TopiaryResult:
 
     def to_long(self):
         from .wide import from_wide
-        long_df = from_wide(self.df, metadata=self._as_metadata())
+        long_df = from_wide(self.df, metadata=self.metadata)
         kwargs = self._field_kwargs()
         kwargs["form"] = "long"
         return TopiaryResult(long_df, **kwargs)
@@ -240,13 +255,31 @@ class TopiaryResult:
 
     def to_tsv(self, path):
         from .io import to_tsv as _to_tsv
-        _to_tsv(self.df, path, metadata=self._as_metadata())
+        _to_tsv(self.df, path, metadata=self.metadata)
 
     def to_csv(self, path):
         from .io import to_csv as _to_csv
-        _to_csv(self.df, path, metadata=self._as_metadata())
+        _to_csv(self.df, path, metadata=self.metadata)
 
-    # -- Internal helpers --------------------------------------------------
+    # -- Accessors / helpers ----------------------------------------------
+
+    @property
+    def metadata(self):
+        """A fresh :class:`Metadata` built from this result's fields.
+
+        Useful for passing to functions that expect a ``Metadata`` (e.g.
+        :func:`to_tsv`, :func:`from_wide`) and for serializing the
+        comment-block without touching private internals.
+        """
+        return Metadata(
+            topiary_version=self.topiary_version,
+            form=self.form,
+            models=OrderedDict(self.models),
+            sources=list(self.sources),
+            filter_by=self.filter_by_str,
+            sort_by=self.sort_by_str,
+            extra=OrderedDict(self.extra),
+        )
 
     def _field_kwargs(self):
         """Return kwargs dict for reconstructing a copy."""
@@ -261,23 +294,6 @@ class TopiaryResult:
             sort_by_ast=self.sort_by_ast,
             extra=OrderedDict(self.extra),
         )
-
-    def _as_metadata(self):
-        """Build a Metadata for serialization / legacy APIs."""
-        return Metadata(
-            topiary_version=self.topiary_version,
-            form=self.form,
-            models=OrderedDict(self.models),
-            sources=list(self.sources),
-            filter_by=self.filter_by_str,
-            sort_by=self.sort_by_str,
-            extra=OrderedDict(self.extra),
-        )
-
-    # Backward-compat: tests and older code access `.metadata`.
-    @property
-    def metadata(self):
-        return self._as_metadata()
 
 
 # ---------------------------------------------------------------------------
@@ -401,6 +417,17 @@ def concat(results):
     else:
         filter_by_str = None
         filter_by_ast = None
+        if any(r.filter_by_str for r in results):
+            present = sorted({r.filter_by_str for r in results if r.filter_by_str})
+            warnings.warn(
+                "Dropping filter_by metadata: inputs to concat() have "
+                f"differing filter history (found: {present}).  The rows are "
+                "still filtered per their individual histories, but the "
+                "combined result has no single filter expression that "
+                "describes all of them.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     sort_strs = {r.sort_by_str for r in results}
     if len(sort_strs) == 1 and None not in sort_strs:
@@ -409,6 +436,15 @@ def concat(results):
     else:
         sort_by_str = None
         sort_by_ast = None
+        if any(r.sort_by_str for r in results):
+            present = sorted({r.sort_by_str for r in results if r.sort_by_str})
+            warnings.warn(
+                "Dropping sort_by metadata: inputs to concat() have "
+                f"differing sort history (found: {present}).  The concatenated "
+                "rows are no longer in a consistent sort order.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     df = pd.concat([r.df for r in results], ignore_index=True)
 


### PR DESCRIPTION
## Summary

Adds `TopiaryResult` — a wrapper that bundles a predictions DataFrame with its metadata (model versions, source files, form, filter/sort history) — plus a `concat()` function for merging results with provenance preserved across the merge.

- Delegates common DataFrame operations so existing code that treats results as DataFrames keeps working
- `read_tsv` / `read_csv` return `TopiaryResult` (breaking: was `(df, Metadata)`)
- Auto-populates a `source` column and `Metadata.sources` from the filename (overridable via `tag=`)
- `concat([r1, r2])` merges model maps (warns on version conflicts), concatenates sources, preserves filter/sort only if all inputs agree, raises on mixed forms
- Added `to_expr_string()` / `to_ast_string()` to legacy filter classes as a stopgap (see #111 for the full DSL refactor that removes them)

Bumps to 4.12.0. 760 tests pass.

See #109 for the wrapper design. Follow-on DSL cleanup in #111.

## Test plan
- [x] 34 new tests in `test_result.py` cover construction, delegation, form conversion, serialization, loader source-tracking, concat semantics (basic, sources-merged, models-union, version-conflict-warns, mixed-forms-raises, empty, single, roundtrip)
- [x] Existing IO tests migrated to new return type
- [x] Full suite: 760 tests pass locally
- [ ] CI green on Python 3.10, 3.11, 3.12