### PR TITLE
DSL polish — v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 5.0.1
+
+Polish pass on the v5.0.0 DSL refactor — no user-visible behavior
+changes, just internal cleanup.
+
+- `DSLNode.child_nodes()` — new abstract method on every node type.
+  Generic tree walkers (column validation, future AST rewriters) no
+  longer need a per-node `isinstance` ladder.  `_collect_column_names`
+  now uses it.
+- The scoped-field filter guard moves from four per-operator overrides
+  on `Field` (`__le__` / `__ge__` / `__lt__` / `__gt__`) into a single
+  check in `Comparison.__init__`.  Same error, less surface area.
+- `apply_filter` now reindexes the evaluated Series to
+  `ctx.group_index` before masking, so an index mismatch surfaces as
+  NaN → False rather than as misaligned row selection.
+
 ## 5.0.0
 
 **Breaking changes (DSL refactor,

--- a/tests/test_dsl_roundtrip.py
+++ b/tests/test_dsl_roundtrip.py
@@ -457,6 +457,29 @@ class TestVectorizedEval:
         sorted_df = apply_sort(df, [Presentation.score, Affinity.score])
         assert sorted_df.iloc[0]["peptide"] == "AAA"
 
+    def test_child_nodes_generic_walk(self):
+        """DSLNode.child_nodes() exposes direct children uniformly — used by
+        generic walkers like column validation."""
+        from topiary.ranking.apply import _collect_column_names
+        node = (
+            0.5 * Affinity.score
+            + 0.3 * (Column("gene_tpm").log1p())
+            - 0.2 * Column("cysteine_count")
+        )
+        names = _collect_column_names(node)
+        assert names == {"gene_tpm", "cysteine_count"}
+
+    def test_child_nodes_inside_comparison_and_bool(self):
+        """Column references inside comparisons and BoolOps are also found."""
+        from topiary.ranking.apply import _collect_column_names
+        node = (
+            (Column("gene_tpm") >= 5)
+            & (Column("cysteine_count") <= 2)
+            | (Column("hydrophobicity") > 0)
+        )
+        names = _collect_column_names(node)
+        assert names == {"gene_tpm", "cysteine_count", "hydrophobicity"}
+
     def test_sort_stability(self):
         """Two groups tied on every sort key must retain input order."""
         df = pd.DataFrame([

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -43,7 +43,7 @@ from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -10,18 +10,9 @@ import pandas as pd
 from mhctools import Kind
 
 from .nodes import (
-    AggExpr,
-    BinOp,
-    BoolOp,
-    ClipExpr,
     Column,
-    Comparison,
     EvalContext,
     Field,
-    LogisticExpr,
-    NormExpr,
-    SurvivalExpr,
-    UnaryOp,
     _kind_matches,
 )
 
@@ -55,7 +46,12 @@ def _check_boolean_like(values: pd.Series):
 
 
 def _collect_column_names(node):
-    """Walk a DSLNode tree and return all explicit Column references."""
+    """Walk a DSLNode tree and return all explicit Column references.
+
+    Uses ``DSLNode.child_nodes()`` so adding a new node type doesn't
+    require touching this walker — new composites just need to
+    implement ``child_nodes()``.
+    """
     names = set()
     stack = [node]
     while stack:
@@ -64,19 +60,7 @@ def _collect_column_names(node):
             continue
         if isinstance(n, Column):
             names.add(n.col_name)
-        elif isinstance(n, BinOp):
-            stack.append(n.left)
-            stack.append(n.right)
-        elif isinstance(n, Comparison):
-            stack.append(n.left)
-            stack.append(n.right)
-        elif isinstance(n, BoolOp):
-            stack.extend(n.children)
-        elif isinstance(n, AggExpr):
-            stack.extend(n.exprs)
-        elif isinstance(n, (UnaryOp, NormExpr, SurvivalExpr,
-                            LogisticExpr, ClipExpr)):
-            stack.append(n.inner)
+        stack.extend(n.child_nodes())
     return names
 
 
@@ -128,7 +112,10 @@ def apply_filter(df, node):
 
     _validate_columns(df, node)
     ctx = EvalContext(df)
-    values = node.eval(ctx)
+    # Reindex defensively so a misbehaving node (index mismatch) surfaces
+    # as NaN → False rather than silently picking up rows from a
+    # different MultiIndex alignment.
+    values = node.eval(ctx).reindex(ctx.group_index)
     _check_boolean_like(values)
     mask = values.fillna(False).astype(bool)
 

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -190,6 +190,16 @@ class DSLNode:
     def eval(self, ctx: EvalContext) -> pd.Series:
         raise NotImplementedError
 
+    def child_nodes(self) -> "list[DSLNode]":
+        """Direct DSLNode children of this node.
+
+        Leaves return ``[]``. Composite nodes return their sub-nodes in
+        a stable order.  Used by generic tree walkers (e.g. column
+        validation) so adding a new node type doesn't require touching
+        every walker.
+        """
+        return []
+
     def to_expr_string(self) -> str:
         """Parseable DSL expression string.
 
@@ -562,32 +572,7 @@ class Field(DSLNode):
             parts.append(f"scope={self.scope!r}")
         return f"Field({', '.join(parts)})"
 
-    # -- scoped fields cannot be used directly in filters --
-
-    def _check_scope_for_filter(self):
-        if self.scope:
-            scope_name = self.scope.rstrip("_")
-            raise TypeError(
-                f"Scoped fields ({scope_name}.*) can't be used in filters. "
-                f"Use them in sorting expressions instead, e.g.: "
-                f"sort_by=[Affinity.score - {scope_name}.Affinity.score]"
-            )
-
-    def __le__(self, other):
-        self._check_scope_for_filter()
-        return super().__le__(other)
-
-    def __ge__(self, other):
-        self._check_scope_for_filter()
-        return super().__ge__(other)
-
-    def __lt__(self, other):
-        self._check_scope_for_filter()
-        return super().__lt__(other)
-
-    def __gt__(self, other):
-        self._check_scope_for_filter()
-        return super().__gt__(other)
+    # (Scoped fields cannot appear in filters — guarded in Comparison.__init__)
 
 
 class Len(DSLNode):
@@ -685,6 +670,9 @@ class BinOp(DSLNode):
         with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             return self.op(a, b)
 
+    def child_nodes(self):
+        return [self.left, self.right]
+
     def __repr__(self):
         sym = _OP_SYMBOLS.get(self.op, "?")
         left_str = repr(self.left)
@@ -730,6 +718,9 @@ class UnaryOp(DSLNode):
     def __init__(self, inner: DSLNode, fn):
         self.inner = inner
         self.fn = fn
+
+    def child_nodes(self):
+        return [self.inner]
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         vals = self.inner.eval(ctx)
@@ -793,6 +784,9 @@ class NormExpr(DSLNode):
         self.mean = float(mean)
         self.std = float(std)
 
+    def child_nodes(self):
+        return [self.inner]
+
     def eval(self, ctx: EvalContext) -> pd.Series:
         vals = self.inner.eval(ctx)
         if self.std == 0:
@@ -823,6 +817,9 @@ class SurvivalExpr(DSLNode):
         self.mean = float(mean)
         self.std = float(std)
 
+    def child_nodes(self):
+        return [self.inner]
+
     def eval(self, ctx: EvalContext) -> pd.Series:
         vals = self.inner.eval(ctx)
         if self.std == 0:
@@ -852,6 +849,9 @@ class LogisticExpr(DSLNode):
         self.inner = inner
         self.midpoint = float(midpoint)
         self.width = float(width)
+
+    def child_nodes(self):
+        return [self.inner]
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         vals = self.inner.eval(ctx)
@@ -886,6 +886,9 @@ class ClipExpr(DSLNode):
         self.inner = inner
         self.lo = lo
         self.hi = hi
+
+    def child_nodes(self):
+        return [self.inner]
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         vals = self.inner.eval(ctx)
@@ -930,6 +933,9 @@ class AggExpr(DSLNode):
     def __init__(self, exprs, name):
         self.exprs = list(exprs)
         self.name = name
+
+    def child_nodes(self):
+        return list(self.exprs)
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         if not self.exprs:
@@ -1026,9 +1032,20 @@ class Comparison(DSLNode):
     __slots__ = ("left", "op", "right")
 
     def __init__(self, left: DSLNode, op, right: DSLNode):
+        for side in (left, right):
+            if isinstance(side, Field) and side.scope:
+                scope_name = side.scope.rstrip("_")
+                raise TypeError(
+                    f"Scoped fields ({scope_name}.*) can't be used in filters. "
+                    f"Use them in sorting expressions instead, e.g.: "
+                    f"sort_by=[Affinity.score - {scope_name}.Affinity.score]"
+                )
         self.left = left
         self.op = op
         self.right = right
+
+    def child_nodes(self):
+        return [self.left, self.right]
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         a = self.left.eval(ctx)
@@ -1076,6 +1093,9 @@ class BoolOp(DSLNode):
     def __init__(self, op, children):
         self.op = op
         self.children = list(children)
+
+    def child_nodes(self):
+        return list(self.children)
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         # Policy: NaN is treated as False.  Naive `astype(bool)` coerces


### PR DESCRIPTION
## Summary

Follow-ups from the v5.0.0 review. No user-visible behavior changes; all changes are internal cleanup.

- **`DSLNode.child_nodes()`** — new abstract method returning direct children. Generic tree walkers (`_collect_column_names`, future AST rewriters) no longer need a per-node `isinstance` ladder. Every composite node type implements it (`BinOp`, `UnaryOp`, `NormExpr`, `SurvivalExpr`, `LogisticExpr`, `ClipExpr`, `AggExpr`, `Comparison`, `BoolOp`); leaves inherit the default empty list from the base class.
- **Scoped-field filter guard** moves from four per-operator overrides on `Field` (`__le__` / `__ge__` / `__lt__` / `__gt__`) into a single check in `Comparison.__init__`. Same error message, less surface area, and the check now fires regardless of which side of the comparison is the scoped `Field`.
- **`apply_filter`** defensively reindexes the evaluated Series to `ctx.group_index` before masking, so an index mismatch surfaces as NaN → False rather than as misaligned row selection.

Version bumped to `5.0.1`.

## Test plan
- [x] `./test.sh` — 839 passed (2 new tests covering the generic `child_nodes()` walker)
- [x] `./lint.sh` — clean
- [ ] CI green on this PR