### PR TITLE
AntigenFragment abstraction — v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 5.2.0
+
+**New features (core abstraction for antigens from any origin):**
+
+- `AntigenFragment` — a universal record for a protein/peptide sequence
+  with source-type, target-region, and comparator metadata. Carries
+  variants, structural variants, ERVs, CTAs, viral proteins, allergens,
+  autoantigens, and synthetic constructs through one pipeline. Free-form
+  `source_type` tag (recommended vocabulary documented, not enforced);
+  `target_intervals: list[tuple[int, int]]` for disjoint regions
+  (breakpoints of tandem duplications, non-self regions of ERVs, etc.);
+  `reference_sequence` + `germline_sequence` with germline-precedence
+  `effective_baseline`. Equality/hash keyed on `fragment_id` (stable
+  human-readable prefix + SHA-1 hash). Convenience constructors
+  `from_variant`, `from_junction`. Stdlib-only serialization:
+  `to_dict` / `from_dict` / `to_json` / `from_json`.
+- `topiary.read_antigens(path)` / `write_antigens(fragments, path)` /
+  `iter_antigens(path)` — TSV IO with JSON-serialized list/dict columns.
+- `TopiaryPredictor.predict_from_antigens(fragments)` — new entry point
+  that scans each fragment's sequence, propagates every fragment field
+  (including arbitrary annotations) onto prediction rows, threads
+  `fragment_id` through for downstream grouping (vaxrank vaccine-window
+  selection), and emits an `overlaps_target` column computed from each
+  peptide's position vs. the fragment's target intervals. Backwards-compat
+  `contains_mutant_residues` alias for `source_type` prefixed with
+  `variant`. `wt_peptide` derived by slicing `effective_baseline`;
+  model-side WT predictions deferred to a follow-up PR.
+- `self_nearest` — reserved DSL scope for cross-reactivity filtering
+  ("closest peptide in essential healthy tissues"). Topiary does not
+  compute these columns — producers populate via BLAST / edit distance
+  against a healthy-tissue proteome with their own "self" definition.
+  The scope reads `self_nearest_*` columns when present, returns NaN
+  otherwise. See `docs/antigens.md` for the reserved column namespace.
+- `fragment_id` is now preferred over `variant` as the group key in the
+  DSL's group-by logic (falls back to `variant`, then
+  `source_sequence_name`).
+
+**Internal:**
+
+- New module `topiary/antigen.py` (dataclass + helpers) and
+  `topiary/io_antigen.py` (TSV IO).
+- 63 new tests covering identity, serialization, geometry,
+  `predict_from_antigens` propagation, `self_nearest` scope reads.
+
 ## 5.1.0
 
 **New features:**

--- a/docs/antigens.md
+++ b/docs/antigens.md
@@ -1,0 +1,172 @@
+# Antigen Fragments
+
+`AntigenFragment` is a universal record for a protein / peptide sequence with source-type, target-region, and comparator metadata. It's the substrate that lets Topiary handle antigens from any origin — somatic variants, structural variants, ERVs, CTAs, viral proteins, allergens, autoantigens, synthetic constructs — through one pipeline, and threads identity through predictions so downstream tools (vaxrank, vaccine-window selection) can group peptides back to their source.
+
+## The dataclass
+
+```python
+from topiary import AntigenFragment
+
+f = AntigenFragment.from_variant(
+    sequence="MAAVTDVGMAVATGSWDSFLKIWN",
+    reference_sequence="MAAVTDVGMAAATGSWDSFLKIWN",   # WT protein
+    mutation_start=10, mutation_end=11, inframe=True,
+    variant="chr7:140753336",
+    effect="p.Val600Glu",
+    gene="BRAF",
+    annotations={"vaf": 0.42, "ccf": 0.9},
+)
+```
+
+Every field except `fragment_id` and `sequence` is optional. `target_intervals` carries the half-open regions within `sequence` considered targetable — its meaning depends on source type (see vocabulary below).
+
+## Running predictions
+
+```python
+from topiary import TopiaryPredictor
+
+predictor = TopiaryPredictor(models=[...], alleles=[...])
+df = predictor.predict_from_antigens(fragments)
+```
+
+Output DataFrame columns, beyond the standard prediction fields:
+
+| Column | Meaning |
+|---|---|
+| `fragment_id` | Source identity — threads back to `AntigenFragment.fragment_id` |
+| `source_type`, `variant`, `effect`, `effect_type`, `gene`, `gene_id`, `transcript_id` | Propagated from the fragment |
+| `gene_expression`, `transcript_expression` | Propagated from the fragment |
+| `overlaps_target` | `True` / `False` / NaN — whether the peptide overlaps any of the fragment's target intervals |
+| `contains_mutant_residues` | Backwards-compat alias — `True` iff `source_type.startswith("variant")` AND `overlaps_target` is True |
+| `wt_peptide`, `wt_peptide_length` | Derived by slicing `effective_baseline` at the peptide's offset; `None` when no baseline exists |
+| *(each annotation key)* | Flattened from every fragment's `annotations` dict |
+
+## source_type vocabulary (recommended, not enforced)
+
+Free-form string. Topiary never interprets it; used for display and DSL filtering. Colon subtyping is convention.
+
+| Category | Values |
+|---|---|
+| Variant, small | `variant:snv`, `variant:indel`, `variant:frameshift`, `variant:stop_gain`, `variant:silent` |
+| Structural variant | `sv:fusion`, `sv:tandem_duplication`, `sv:inversion`, `sv:translocation`, `sv:cryptic_exon`, `sv:large_insertion`, `sv:large_deletion` |
+| Aberrant expression | `erv`, `cta`, `tumor_overexpressed`, `intron_retention`, `utr`, `novel_orf` |
+| Pathogen | `viral`, `viral:hpv16`, `viral:hiv`, `bacterial`, `parasitic` |
+| Environmental | `allergen`, `allergen:plant`, `allergen:food`, `allergen:mold`, `allergen:dander` |
+| Self / autoimmunity | `self`, `autoantigen`, `autoantigen:myelin` |
+| Synthetic | `synthetic`, `designed` |
+
+Producers are free to invent new subtypes.
+
+## target_intervals — geometry per source type
+
+The producer computes `target_intervals`; Topiary never interprets. Meaning varies by source type:
+
+| source_type | `target_intervals` |
+|---|---|
+| `variant:snv` at position k | `[(k, k+1)]` |
+| `variant:indel` (in-frame insertion) at k, length L | `[(k, k+L)]` |
+| `variant:indel` (in-frame deletion) at k | `[(k, k)]` — the junction where formerly-distant residues now sit together |
+| `variant:frameshift` at k | `[(k, len(sequence))]` — everything downstream is novel (sequence should be truncated at the new stop) |
+| `sv:fusion` (in-frame, coding-coding) with junction at k | `[(k-1, k+1)]` — junction residues only; internal partner residues are self |
+| `sv:fusion` onto non-coding partner with junction at k | `[(k, len(sequence))]` — readthrough translation is all novel |
+| `sv:tandem_duplication` with breakpoints at k1, k2 | `[(k1, k1+1), (k2, k2+1)]` — breakpoints only; duplicated bulk is self |
+| `sv:inversion` within coding region [a, b] | `[(a, b)]` — reversed translation is entirely novel |
+| `sv:cryptic_exon` (in-frame inclusion) at [a, b] | `[(a, b)]` |
+| `sv:cryptic_exon` (frameshift inclusion) at [a, b] | `[(a, len(sequence))]` |
+| `erv`, `cta` | Producer-computed non-self regions (based on the producer's definition of "self" — healthy-tissue expression, homology to non-CTA proteins). `None` when the producer can't decide. |
+| `viral`, `allergen` | Immunodominant / IgE-reactive hotspots if known; `None` otherwise |
+
+`None` means unspecified — downstream tools decide whether to treat as "whole sequence." Empty list `[]` explicitly means "nothing targetable."
+
+## Reference vs germline
+
+```python
+reference_sequence: str | None      # canonical (Ensembl, RefSeq, reference strain)
+germline_sequence: str | None       # patient / strain-specific baseline
+```
+
+The DSL's `wt.*` scope reads `effective_baseline`:
+
+```python
+@property
+def effective_baseline(self) -> str | None:
+    return self.germline_sequence if self.germline_sequence is not None else self.reference_sequence
+```
+
+Germline takes precedence when populated; reference is the fallback. Both `None` → `wt.*` returns NaN.
+
+| source_type | typical `reference_sequence` | typical `germline_sequence` |
+|---|---|---|
+| `variant:*` | Canonical WT from varcode/Ensembl | Patient's non-tumor protein if available |
+| `sv:*` | Usually `None` | `None` |
+| `viral[:strain]` | Reference-strain protein | `None` (patient has no germline virus) |
+| `erv` | `None` | `None` |
+| `cta` | Canonical protein (equals `sequence`) | Same as reference (CTAs are non-neoantigens) |
+| `autoantigen` | Canonical (UniProt MBP etc.) | Patient-specific with SNPs — can matter for TCR specificity |
+| `allergen` | Canonical isoform | `None` (patient doesn't have it) |
+| `synthetic` | Natural parent if any, else `None` | `None` |
+
+## Reserved DSL scope: `self_nearest`
+
+For cross-reactivity filtering — "what's the closest peptide in essential healthy tissues, and does it also bind this MHC?"
+
+Topiary **does not compute** these — producers populate externally (via BLAST / edit distance against a healthy-tissue proteome with their own definition of "self"). The DSL scope just reads `self_nearest_*` columns. When columns are absent, `self_nearest.*` returns NaN.
+
+Reserved column namespace:
+
+| Column | Meaning |
+|---|---|
+| `self_nearest_peptide` | Closest healthy-tissue peptide at the same length |
+| `self_nearest_peptide_length` | (Trivially same as the mutant) |
+| `self_nearest_edit_distance` | Producer-chosen distance metric (Hamming / Levenshtein / BLAST score) |
+| `self_nearest_gene` | Source gene of the nearest-self hit |
+| `self_nearest_gene_id`, `self_nearest_transcript_id` | Provenance |
+| `self_nearest_tissues` | Which healthy tissues the source gene is expressed in |
+| `self_nearest_value`, `self_nearest_score`, `self_nearest_percentile_rank` | MHC binding of the nearest-self peptide, paired to the same allele |
+
+```python
+from topiary import Affinity, Column, apply_filter, self_nearest
+
+# Drop neoepitopes too similar to healthy-tissue self
+df = apply_filter(
+    df,
+    (Affinity.score >= 0.5) & (Column("self_nearest_edit_distance") >= 3),
+)
+
+# Ranking that penalizes cross-reactivity
+ranking = Affinity.score - 0.5 * self_nearest.Affinity.score
+```
+
+## IO
+
+```python
+from topiary import read_antigens, write_antigens
+
+write_antigens(fragments, "my_antigens.tsv")
+loaded = read_antigens("my_antigens.tsv")
+```
+
+TSV format: one row per fragment. Scalar fields map to same-named columns. `target_intervals` and `annotations` are JSON-encoded in their own columns. Missing columns on read fall back to field defaults; unknown columns raise.
+
+For single-fragment / API use: `fragment.to_dict()`, `fragment.to_json()`, and the `from_dict` / `from_json` classmethods — stdlib only, no dependencies.
+
+## Identity
+
+`fragment_id` is canonical. Two fragments with the same id are equal and hash-equal, regardless of other content. Use `make_fragment_id(prefix, sequence, variant=...)` for a deterministic content-derived id with a readable prefix:
+
+```
+BRAF_p.Val600Glu__a1b2c3d4
+EWSR1-FLI1_fusion__3c8e4b91
+erv_Hsap38.chr7.64991215__7f2e89a1
+HPV16_E6__5f6a1c23
+__4f9c2a8e                  # no metadata → hash-only fallback
+```
+
+Prefix is sanitized to `[A-Za-z0-9._:-]`; runs of other characters collapse to `_`. Hash is 8 hex chars of SHA-1 over `sequence` + optional `variant`.
+
+## What's not in this release
+
+- **WT model predictions** (`wt_value`, `wt_score`, `wt_percentile_rank`) — `wt_peptide` is derived but not fed through the MHC predictor. `wt.Affinity.score` returns NaN until a future PR populates these.
+- **Nearest-self compute** — the scope is reserved but no Topiary module produces the columns. Populate externally for now.
+- **Varcode refactor** — the existing `predict_from_variants` pipeline doesn't yet emit `AntigenFragment`s; it still takes its own path. Planned for a follow-up PR.
+- **Format-specific loaders** (`read_lens_fragments`, `read_pvacseq_fragments`, `read_isovar_fragments`) — each ~50-100 lines on top of the core abstraction; separate PRs.

--- a/tests/test_antigen.py
+++ b/tests/test_antigen.py
@@ -1,0 +1,441 @@
+"""Tests for topiary.antigen (AntigenFragment + helpers)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from topiary import AntigenFragment, make_fragment_id
+from topiary.antigen import _sanitize_prefix, _default_prefix, collect_annotations
+from topiary.io_antigen import read_antigens, write_antigens, iter_antigens
+
+
+# ---------------------------------------------------------------------------
+# fragment_id construction
+# ---------------------------------------------------------------------------
+
+
+class TestMakeFragmentId:
+    def test_shape(self):
+        fid = make_fragment_id("BRAF_p.V600E", "MAVS")
+        assert "__" in fid
+        prefix, rest = fid.split("__")
+        assert prefix == "BRAF_p.V600E"
+        assert len(rest) == 8  # default hash_length
+        assert all(c in "0123456789abcdef" for c in rest)
+
+    def test_deterministic(self):
+        a = make_fragment_id("gene_X", "MAVS", variant="v1")
+        b = make_fragment_id("gene_X", "MAVS", variant="v1")
+        assert a == b
+
+    def test_variant_changes_hash(self):
+        a = make_fragment_id("gene_X", "MAVS", variant="v1")
+        b = make_fragment_id("gene_X", "MAVS", variant="v2")
+        assert a != b
+
+    def test_sequence_changes_hash(self):
+        a = make_fragment_id("X", "MAVS")
+        b = make_fragment_id("X", "MAVT")
+        assert a != b
+
+    def test_prefix_sanitization(self):
+        # Spaces, slashes, etc. collapse to single underscore
+        fid = make_fragment_id("gene name / with   weird", "X")
+        prefix, _ = fid.split("__")
+        assert prefix == "gene_name_with_weird"
+
+    def test_preserves_safe_chars(self):
+        fid = make_fragment_id("BRAF_p.V600E:mut-1", "X")
+        prefix, _ = fid.split("__")
+        assert prefix == "BRAF_p.V600E:mut-1"
+
+    def test_empty_prefix(self):
+        fid = make_fragment_id("", "X")
+        assert fid.startswith("__")
+        assert len(fid) == 10  # "" + "__" + 8 hex chars
+
+
+# ---------------------------------------------------------------------------
+# Dataclass identity / hashing
+# ---------------------------------------------------------------------------
+
+
+class TestIdentity:
+    def _sample(self, **overrides):
+        kwargs = dict(
+            fragment_id="test__abcdef01",
+            source_type="variant:snv",
+            sequence="MAAV",
+            target_intervals=[(2, 3)],
+        )
+        kwargs.update(overrides)
+        return AntigenFragment(**kwargs)
+
+    def test_equality_by_id(self):
+        a = self._sample()
+        b = self._sample(sequence="DIFFERENT", target_intervals=None)
+        # Same fragment_id → equal even though content differs
+        assert a == b
+
+    def test_hashable_in_set(self):
+        a = self._sample()
+        b = self._sample()
+        assert {a, b} == {a}
+
+    def test_inequality_by_id(self):
+        a = self._sample(fragment_id="test__aaaaaaaa")
+        b = self._sample(fragment_id="test__bbbbbbbb")
+        assert a != b
+
+    def test_hash_ignores_unhashable_fields(self):
+        # target_intervals is a list, annotations a dict — both unhashable.
+        # Auto-generated __hash__ would blow up; ours is fine because it keys
+        # on fragment_id.
+        f = self._sample(annotations={"vaf": 0.5})
+        hash(f)  # does not raise
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def _rich(self):
+        return AntigenFragment(
+            fragment_id="BRAF_p.V600E__abcdef01",
+            source_type="variant:snv",
+            sequence="MAAVTDVGMAV",
+            reference_sequence="MAAVTDVGMAA",
+            germline_sequence=None,
+            target_intervals=[(10, 11)],
+            variant="chr7:140753336",
+            effect="p.Val600Glu",
+            effect_type="Substitution",
+            gene="BRAF",
+            gene_id="ENSG00000157764",
+            transcript_id="ENST00000288602",
+            gene_expression=12.3,
+            transcript_expression=8.1,
+            annotations={"vaf": 0.42, "ccf": 0.9, "caller": "mutect2"},
+        )
+
+    def test_to_dict_shape(self):
+        d = self._rich().to_dict()
+        assert d["fragment_id"] == "BRAF_p.V600E__abcdef01"
+        # target_intervals serialized as lists, not tuples
+        assert d["target_intervals"] == [[10, 11]]
+
+    def test_dict_roundtrip(self):
+        f = self._rich()
+        f2 = AntigenFragment.from_dict(f.to_dict())
+        assert f == f2
+        assert f2.target_intervals == [(10, 11)]  # restored as tuples
+        assert f2.annotations == f.annotations
+
+    def test_json_roundtrip(self):
+        f = self._rich()
+        f2 = AntigenFragment.from_json(f.to_json())
+        assert f == f2
+        assert f2.sequence == f.sequence
+        assert f2.target_intervals == [(10, 11)]
+
+    def test_json_pretty(self):
+        f = self._rich()
+        s = f.to_json(indent=2)
+        assert "\n" in s
+        assert AntigenFragment.from_json(s) == f
+
+    def test_from_dict_rejects_unknown_keys(self):
+        with pytest.raises(ValueError, match="Unknown AntigenFragment field"):
+            AntigenFragment.from_dict({
+                "fragment_id": "x__00000000", "sequence": "M",
+                "bogus_field": 1,
+            })
+
+    def test_from_dict_missing_optional_defaults(self):
+        f = AntigenFragment.from_dict({
+            "fragment_id": "x__00000000", "sequence": "M",
+        })
+        assert f.source_type is None
+        assert f.target_intervals is None
+        assert f.annotations == {}
+
+    def test_none_target_intervals_serializes(self):
+        f = AntigenFragment(fragment_id="x__00000000", sequence="M")
+        d = f.to_dict()
+        assert d["target_intervals"] is None
+        f2 = AntigenFragment.from_dict(d)
+        assert f2.target_intervals is None
+
+    def test_empty_target_intervals(self):
+        f = AntigenFragment(fragment_id="x__00000000", sequence="M", target_intervals=[])
+        f2 = AntigenFragment.from_json(f.to_json())
+        assert f2.target_intervals == []
+
+
+# ---------------------------------------------------------------------------
+# Stringification
+# ---------------------------------------------------------------------------
+
+
+class TestStringification:
+    def test_str_is_compact(self):
+        f = AntigenFragment(
+            fragment_id="BRAF_p.V600E__abcdef01",
+            source_type="variant:snv",
+            sequence="MAAVTDVGMAV",
+            target_intervals=[(10, 11)],
+            gene="BRAF",
+        )
+        s = str(f)
+        assert "BRAF_p.V600E__abcdef01" in s
+        assert "11 aa" in s
+        assert "variant:snv" in s
+        assert "1 target interval" in s
+        assert "gene=BRAF" in s
+
+    def test_repr_unambiguous(self):
+        f = AntigenFragment(fragment_id="x__00000000", sequence="M")
+        r = repr(f)
+        # dataclass-generated repr contains class name and fragment_id
+        assert "AntigenFragment" in r
+        assert "fragment_id='x__00000000'" in r
+
+
+# ---------------------------------------------------------------------------
+# Geometry: peptide_overlaps_target
+# ---------------------------------------------------------------------------
+
+
+class TestOverlaps:
+    def _f(self, intervals):
+        return AntigenFragment(
+            fragment_id="x__00000000",
+            sequence="A" * 20,
+            target_intervals=intervals,
+        )
+
+    def test_none_intervals_never_overlap(self):
+        f = self._f(None)
+        assert f.peptide_overlaps_target(0, 9) is False
+        assert f.has_target is False
+
+    def test_empty_intervals_never_overlap(self):
+        f = self._f([])
+        assert f.peptide_overlaps_target(0, 9) is False
+        assert f.has_target is False
+
+    def test_single_interval_exact(self):
+        # Target at [5, 6) — a single residue at position 5
+        f = self._f([(5, 6)])
+        assert f.has_target is True
+        # Peptide covering [5, 5+9) — overlaps
+        assert f.peptide_overlaps_target(5, 9) is True
+        # Peptide ending at 5 — no overlap (half-open)
+        assert f.peptide_overlaps_target(0, 5) is False
+        # Peptide starting at 6 — no overlap
+        assert f.peptide_overlaps_target(6, 9) is False
+
+    def test_multiple_intervals(self):
+        # Target at two disjoint positions
+        f = self._f([(3, 4), (15, 16)])
+        assert f.peptide_overlaps_target(0, 9) is True    # covers pos 3
+        assert f.peptide_overlaps_target(5, 9) is False   # [5, 14): misses both
+        assert f.peptide_overlaps_target(10, 9) is True   # covers 10-19, includes 15
+
+    def test_interval_inside_peptide(self):
+        f = self._f([(5, 8)])
+        assert f.peptide_overlaps_target(3, 9) is True  # [3, 12) fully contains [5, 8)
+
+
+# ---------------------------------------------------------------------------
+# from_variant / from_junction
+# ---------------------------------------------------------------------------
+
+
+class TestClassmethods:
+    def test_from_variant_inframe_snv(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11,
+            inframe=True,
+            gene="BRAF", effect="p.Ala290Val",
+        )
+        assert f.source_type == "variant:snv"
+        assert f.target_intervals == [(10, 11)]
+        assert f.gene == "BRAF"
+        assert f.fragment_id.startswith("BRAF_p.Ala290Val")
+
+    def test_from_variant_inframe_indel(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=8, mutation_end=11,
+            inframe=True,
+        )
+        assert f.source_type == "variant:indel"
+        assert f.target_intervals == [(8, 11)]
+
+    def test_from_variant_frameshift(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",  # length 11
+            mutation_start=5, mutation_end=5,
+            inframe=False,
+        )
+        assert f.source_type == "variant:frameshift"
+        # Targets everything from the shift to the end
+        assert f.target_intervals == [(5, 11)]
+
+    def test_from_junction_crossing_only(self):
+        f = AntigenFragment.from_junction(
+            sequence="AAAAAABBBBBB",
+            junction_position=6,
+            novel_downstream=False,
+            gene="EWSR1", variant="EWSR1-FLI1",
+        )
+        assert f.source_type == "sv:fusion"
+        assert f.target_intervals == [(5, 7)]  # junction ± 1
+
+    def test_from_junction_novel_downstream(self):
+        f = AntigenFragment.from_junction(
+            sequence="AAAAAABBBBBB",  # length 12
+            junction_position=6,
+            novel_downstream=True,
+        )
+        assert f.target_intervals == [(6, 12)]
+
+    def test_from_variant_fragment_id_prefix(self):
+        # Provide all three fields; prefix should concatenate
+        f = AntigenFragment.from_variant(
+            sequence="ABC", mutation_start=1, mutation_end=2, inframe=True,
+            gene="GENE", effect="p.Ala1Val", variant="chr1:100",
+        )
+        prefix, _ = f.fragment_id.split("__")
+        assert "GENE" in prefix
+        assert "p.Ala1Val" in prefix
+        assert "chr1:100" in prefix
+
+
+# ---------------------------------------------------------------------------
+# effective_baseline property
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveBaseline:
+    def test_germline_takes_precedence(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="M",
+            reference_sequence="REF", germline_sequence="GERM",
+        )
+        assert f.effective_baseline == "GERM"
+
+    def test_fallback_to_reference(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="M",
+            reference_sequence="REF", germline_sequence=None,
+        )
+        assert f.effective_baseline == "REF"
+
+    def test_both_none(self):
+        f = AntigenFragment(fragment_id="x__00000000", sequence="M")
+        assert f.effective_baseline is None
+
+
+# ---------------------------------------------------------------------------
+# TSV IO
+# ---------------------------------------------------------------------------
+
+
+class TestTsvIo:
+    def _fragments(self):
+        return [
+            AntigenFragment.from_variant(
+                sequence="MAAVTDVGMAV",
+                reference_sequence="MAAVTDVGMAA",
+                mutation_start=10, mutation_end=11,
+                inframe=True,
+                gene="BRAF", effect="p.Val600Glu",
+                variant="chr7:140753336",
+                annotations={"vaf": 0.42, "ccf": 0.9},
+            ),
+            AntigenFragment(
+                fragment_id="erv_Hsap38.chr7__abcdef01",
+                source_type="erv",
+                sequence="MLGMNMLL",
+                target_intervals=None,
+                annotations={"erv_orf_id": "X", "erv_norm_cpm": 1.2},
+            ),
+        ]
+
+    def test_roundtrip(self, tmp_path):
+        frags = self._fragments()
+        p = tmp_path / "antigens.tsv"
+        write_antigens(frags, p)
+        loaded = read_antigens(p)
+        for a, b in zip(frags, loaded):
+            assert a == b
+            assert a.sequence == b.sequence
+            assert a.target_intervals == b.target_intervals
+            assert a.annotations == b.annotations
+
+    def test_file_is_tsv(self, tmp_path):
+        frags = self._fragments()
+        p = tmp_path / "antigens.tsv"
+        write_antigens(frags, p)
+        first_line = p.read_text().splitlines()[0]
+        assert "\t" in first_line
+        assert first_line.startswith("fragment_id\t")
+
+    def test_unknown_column_raises(self, tmp_path):
+        p = tmp_path / "bad.tsv"
+        p.write_text(
+            "fragment_id\tsequence\tfoobar\n"
+            "x__00000000\tM\tvalue\n"
+        )
+        with pytest.raises(ValueError, match="Unknown antigen-TSV column"):
+            read_antigens(p)
+
+    def test_missing_optional_columns(self, tmp_path):
+        p = tmp_path / "minimal.tsv"
+        p.write_text("fragment_id\tsequence\nx__00000000\tMAVS\n")
+        loaded = read_antigens(p)
+        assert len(loaded) == 1
+        assert loaded[0].sequence == "MAVS"
+        assert loaded[0].annotations == {}
+        assert loaded[0].target_intervals is None
+
+    def test_iter_antigens(self, tmp_path):
+        frags = self._fragments()
+        p = tmp_path / "antigens.tsv"
+        write_antigens(frags, p)
+        streamed = list(iter_antigens(p))
+        assert len(streamed) == len(frags)
+        for a, b in zip(frags, streamed):
+            assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+class TestUtilities:
+    def test_sanitize_prefix(self):
+        assert _sanitize_prefix("  hello  world/foo ") == "hello_world_foo"
+        assert _sanitize_prefix("already.clean-text:ok") == "already.clean-text:ok"
+        assert _sanitize_prefix("") == ""
+
+    def test_default_prefix_skips_none(self):
+        assert _default_prefix("BRAF", None, "chr1:100") == "BRAF_chr1:100"
+        assert _default_prefix(None, None, None) == ""
+
+    def test_collect_annotations(self):
+        frags = [
+            AntigenFragment(fragment_id="a__00000000", sequence="M",
+                            annotations={"x": 1, "y": 2}),
+            AntigenFragment(fragment_id="b__00000000", sequence="M",
+                            annotations={"y": 3, "z": 4}),
+        ]
+        assert collect_annotations(frags) == {"x", "y", "z"}

--- a/tests/test_predict_from_antigens.py
+++ b/tests/test_predict_from_antigens.py
@@ -201,6 +201,20 @@ class TestWtPeptide:
         aff = df[df["kind"] == "pMHC_affinity"]
         assert (aff["wt_peptide_length"] == 8).all()
 
+    def test_wt_peptide_none_for_length_changing_baseline(self):
+        """Indels / frameshifts where baseline and mutant differ in length
+        can't be sliced with mutant coordinates — wt_peptide stays None
+        until coordinate remapping lands."""
+        f = AntigenFragment.from_variant(
+            sequence="MAAGVTDVGMAV",                # 12 aa — post-indel
+            reference_sequence="MAAGVTDVGMA",        # 11 aa — pre-indel
+            mutation_start=10, mutation_end=12,
+            inframe=True,
+        )
+        df = _predictor().predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        assert aff["wt_peptide"].isna().all()
+
 
 # ---------------------------------------------------------------------------
 # Multiple fragments & fragment_id as group key
@@ -289,6 +303,70 @@ class TestSelfNearestScope:
         df["self_nearest_edit_distance"] = 4.0
         result = apply_filter(df, Column("self_nearest_edit_distance") >= 3)
         assert len(result) == len(df)
+
+    def test_self_nearest_parses_from_dsl_string(self):
+        """parse("self_nearest.affinity.score") yields a node that reads
+        self_nearest_score — matches the Python-side Scope("self_nearest")."""
+        from topiary.ranking import EvalContext, parse
+        node = parse("self_nearest.affinity.score")
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f])
+        df["self_nearest_score"] = 0.7
+        s = node.eval(EvalContext(df))
+        assert (s == 0.7).all()
+
+    def test_self_nearest_parses_in_sort_expression(self):
+        """parse("affinity.score - self_nearest.affinity.score") composes."""
+        from topiary.ranking import parse
+        node = parse("affinity.score - self_nearest.affinity.score")
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f])
+        df["self_nearest_score"] = 0.2
+        result = apply_sort(df, [node])
+        assert len(result) == len(df)
+
+
+# ---------------------------------------------------------------------------
+# only_novel_epitopes flag
+# ---------------------------------------------------------------------------
+
+
+class TestOnlyNovelEpitopes:
+    def test_only_novel_drops_non_mutant_rows(self):
+        """When only_novel_epitopes=True, keep only rows with
+        contains_mutant_residues == True (parallels predict_from_mutation_effects)."""
+        f = AntigenFragment.from_variant(
+            sequence="MAAGVTDVGMAVATGSWDSFLKIWN",
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        pred = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=[ALLELE], default_peptide_lengths=[9],
+            ),
+            only_novel_epitopes=True,
+        )
+        df = pred.predict_from_antigens([f])
+        assert df["contains_mutant_residues"].astype(bool).all()
+
+    def test_only_novel_drops_non_variant_fragments(self):
+        """Fragments whose source_type isn't a variant have NaN
+        contains_mutant_residues and are dropped when only_novel is on."""
+        erv = AntigenFragment(
+            fragment_id="erv__00000000", source_type="erv",
+            sequence="MLGMNMLLITLFLLLPLSMLKGEPWEGCLHCTH",
+        )
+        pred = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=[ALLELE], default_peptide_lengths=[9],
+            ),
+            only_novel_epitopes=True,
+        )
+        df = pred.predict_from_antigens([erv])
+        assert df.empty
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_from_antigens.py
+++ b/tests/test_predict_from_antigens.py
@@ -1,0 +1,317 @@
+"""Tests for TopiaryPredictor.predict_from_antigens."""
+
+import math
+
+import pandas as pd
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import (
+    Affinity,
+    AntigenFragment,
+    Column,
+    TopiaryPredictor,
+    apply_filter,
+    apply_sort,
+    self_nearest,
+)
+
+
+ALLELE = "HLA-A*02:01"
+
+
+def _predictor(lengths=(9,)):
+    return TopiaryPredictor(
+        models=RandomBindingPredictor(
+            alleles=[ALLELE], default_peptide_lengths=list(lengths),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core: rows carry fragment metadata
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataPropagation:
+    def test_fragment_id_on_every_row(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11, inframe=True,
+            gene="BRAF",
+        )
+        df = _predictor().predict_from_antigens([f])
+        assert (df["fragment_id"] == f.fragment_id).all()
+
+    def test_source_type_propagated(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11, inframe=True,
+        )
+        df = _predictor().predict_from_antigens([f])
+        assert (df["source_type"] == "variant:snv").all()
+
+    def test_variant_effect_gene_propagated(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11, inframe=True,
+            variant="chr1:100", effect="p.Ala290Val", gene="BRAF",
+            gene_id="ENSG123", transcript_id="ENST456",
+            gene_expression=12.3, transcript_expression=8.1,
+        )
+        df = _predictor().predict_from_antigens([f])
+        assert (df["variant"] == "chr1:100").all()
+        assert (df["effect"] == "p.Ala290Val").all()
+        assert (df["gene"] == "BRAF").all()
+        assert (df["gene_id"] == "ENSG123").all()
+        assert (df["transcript_id"] == "ENST456").all()
+        assert (df["gene_expression"] == 12.3).all()
+        assert (df["transcript_expression"] == 8.1).all()
+
+    def test_annotations_flattened(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11, inframe=True,
+            annotations={"vaf": 0.42, "ccf": 0.9},
+        )
+        df = _predictor().predict_from_antigens([f])
+        assert "vaf" in df.columns
+        assert "ccf" in df.columns
+        assert (df["vaf"] == 0.42).all()
+        assert (df["ccf"] == 0.9).all()
+
+    def test_annotations_nan_when_absent(self):
+        """Fragments without a given annotation key get NaN for it."""
+        with_vaf = AntigenFragment(
+            fragment_id="a__00000000", sequence="MAAVTDVGMAV",
+            annotations={"vaf": 0.42},
+        )
+        without_vaf = AntigenFragment(
+            fragment_id="b__00000000", sequence="MAAVTDVGMAV",
+            annotations={},
+        )
+        df = _predictor().predict_from_antigens([with_vaf, without_vaf])
+        for fid, row in df.groupby("fragment_id"):
+            if fid == "a__00000000":
+                assert (row["vaf"] == 0.42).all()
+            else:
+                assert row["vaf"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# Geometry: overlaps_target / contains_mutant_residues
+# ---------------------------------------------------------------------------
+
+
+class TestGeometry:
+    def test_overlaps_target_for_snv(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAGVTDVGMAVATGSWDSFLKIWN",  # length 25
+            mutation_start=11, mutation_end=12,
+            inframe=True,
+        )
+        df = _predictor().predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        # Peptides covering position 11 should be True; others False.
+        for _, row in aff.iterrows():
+            start = int(row["peptide_offset"])
+            touches = start <= 11 < start + 9
+            assert row["overlaps_target"] is touches, (start, touches, row["overlaps_target"])
+
+    def test_overlaps_target_nan_when_intervals_none(self):
+        f = AntigenFragment(
+            fragment_id="erv__00000000", source_type="erv",
+            sequence="MLGMNMLLITLFLLLPLSMLKGEPWEGCLHCTH",
+            target_intervals=None,
+        )
+        df = _predictor().predict_from_antigens([f])
+        assert df["overlaps_target"].isna().all()
+
+    def test_contains_mutant_residues_only_for_variants(self):
+        variant_f = AntigenFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        erv_f = AntigenFragment(
+            fragment_id="erv__00000000", source_type="erv",
+            sequence="MLGMNMLLITLFLLL",
+            target_intervals=[(5, 10)],   # even if targets given, not a variant
+        )
+        df = _predictor().predict_from_antigens([variant_f, erv_f])
+        variant_rows = df[df["fragment_id"] == variant_f.fragment_id]
+        erv_rows = df[df["fragment_id"] == erv_f.fragment_id]
+        # Variant fragment: contains_mutant_residues populated (True/False)
+        assert variant_rows["contains_mutant_residues"].notna().any()
+        # ERV: always NaN regardless of whether its target region exists
+        assert erv_rows["contains_mutant_residues"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# WT peptide derivation
+# ---------------------------------------------------------------------------
+
+
+class TestWtPeptide:
+    def test_wt_peptide_from_reference(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            reference_sequence="MAAGVTDVGMAA",  # diff at pos 11 (V → A)
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        df = _predictor().predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        for _, row in aff.iterrows():
+            mut = row["peptide"]
+            wt = row["wt_peptide"]
+            assert isinstance(wt, str)
+            start = int(row["peptide_offset"])
+            if start <= 11 < start + 9:
+                # Peptide straddles the mutation → WT should differ
+                assert mut != wt
+            else:
+                # Peptide doesn't straddle → WT should match
+                assert mut == wt
+
+    def test_germline_takes_precedence_over_reference(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVG",
+            reference_sequence="XXXXXXXX",
+            germline_sequence="GGGGGGGG",
+        )
+        df = _predictor(lengths=[8]).predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        assert len(aff) == 1
+        assert aff.iloc[0]["wt_peptide"] == "GGGGGGGG"
+
+    def test_no_baseline_leaves_wt_none(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", source_type="erv",
+            sequence="MAAVTDVG",
+        )
+        df = _predictor(lengths=[8]).predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        assert aff["wt_peptide"].isna().all()
+
+    def test_wt_peptide_length(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVG",
+            reference_sequence="REFXXXXX",
+        )
+        df = _predictor(lengths=[8]).predict_from_antigens([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        assert (aff["wt_peptide_length"] == 8).all()
+
+
+# ---------------------------------------------------------------------------
+# Multiple fragments & fragment_id as group key
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleFragments:
+    def test_fragment_id_groups_preserved(self):
+        f1 = AntigenFragment(
+            fragment_id="frag_one__00000001", source_type="erv",
+            sequence="MAAVTDVGMAV",
+        )
+        f2 = AntigenFragment(
+            fragment_id="frag_two__00000002", source_type="cta",
+            sequence="MAAVTDVGMAV",  # same sequence, different fragment
+        )
+        df = _predictor().predict_from_antigens([f1, f2])
+        assert set(df["fragment_id"].unique()) == {
+            "frag_one__00000001", "frag_two__00000002",
+        }
+        # Predictions for the same peptide show up under each fragment_id
+        # without collapsing.
+        peptide_counts = df.groupby("peptide").size()
+        assert (peptide_counts >= 2).any()  # at least some peptides duplicated
+
+    def test_apply_filter_groups_by_fragment_id(self):
+        f1 = AntigenFragment(
+            fragment_id="frag_one__00000001", source_type="erv",
+            sequence="MAAVTDVGMAV",
+        )
+        f2 = AntigenFragment(
+            fragment_id="frag_two__00000002", source_type="cta",
+            sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f1, f2])
+        # Filter on Affinity — fragment_id used as group key so each
+        # fragment's pass/fail is independent.
+        result = apply_filter(df, Affinity <= 50000)
+        # Both fragments survive (they share the same peptides so binding is identical)
+        assert set(result["fragment_id"].unique()) == {
+            "frag_one__00000001", "frag_two__00000002",
+        }
+
+
+# ---------------------------------------------------------------------------
+# self_nearest scope reservation (columns absent → NaN)
+# ---------------------------------------------------------------------------
+
+
+class TestSelfNearestScope:
+    def test_self_nearest_score_nan_when_columns_absent(self):
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f])
+        # self_nearest_* columns aren't emitted by PR A
+        assert "self_nearest_score" not in df.columns
+        # But the DSL scope evaluates to NaN silently
+        from topiary.ranking import EvalContext
+        node = self_nearest.Affinity.score
+        ctx = EvalContext(df)
+        s = node.eval(ctx)
+        assert s.isna().all()
+
+    def test_self_nearest_reads_populated_columns(self):
+        """If a producer writes self_nearest_score etc., the DSL scope reads them."""
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f])
+        # Simulate an external tool populating the reserved columns.
+        df["self_nearest_peptide"] = "ABCDEFGHI"
+        df["self_nearest_score"] = 0.5
+        df["self_nearest_percentile_rank"] = 2.0
+        # Filter via self_nearest.Affinity.score — reads self_nearest_score.
+        # (Field kind filtering still applies.)
+        assert "self_nearest_score" in df.columns
+
+    def test_self_nearest_edit_distance_filter(self):
+        """Users filter with Column() on self_nearest_edit_distance."""
+        f = AntigenFragment(
+            fragment_id="x__00000000", sequence="MAAVTDVGMAV",
+        )
+        df = _predictor().predict_from_antigens([f])
+        # Producer populates edit distance
+        df["self_nearest_edit_distance"] = 4.0
+        result = apply_filter(df, Column("self_nearest_edit_distance") >= 3)
+        assert len(result) == len(df)
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_fragment_list(self):
+        df = _predictor().predict_from_antigens([])
+        assert df.empty
+
+    def test_fragment_shorter_than_peptide_length(self):
+        f = AntigenFragment(fragment_id="x__00000000", sequence="MA")
+        df = _predictor(lengths=[9]).predict_from_antigens([f])
+        # No 9-mers fit in a 2-aa sequence
+        assert df.empty or (df["peptide"].str.len() == 9).sum() == 0
+
+    def test_reset_index(self):
+        f = AntigenFragment.from_variant(
+            sequence="MAAVTDVGMAV",
+            mutation_start=10, mutation_end=11, inframe=True,
+        )
+        df = _predictor().predict_from_antigens([f])
+        # Index should be clean 0..N-1
+        assert list(df.index) == list(range(len(df)))

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -1,5 +1,6 @@
 from .predictor import TopiaryPredictor
 from .ranking import (
+    self_nearest,
     Affinity,
     BinOp,
     BoolOp,
@@ -40,12 +41,14 @@ from .sequence_helpers import (
     contains_mutant_residues,
     protein_subsequences_around_mutations,
 )
+from .antigen import AntigenFragment, make_fragment_id
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
+from .io_antigen import read_antigens, write_antigens, iter_antigens
 from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -79,6 +82,7 @@ __all__ = [
     "median",
     "minimum",
     "parse",
+    "self_nearest",
     "self_scope",
     "shuffled",
     "wt",
@@ -86,6 +90,11 @@ __all__ = [
     "check_padding_around_mutation",
     "peptide_mutation_interval",
     "protein_subsequences_around_mutations",
+    "AntigenFragment",
+    "make_fragment_id",
+    "read_antigens",
+    "write_antigens",
+    "iter_antigens",
     "Metadata",
     "detect_lens_version",
     "read_csv",

--- a/topiary/antigen.py
+++ b/topiary/antigen.py
@@ -1,0 +1,416 @@
+"""AntigenFragment — a universal record for a protein/peptide sequence
+with source-type, target-region, and comparator metadata.
+
+Designed to carry antigens from any origin (somatic variant, structural
+variant, ERV, CTA, viral, allergen, autoantigen, synthetic) through a
+single prediction pipeline and into downstream tools (vaxrank, etc.)
+without losing provenance or comparator information.
+
+This module defines only the data model + helpers.  IO, prediction,
+and format-specific loaders live in sibling modules.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+
+# =============================================================================
+# AntigenFragment
+# =============================================================================
+
+
+@dataclass(frozen=True, eq=False)
+class AntigenFragment:
+    """A protein/peptide sequence with source-type, target-region, and
+    comparator metadata.
+
+    Parameters
+    ----------
+    fragment_id : str
+        Canonical identity.  Convention is
+        ``{readable_prefix}__{short_hash}`` — see :func:`make_fragment_id`.
+        Two fragments with the same ``fragment_id`` are treated as the
+        same fragment (equality and hash key on this field alone).
+    source_type : str, optional
+        Free-form biological category (e.g. ``"variant:snv"``,
+        ``"sv:fusion"``, ``"erv"``, ``"viral:hpv16"``,
+        ``"allergen:peanut"``, ``"cta"``, ``"autoantigen"``,
+        ``"synthetic"``).  Used for filtering and display; never
+        interpreted by Topiary.  See ``docs/antigens.md`` for the
+        recommended (not enforced) vocabulary.
+    sequence : str
+        The antigen's protein / peptide sequence.  Sliding-window scans
+        produced by the predictor run over this string.
+    reference_sequence : str, optional
+        A canonical reference sequence (Ensembl/RefSeq, reference strain,
+        reference allergen isoform) to diff against.  ``None`` when no
+        natural reference exists (ERV, CTA, pure self, synthetic).
+    germline_sequence : str, optional
+        A patient-specific (or strain-specific) baseline that may differ
+        from ``reference_sequence`` due to polymorphism.  The DSL's
+        ``wt.*`` scope reads germline if present, otherwise falls back
+        to reference.  Typically populated only for somatic-variant and
+        autoantigen workflows.
+    target_intervals : list of (int, int), optional
+        Half-open intervals within ``sequence`` considered targetable /
+        distinguishing.  Meaning depends on ``source_type``:
+        for variants the mutated residues; for fusions the junction; for
+        splice the residues downstream of a novel junction; for ERVs and
+        CTAs the non-self regions (where "self" is whatever the producer
+        cares about).  ``None`` = unspecified (downstream can treat as
+        "whole sequence").  Empty list = explicitly nothing.
+    variant, effect, effect_type : str, optional
+        Variant-level provenance when applicable.  ``variant`` is a
+        free-form identifier (``chr:pos:ref>alt``, HGVS, strain name);
+        ``effect`` is typically HGVS protein notation; ``effect_type``
+        is a coarse label (``Substitution``, ``FrameShift``, etc.).
+    gene, gene_id, transcript_id : str, optional
+        Source gene / transcript identifiers.
+    gene_expression, transcript_expression : float, optional
+        Expression evidence carried forward into prediction rows.
+    annotations : dict
+        Tool-specific signals that don't fit the above fields.
+        Serialized as JSON in TSV IO; carried through prediction.
+    """
+
+    fragment_id: str
+
+    source_type: Optional[str] = None
+
+    sequence: str = ""
+    reference_sequence: Optional[str] = None
+    germline_sequence: Optional[str] = None
+
+    target_intervals: Optional[list] = None  # list[tuple[int, int]] | None
+
+    variant: Optional[str] = None
+    effect: Optional[str] = None
+    effect_type: Optional[str] = None
+    gene: Optional[str] = None
+    gene_id: Optional[str] = None
+    transcript_id: Optional[str] = None
+
+    gene_expression: Optional[float] = None
+    transcript_expression: Optional[float] = None
+
+    annotations: dict = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Identity: fragment_id is the canonical key.  Using all-field eq
+    # would trip over unhashable list/dict members; keying on
+    # fragment_id also matches the intent that id is a stable
+    # content-derived handle.
+    # ------------------------------------------------------------------
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, AntigenFragment)
+            and self.fragment_id == other.fragment_id
+        )
+
+    def __hash__(self):
+        return hash(self.fragment_id)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def effective_baseline(self) -> Optional[str]:
+        """Sequence the DSL's ``wt.*`` scope reads.
+
+        Resolution order: ``germline_sequence`` if populated, else
+        ``reference_sequence``, else ``None``.
+        """
+        if self.germline_sequence is not None:
+            return self.germline_sequence
+        return self.reference_sequence
+
+    @property
+    def has_target(self) -> bool:
+        """True iff ``target_intervals`` names at least one interval."""
+        return bool(self.target_intervals)
+
+    # ------------------------------------------------------------------
+    # Geometry
+    # ------------------------------------------------------------------
+
+    def peptide_overlaps_target(self, peptide_start: int, peptide_length: int) -> bool:
+        """Whether the window ``[peptide_start, peptide_start+peptide_length)``
+        overlaps any target interval.
+
+        Returns ``False`` when ``target_intervals is None`` (unspecified —
+        downstream code decides whether to treat as "whole sequence")
+        or an empty list.
+        """
+        if not self.target_intervals:
+            return False
+        p_end = peptide_start + peptide_length
+        for t_start, t_end in self.target_intervals:
+            if peptide_start < t_end and t_start < p_end:
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Plain-dict representation (tuples → lists, JSON-compatible)."""
+        d = dataclasses.asdict(self)
+        if d["target_intervals"] is not None:
+            d["target_intervals"] = [list(p) for p in d["target_intervals"]]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "AntigenFragment":
+        """Construct from a plain dict (e.g. parsed JSON or a row-dict).
+
+        Missing optional fields fall back to ``None`` / empty
+        annotations.  Unknown keys are rejected to catch typos — pass
+        them through ``annotations`` instead.
+        """
+        known = {
+            "fragment_id", "source_type", "sequence",
+            "reference_sequence", "germline_sequence", "target_intervals",
+            "variant", "effect", "effect_type",
+            "gene", "gene_id", "transcript_id",
+            "gene_expression", "transcript_expression", "annotations",
+        }
+        unknown = set(d.keys()) - known
+        if unknown:
+            raise ValueError(
+                f"Unknown AntigenFragment field(s): {sorted(unknown)}. "
+                f"Move them to the annotations dict."
+            )
+        ti = d.get("target_intervals")
+        if ti is not None:
+            ti = [tuple(pair) for pair in ti]
+        return cls(
+            fragment_id=d["fragment_id"],
+            source_type=d.get("source_type"),
+            sequence=d.get("sequence", ""),
+            reference_sequence=d.get("reference_sequence"),
+            germline_sequence=d.get("germline_sequence"),
+            target_intervals=ti,
+            variant=d.get("variant"),
+            effect=d.get("effect"),
+            effect_type=d.get("effect_type"),
+            gene=d.get("gene"),
+            gene_id=d.get("gene_id"),
+            transcript_id=d.get("transcript_id"),
+            gene_expression=d.get("gene_expression"),
+            transcript_expression=d.get("transcript_expression"),
+            annotations=dict(d.get("annotations") or {}),
+        )
+
+    def to_json(self, **kwargs) -> str:
+        """JSON string. Extra kwargs are forwarded to :func:`json.dumps`
+        (e.g. ``indent=2`` for pretty-printing).
+        """
+        return json.dumps(self.to_dict(), **kwargs)
+
+    @classmethod
+    def from_json(cls, s: str) -> "AntigenFragment":
+        return cls.from_dict(json.loads(s))
+
+    # ------------------------------------------------------------------
+    # Stringification
+    # ------------------------------------------------------------------
+
+    # __repr__ stays as dataclass-generated (verbose, unambiguous — the
+    # right thing for debugging / pytest failure output).
+
+    def __str__(self) -> str:
+        """Short human-friendly summary for logs."""
+        bits = [self.fragment_id, f"{len(self.sequence)} aa"]
+        if self.source_type:
+            bits.append(self.source_type)
+        if self.target_intervals:
+            n = len(self.target_intervals)
+            bits.append(f"{n} target {'interval' if n == 1 else 'intervals'}")
+        if self.gene:
+            bits.append(f"gene={self.gene}")
+        return f"AntigenFragment({', '.join(bits)})"
+
+    # ------------------------------------------------------------------
+    # Convenience constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_variant(
+        cls,
+        *,
+        sequence: str,
+        reference_sequence: Optional[str] = None,
+        germline_sequence: Optional[str] = None,
+        mutation_start: int,
+        mutation_end: int,
+        inframe: bool,
+        variant: Optional[str] = None,
+        effect: Optional[str] = None,
+        gene: Optional[str] = None,
+        gene_id: Optional[str] = None,
+        transcript_id: Optional[str] = None,
+        **extra_kwargs,
+    ) -> "AntigenFragment":
+        """Build a fragment for a variant-derived antigen.
+
+        In-frame mutations: ``target_intervals = [(mutation_start, mutation_end)]``.
+        Frameshifts: ``target_intervals = [(mutation_start, len(sequence))]``
+        — everything downstream is novel (caller is responsible for
+        having truncated ``sequence`` at the new stop codon if desired).
+        """
+        if inframe:
+            intervals = [(mutation_start, mutation_end)]
+            source_type = extra_kwargs.pop("source_type", None) or (
+                "variant:indel" if mutation_end - mutation_start != 1 else "variant:snv"
+            )
+        else:
+            intervals = [(mutation_start, len(sequence))]
+            source_type = extra_kwargs.pop("source_type", None) or "variant:frameshift"
+        prefix = extra_kwargs.pop("fragment_prefix", None)
+        if prefix is None:
+            prefix = _default_prefix(gene, effect, variant)
+        fragment_id = make_fragment_id(prefix, sequence, variant=variant)
+        return cls(
+            fragment_id=fragment_id,
+            source_type=source_type,
+            sequence=sequence,
+            reference_sequence=reference_sequence,
+            germline_sequence=germline_sequence,
+            target_intervals=intervals,
+            variant=variant,
+            effect=effect,
+            effect_type=extra_kwargs.pop("effect_type", None),
+            gene=gene,
+            gene_id=gene_id,
+            transcript_id=transcript_id,
+            gene_expression=extra_kwargs.pop("gene_expression", None),
+            transcript_expression=extra_kwargs.pop("transcript_expression", None),
+            annotations=extra_kwargs.pop("annotations", {}) or {},
+        )
+
+    @classmethod
+    def from_junction(
+        cls,
+        *,
+        sequence: str,
+        junction_position: int,
+        novel_downstream: bool,
+        reference_sequence: Optional[str] = None,
+        germline_sequence: Optional[str] = None,
+        source_type: Optional[str] = None,
+        variant: Optional[str] = None,
+        effect: Optional[str] = None,
+        gene: Optional[str] = None,
+        gene_id: Optional[str] = None,
+        transcript_id: Optional[str] = None,
+        **extra_kwargs,
+    ) -> "AntigenFragment":
+        """Build a fragment for a fusion / splice / cryptic-exon /
+        readthrough case.
+
+        ``novel_downstream=False`` (in-frame coding-coding fusion, splice
+        junction of known exons): targets the junction residue pair only.
+
+        ``novel_downstream=True`` (splice into novel exon, coding→noncoding
+        readthrough, frameshift from junction): targets the junction
+        through the end of ``sequence``.
+        """
+        if novel_downstream:
+            intervals = [(junction_position, len(sequence))]
+        else:
+            lo = max(0, junction_position - 1)
+            hi = min(len(sequence), junction_position + 1)
+            intervals = [(lo, hi)]
+        if source_type is None:
+            source_type = "sv:fusion"
+        prefix = extra_kwargs.pop("fragment_prefix", None)
+        if prefix is None:
+            prefix = _default_prefix(gene, effect, variant) or source_type
+        fragment_id = make_fragment_id(prefix, sequence, variant=variant)
+        return cls(
+            fragment_id=fragment_id,
+            source_type=source_type,
+            sequence=sequence,
+            reference_sequence=reference_sequence,
+            germline_sequence=germline_sequence,
+            target_intervals=intervals,
+            variant=variant,
+            effect=effect,
+            effect_type=extra_kwargs.pop("effect_type", None),
+            gene=gene,
+            gene_id=gene_id,
+            transcript_id=transcript_id,
+            gene_expression=extra_kwargs.pop("gene_expression", None),
+            transcript_expression=extra_kwargs.pop("transcript_expression", None),
+            annotations=extra_kwargs.pop("annotations", {}) or {},
+        )
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+_SAFE_PREFIX_RE = re.compile(r"[^A-Za-z0-9._:\-]+")
+
+
+def _sanitize_prefix(s: str) -> str:
+    """Collapse any run of non-safe characters in *s* to a single ``_``."""
+    return _SAFE_PREFIX_RE.sub("_", s).strip("_")
+
+
+def _default_prefix(gene, effect, variant) -> str:
+    parts = []
+    for p in (gene, effect, variant):
+        if isinstance(p, str) and p:
+            parts.append(p)
+    return _sanitize_prefix("_".join(parts))
+
+
+def make_fragment_id(
+    prefix: str,
+    sequence: str,
+    *,
+    variant: Optional[str] = None,
+    hash_length: int = 8,
+) -> str:
+    """Build a stable, human-readable fragment id.
+
+    Format: ``{prefix}__{short_hash}``.  Prefix is sanitized to
+    ``[A-Za-z0-9._:-]``; runs of other characters collapse to ``_``.
+    Empty prefix yields just ``__{short_hash}``.
+
+    The hash portion is a SHA-1 prefix over ``sequence`` + ``variant``
+    (when provided), making it deterministic for the same content.
+    """
+    prefix = _sanitize_prefix(prefix or "")
+    hasher = hashlib.sha1()
+    hasher.update(sequence.encode("utf-8"))
+    if variant:
+        hasher.update(b"\x00")
+        hasher.update(variant.encode("utf-8"))
+    short = hasher.hexdigest()[:hash_length]
+    return f"{prefix}__{short}"
+
+
+# =============================================================================
+# Iteration helpers
+# =============================================================================
+
+
+def collect_annotations(fragments: Iterable[AntigenFragment]) -> set:
+    """Return the union of annotation keys across *fragments*.  Useful
+    for TSV writers deciding whether to expand known keys into columns."""
+    keys = set()
+    for f in fragments:
+        keys.update(f.annotations.keys())
+    return keys

--- a/topiary/io_antigen.py
+++ b/topiary/io_antigen.py
@@ -1,0 +1,150 @@
+"""TSV IO for :class:`AntigenFragment` collections.
+
+Format: one row per fragment.  Scalar fields map to columns of the same
+name.  ``target_intervals`` and ``annotations`` are JSON-serialized into
+their own columns; empty annotations serialize as the empty object
+``{}``, absent target_intervals serialize as empty strings.
+
+Missing columns on read fall back to field defaults.  Unknown columns
+are rejected with a clear error (catches typos; use ``annotations`` for
+tool-specific extensions).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+import pandas as pd
+
+from .antigen import AntigenFragment
+
+_COLUMNS = [
+    "fragment_id",
+    "source_type",
+    "sequence",
+    "reference_sequence",
+    "germline_sequence",
+    "target_intervals",
+    "variant",
+    "effect",
+    "effect_type",
+    "gene",
+    "gene_id",
+    "transcript_id",
+    "gene_expression",
+    "transcript_expression",
+    "annotations",
+]
+
+_COLUMN_SET = set(_COLUMNS)
+
+
+def _fragment_to_row(f: AntigenFragment) -> dict:
+    """Convert an :class:`AntigenFragment` to a flat dict suitable for
+    a TSV row (lists / dicts JSON-encoded)."""
+    row = {}
+    for col in _COLUMNS:
+        val = getattr(f, col)
+        if col == "target_intervals":
+            row[col] = json.dumps([list(p) for p in val]) if val is not None else ""
+        elif col == "annotations":
+            row[col] = json.dumps(val or {}, sort_keys=True)
+        elif val is None:
+            row[col] = ""
+        else:
+            row[col] = val
+    return row
+
+
+def _row_to_fragment(row: dict) -> AntigenFragment:
+    """Inverse of :func:`_fragment_to_row`."""
+    unknown = set(row.keys()) - _COLUMN_SET
+    if unknown:
+        raise ValueError(
+            f"Unknown antigen-TSV column(s): {sorted(unknown)}. "
+            f"Use the annotations JSON column for tool-specific fields."
+        )
+
+    def _clean(col):
+        v = row.get(col, "")
+        if v is None:
+            return None
+        if isinstance(v, float) and pd.isna(v):
+            return None
+        if isinstance(v, str) and v == "":
+            return None
+        return v
+
+    ti_raw = _clean("target_intervals")
+    if ti_raw is None:
+        target_intervals = None
+    else:
+        target_intervals = [tuple(p) for p in json.loads(ti_raw)]
+
+    ann_raw = _clean("annotations")
+    annotations = json.loads(ann_raw) if ann_raw else {}
+
+    def _num(col):
+        v = _clean(col)
+        return float(v) if v is not None else None
+
+    def _str(col):
+        v = _clean(col)
+        return str(v) if v is not None else None
+
+    fragment_id = _str("fragment_id")
+    if fragment_id is None:
+        raise ValueError("antigen TSV row is missing fragment_id")
+
+    return AntigenFragment(
+        fragment_id=fragment_id,
+        source_type=_str("source_type"),
+        sequence=_str("sequence") or "",
+        reference_sequence=_str("reference_sequence"),
+        germline_sequence=_str("germline_sequence"),
+        target_intervals=target_intervals,
+        variant=_str("variant"),
+        effect=_str("effect"),
+        effect_type=_str("effect_type"),
+        gene=_str("gene"),
+        gene_id=_str("gene_id"),
+        transcript_id=_str("transcript_id"),
+        gene_expression=_num("gene_expression"),
+        transcript_expression=_num("transcript_expression"),
+        annotations=annotations,
+    )
+
+
+def write_antigens(fragments: Iterable[AntigenFragment], path, sep: str = "\t") -> None:
+    """Write fragments to a TSV (or custom-separator) file.
+
+    Parameters
+    ----------
+    fragments : iterable of AntigenFragment
+    path : str or Path
+    sep : str
+        Column separator (default tab).
+    """
+    rows = [_fragment_to_row(f) for f in fragments]
+    df = pd.DataFrame(rows, columns=_COLUMNS)
+    df.to_csv(Path(path), sep=sep, index=False)
+
+
+def read_antigens(path, sep: str = "\t") -> List[AntigenFragment]:
+    """Read fragments from a TSV (or custom-separator) file.
+
+    Missing columns fall back to field defaults.  Unknown columns raise.
+    """
+    df = pd.read_csv(Path(path), sep=sep, dtype=object, keep_default_na=False)
+    return [_row_to_fragment(r) for r in df.to_dict(orient="records")]
+
+
+def iter_antigens(path, sep: str = "\t") -> Iterator[AntigenFragment]:
+    """Stream fragments from a file one at a time (for large inputs)."""
+    for chunk in pd.read_csv(
+        Path(path), sep=sep, dtype=object, keep_default_na=False, chunksize=1000,
+    ):
+        for record in chunk.to_dict(orient="records"):
+            yield _row_to_fragment(record)

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -447,8 +447,10 @@ class TopiaryPredictor(object):
         - ``wt_peptide`` / ``wt_peptide_length`` — derived by slicing
           ``fragment.effective_baseline`` at the mutant peptide's
           offset (germline precedence, falls back to reference).
-          ``None`` / NaN when no baseline is present or the mutant
-          peptide's coordinates don't map cleanly.
+          Only populated when the baseline is the same length as the
+          mutant sequence (substitution-compatible); indels and
+          frameshifts yield ``None`` until coordinate remapping lands.
+          ``None`` / NaN when no baseline is present.
 
         WT model predictions (``wt_value``, ``wt_score``, etc.) are
         **not populated** in this release — populate them externally
@@ -512,6 +514,11 @@ class TopiaryPredictor(object):
             base = f.effective_baseline
             if base is None:
                 return None
+            # Only meaningful for substitution-compatible fragments where
+            # mutant and baseline coordinates align 1:1.  Indels and
+            # frameshifts need explicit remapping, which PR A does not do.
+            if len(base) != len(f.sequence):
+                return None
             start = int(row["peptide_offset"])
             end = start + int(row["peptide_length"])
             if end > len(base):
@@ -535,6 +542,10 @@ class TopiaryPredictor(object):
             )
 
         df = self._apply_filter(df)
+
+        if self.only_novel_epitopes:
+            df = df[df["contains_mutant_residues"].eq(True)]
+
         return df.reset_index(drop=True)
 
     def predict_from_sequences(self, sequences):

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -423,6 +423,120 @@ class TopiaryPredictor(object):
             df = apply_sort(df, self.sort_by, sort_direction=self.sort_direction)
         return df
 
+    def predict_from_antigens(self, fragments):
+        """Predict MHC binding for peptides derived from a collection of
+        :class:`AntigenFragment`.
+
+        Each fragment's ``sequence`` is scanned with the configured
+        models' sliding windows.  Fragment-level metadata
+        (``source_type``, ``variant``, ``effect``, ``effect_type``,
+        ``gene``, ``gene_id``, ``transcript_id``,
+        ``gene_expression``, ``transcript_expression``, and every
+        annotation key) is propagated onto each prediction row.
+        ``fragment_id`` is threaded through so downstream code
+        (vaxrank, vaccine-window selection) can group peptides back to
+        their source fragment.
+
+        Additional computed columns on the output:
+        - ``overlaps_target`` (bool / NaN) — whether the peptide
+          overlaps any interval in ``fragment.target_intervals``.
+          NaN when ``target_intervals is None``.
+        - ``contains_mutant_residues`` (bool / NaN) — backwards-compat
+          alias: True iff the fragment's ``source_type`` starts with
+          ``variant`` and the peptide overlaps a target interval.
+        - ``wt_peptide`` / ``wt_peptide_length`` — derived by slicing
+          ``fragment.effective_baseline`` at the mutant peptide's
+          offset (germline precedence, falls back to reference).
+          ``None`` / NaN when no baseline is present or the mutant
+          peptide's coordinates don't map cleanly.
+
+        WT model predictions (``wt_value``, ``wt_score``, etc.) are
+        **not populated** in this release — populate them externally
+        or wait for a follow-up PR.  The DSL's ``wt.*`` scope returns
+        NaN for those columns until they're written.
+        """
+        fragments = list(fragments)
+        if not fragments:
+            return pd.DataFrame()
+
+        name_to_seq = {f.fragment_id: f.sequence for f in fragments}
+        df = self._predict_raw(name_to_seq)
+        if df.empty:
+            return df
+
+        df = df.rename(columns={"source_sequence_name": "fragment_id"})
+        # Keep source_sequence_name populated for any code path that
+        # still looks at it; fragment_id is the canonical group key.
+        df["source_sequence_name"] = df["fragment_id"]
+
+        by_id = {f.fragment_id: f for f in fragments}
+
+        def _map_attr(attr):
+            return df["fragment_id"].map(
+                lambda fid, a=attr: getattr(by_id[fid], a, None) if fid in by_id else None
+            )
+
+        for attr in (
+            "source_type", "variant", "effect", "effect_type",
+            "gene", "gene_id", "transcript_id",
+            "gene_expression", "transcript_expression",
+        ):
+            df[attr] = _map_attr(attr)
+
+        def _overlaps(row):
+            f = by_id.get(row["fragment_id"])
+            if f is None or f.target_intervals is None:
+                return None
+            return f.peptide_overlaps_target(
+                int(row["peptide_offset"]), int(row["peptide_length"])
+            )
+
+        df["overlaps_target"] = df.apply(_overlaps, axis=1)
+
+        def _contains_mutant(row):
+            f = by_id.get(row["fragment_id"])
+            if f is None or not f.source_type or not f.source_type.startswith("variant"):
+                return None
+            if f.target_intervals is None:
+                return None
+            return f.peptide_overlaps_target(
+                int(row["peptide_offset"]), int(row["peptide_length"])
+            )
+
+        df["contains_mutant_residues"] = df.apply(_contains_mutant, axis=1)
+
+        def _wt_peptide(row):
+            f = by_id.get(row["fragment_id"])
+            if f is None:
+                return None
+            base = f.effective_baseline
+            if base is None:
+                return None
+            start = int(row["peptide_offset"])
+            end = start + int(row["peptide_length"])
+            if end > len(base):
+                return None
+            return base[start:end]
+
+        df["wt_peptide"] = df.apply(_wt_peptide, axis=1)
+        df["wt_peptide_length"] = df["wt_peptide"].map(
+            lambda p: len(p) if isinstance(p, str) else None
+        )
+
+        all_annotation_keys = set()
+        for f in fragments:
+            all_annotation_keys.update(f.annotations.keys())
+        for key in sorted(all_annotation_keys):
+            if key in df.columns:
+                continue
+            df[key] = df["fragment_id"].map(
+                lambda fid, k=key: by_id[fid].annotations.get(k)
+                if fid in by_id else None
+            )
+
+        df = self._apply_filter(df)
+        return df.reset_index(drop=True)
+
     def predict_from_sequences(self, sequences):
         """
         Predict MHC ligands for sub-sequences of each input sequence.

--- a/topiary/ranking/__init__.py
+++ b/topiary/ranking/__init__.py
@@ -56,6 +56,7 @@ from .nodes import (
     mean,
     median,
     minimum,
+    self_nearest,
     self_scope,
     shuffled,
     wt,
@@ -92,6 +93,7 @@ __all__ = [
     "wt",
     "shuffled",
     "self_scope",
+    "self_nearest",
     # Aggregations
     "mean",
     "geomean",

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -483,7 +483,8 @@ class Field(DSLNode):
         Exact match against ``predictor_version`` (string-compared).
     scope : str
         Column-name prefix for alternate peptide contexts
-        (``""``, ``"wt_"``, ``"shuffled_"``, ``"self_"``).
+        (``""``, ``"wt_"``, ``"shuffled_"``, ``"self_"``,
+        ``"self_nearest_"``).
     """
 
     __slots__ = ("kind", "field", "method", "version", "scope")
@@ -1363,7 +1364,7 @@ Processing = KindAccessor(Kind.antigen_processing)
 # Scope — alternate peptide context (wt, shuffled, self)
 # =============================================================================
 
-_CONTEXT_KEYWORDS = {"wt", "shuffled", "self"}
+_CONTEXT_KEYWORDS = {"wt", "shuffled", "self", "self_nearest"}
 
 
 class Scope:

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -114,7 +114,15 @@ _GROUP_KEYS = ["source_sequence_name", "peptide", "peptide_offset", "allele"]
 _GROUP_KEYS_VARIANT = ["variant", "peptide", "peptide_offset", "allele"]
 
 
+_GROUP_KEYS_FRAGMENT = ["fragment_id", "peptide", "peptide_offset", "allele"]
+
+
 def _pick_group_keys(df):
+    # fragment_id is the most specific identity (from predict_from_antigens);
+    # variant is for the legacy varcode pipeline; source_sequence_name is the
+    # generic fallback.
+    if "fragment_id" in df.columns:
+        return list(_GROUP_KEYS_FRAGMENT)
     if "variant" in df.columns:
         return list(_GROUP_KEYS_VARIANT)
     return list(_GROUP_KEYS)
@@ -1391,6 +1399,14 @@ class Scope:
 wt = Scope("wt")
 shuffled = Scope("shuffled")
 self_scope = Scope("self")
+
+# Reserved DSL scope for "nearest-self healthy-tissue peptide" data.
+# Topiary does not compute these columns — producers populate them
+# externally (via BLAST / edit distance against a healthy-tissue
+# proteome, with a producer-chosen definition of "self").  The scope
+# reads ``self_nearest_*`` columns; when absent, evaluates to NaN.
+# See docs/antigens.md for the reserved column namespace.
+self_nearest = Scope("self_nearest")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR A of the multi-source antigen unification ([#102](https://github.com/openvax/topiary/issues/102)). Core abstraction, no upstream-tool loaders — those come in follow-up PRs.

`AntigenFragment` carries antigens from any origin (somatic / structural variants, ERVs, CTAs, viral, allergen, autoantigen, synthetic) with identity, source-type, target-region geometry, and reference/germline comparators — designed so **vaxrank can do vaccine-window selection** on the same objects, not just epitope prediction.

### What's in

- `topiary/antigen.py` — dataclass + `make_fragment_id` + `from_variant` / `from_junction` classmethods + serialization helpers
- `topiary/io_antigen.py` — TSV IO with JSON-encoded list/dict columns
- `TopiaryPredictor.predict_from_antigens(fragments)` — propagates all fragment metadata (including annotations) to prediction rows; threads `fragment_id` through for downstream grouping; emits `overlaps_target`; derives `wt_peptide` from `effective_baseline`
- `self_nearest` reserved DSL scope for cross-reactivity filtering (columns populated externally; Topiary doesn't ship a database or compute them)
- `_pick_group_keys` now prefers `fragment_id` > `variant` > `source_sequence_name`
- `docs/antigens.md` — source_type vocabulary, target_interval geometry per origin, reference vs germline semantics, self_nearest column namespace
- 63 new tests; 939 total passing

### Design decisions reached in discussion

- **Free-form `source_type`**, recommended vocabulary documented (variants, SVs, ERVs, CTAs, viral, allergen, autoantigen, synthetic). Topiary never interprets; producers use whatever string fits.
- **`target_intervals` as a list** not a scalar — tandem duplications need two breakpoint intervals, ERVs may need complement-of-self-regions, etc. Producer computes the geometry; Topiary carries it.
- **Germline takes precedence over reference** via `effective_baseline` property; both optional; `None` falls through to NaN in the DSL.
- **Fragment id format** `{readable_prefix}__{short_hash}` — SHA-1 of content for determinism, readable prefix for debugging.
- **Identity keyed on `fragment_id`** alone (not all-field equality) — avoids unhashable-list/dict issue and matches "id is content-derived handle" intent.
- **`self_nearest` scope reserved but compute deferred** — producers populate `self_nearest_*` columns with their own BLAST or edit-distance pipeline.

### Not in this PR (follow-ups)

- WT model predictions via a second prediction pass (currently `wt_peptide` is derived but `wt.Affinity.score` still returns NaN)
- Refactor existing `predict_from_variants` path onto `AntigenFragment`s (PR B)
- Format-specific fragment loaders — LENS / pVACseq / Isovar / Exacto (each ~50-100 lines on top of this)

## Test plan

- [x] `./test.sh` — 939 passed, 1 skipped
- [x] `./lint.sh` — clean
- [ ] CI green on this PR