### PR TITLE
Cache pip + pyensembl data in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Cache pyensembl data
+        uses: actions/cache@v4
+        with:
+          path: ~/.pyensembl
+          key: pyensembl-GRCh37.75-GRCm38.102-GRCh38.93-GRCm38.93-v1
       - name: Checkout private netmhc-bundle repo
         if: env.HAS_NETMHC_TOKEN == 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `cache: 'pip'` on `setup-python@v5` keyed on `requirements.txt` — avoids reinstalling numpy/pandas/mhctools/varcode etc. on every run.
- `actions/cache@v4` on `~/.pyensembl` keyed on the four release numbers in the workflow — avoids re-downloading the Ensembl releases, which is the largest single cost in the current workflow (~3-4 min of the 7.5 min total).

First run on a fresh cache is unchanged; subsequent runs should drop from ~7.5 min to ~3 min per matrix entry. Bump the cache key suffix when the release set or pyensembl's on-disk layout changes.

## Test plan
- [ ] CI green on this PR
- [ ] Second push to this branch hits caches and runs noticeably faster