### PR TITLE
Pin TopiaryPredictor bare-predictor auto-wrap — closes #127

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -49,6 +49,24 @@ def test_no_models_raises():
         TopiaryPredictor()
 
 
+def test_bare_predictor_instance_autowraps():
+    """``models=`` accepts a bare mhctools predictor instance (no list)."""
+    instance = RandomBindingPredictor(
+        alleles=["HLA-A*02:01"], default_peptide_lengths=[9],
+    )
+    predictor = TopiaryPredictor(models=instance)
+    assert predictor.models == [instance]
+    df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+    assert len(df) > 0
+
+
+def test_bare_predictor_class_autowraps():
+    """``models=`` accepts a bare predictor class (no list)."""
+    predictor = TopiaryPredictor(models=RandomBindingPredictor, alleles=["A0201"])
+    assert len(predictor.models) == 1
+    assert isinstance(predictor.models[0], RandomBindingPredictor)
+
+
 # ---------------------------------------------------------------------------
 # String model names
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #127 asked for \`TopiaryPredictor(models=bare_predictor)\` to work without list-wrapping. Investigating found the behavior is **already in place** at \`topiary/predictor.py:421-422\` — any non-list \`models=\` value gets wrapped, and the docstring already documents the bare-instance form.

This PR adds two regression tests so a future refactor can't silently revert the auto-wrap:

- \`test_bare_predictor_instance_autowraps\` — passes a bare \`RandomBindingPredictor()\` instance, verifies \`predictor.models == [instance]\` and an end-to-end prediction succeeds.
- \`test_bare_predictor_class_autowraps\` — passes a bare class + \`alleles=\`, verifies the class is instantiated into a single-element \`models\` list.

No code change. No release needed — v5.4.0 already supports this.

## Test plan

- [x] \`python -m pytest tests/test_coverage_gaps.py::test_bare_predictor_instance_autowraps tests/test_coverage_gaps.py::test_bare_predictor_class_autowraps\` — 2 passed locally.
- [ ] CI green.