### PR TITLE
Add CachedPredictor — predictions-as-data core (part 1 of #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## 5.5.0
+
+**New feature — `CachedPredictor`:**
+
+- Pluggable prediction source (part 1 of #128) that loads MHC binding
+  predictions from a pre-computed table and plugs into
+  `TopiaryPredictor(models=…)` alongside live mhctools predictors.
+  Use cases: reproducibility, iterating on filters/ranking without
+  rerunning the predictor, per-allele / per-sample parallel
+  predictions, ingesting output from tools topiary doesn't natively
+  run.
+- Loaders shipped: `CachedPredictor.from_dataframe`,
+  `from_topiary_output` (Parquet / TSV), `from_tsv` (generic with
+  column mapping), `from_mhcflurry` (maps `mhcflurry_*` columns onto
+  canonical names).
+- NetMHCpan / NetMHC / NetMHCstabpan / NetMHCIIpan / NetMHCcons
+  loaders are queued for a follow-up PR.
+- Sharding (`concat` / `from_directory`) is queued for a separate
+  follow-up.
+
+**Version invariant:**
+
+- A single `CachedPredictor` holds exactly one
+  `(prediction_method_name, predictor_version)` pair; `None` / `NaN`
+  / empty-string values are rejected at construction. Mixing versions
+  would produce outputs that pass downstream filters invisibly, so
+  the invariant is enforced everywhere (load, fallback attach, concat).
+- Explicit opt-in equivalence: pass `also_accept_versions={"…", …}`
+  when two labels really are interchangeable (rc → final, timestamp-
+  only model-data reflashes).
+
+**mhcflurry-specific version composition:**
+
+- New `topiary.mhcflurry_composite_version()` helper discovers the
+  locally-installed mhcflurry package version plus its active model
+  release and returns a composite string like `"2.2.1+release-2.2.0"`.
+  `CachedPredictor.from_mhcflurry(path)` uses it automatically when
+  no explicit `predictor_version` is passed — users never enumerate
+  model bundles manually.
+
+**Fallback mode:**
+
+- Pass `fallback=<live_predictor>` to delegate cache misses; results
+  are merged back into the cache so subsequent queries serve locally.
+  No separate flag — caching fallback hits is always right for the
+  batch-prediction workload.
+- Pure read-through: `CachedPredictor(fallback=p)` with no df starts
+  empty; identity is discovered from the fallback's first output.
+
+**Documentation:**
+
+- New `docs/cached.md` covering the full surface.
+- `CachedPredictor` section added to `docs/api.md`.
+- Subsection in `docs/quickstart.md`.
+- README has a top-level "Cached predictions" section.
+- Feature list in `docs/index.md` updated.
+
+**Tests:**
+
+- 38 new tests in `tests/test_cached_predictor.py` (up from 0),
+  covering construction, version invariant (mixed rows, null rejection,
+  name/version round-trip as string), predict_peptides +
+  predict_proteins sliding-window, fallback hit + miss + version
+  mismatch + empty-cache identity discovery, `also_accept_versions`,
+  all four loaders, `mhcflurry_composite_version` via stubbed
+  mhcflurry module (no tensorflow/libomp collisions), and
+  integration with `TopiaryPredictor(models=cache)`.
+- Full suite: 1090 passed (up from 1052), 3 skipped.
+
+**Related upstream issue:**
+
+- Filed `openvax/mhctools#193` — `predict_peptides_dataframe` misses
+  `predictor_version` / `kind` / `value` columns returned by
+  `predict_proteins_dataframe`. `CachedPredictor` currently backfills
+  the gap internally; can simplify once the mhctools asymmetry is
+  resolved.
+
 ## 5.4.0
 
 **Breaking rename (no back-compat alias):**

--- a/README.md
+++ b/README.md
@@ -439,6 +439,36 @@ Remove peptides found in reference proteomes — for tumor-specific or pathogen-
 --exclude-mode substring             # "substring" (default) or "exact"
 ```
 
+## Cached predictions
+
+Skip the live predictor by loading pre-computed scores into a
+`CachedPredictor`, then passing it to `TopiaryPredictor(models=…)`.
+Useful for reproducibility, iterating on filters/ranking without
+paying the predictor cost, or ingesting predictions from a tool
+topiary doesn't natively run.
+
+```python
+from topiary import CachedPredictor, TopiaryPredictor
+
+# From topiary's own saved output, mhcflurry CSV,
+# or a generic TSV/CSV with column mapping.
+cache = CachedPredictor.from_topiary_output("run.parquet")
+# cache = CachedPredictor.from_mhcflurry("mhcflurry.csv")
+# cache = CachedPredictor.from_tsv("third_party.tsv", columns={...},
+#                                  prediction_method_name="netchop",
+#                                  predictor_version="3.1")
+
+predictor = TopiaryPredictor(models=cache)
+df = predictor.predict_from_variants(variants)
+```
+
+Every cache holds exactly one `(predictor_name, predictor_version)`
+pair — mixing versions is rejected. mhcflurry's composite version
+(package + model bundle) is auto-composed from the local install;
+users never enumerate bundles manually. See
+[docs/cached.md](docs/cached.md) for full detail, including
+cache-plus-fallback mode and opt-in version equivalence.
+
 ## MHC prediction models
 
 Specify one or more predictors with `--mhc-predictor` and alleles with `--mhc-alleles`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,32 @@
 | `predict_from_variants(variants)` | VariantCollection | Variant pipeline (builds `ProteinFragment`s internally and delegates). |
 | `predict_from_mutation_effects(effects)` | EffectCollection | Same as `predict_from_variants` but starting from pre-computed effects. |
 
+## CachedPredictor
+
+Drop-in replacement for a live predictor that serves scores from a
+pre-computed table. Pass as `models=cache` to `TopiaryPredictor`. See
+[Cached Predictions](cached.md) for full detail.
+
+| Loader | Source |
+|--------|--------|
+| `CachedPredictor.from_topiary_output(path)` | Parquet / TSV / CSV previously written from a topiary run. |
+| `CachedPredictor.from_mhcflurry(path)` | mhcflurry-predict CSV output. `predictor_version` auto-composed from the installed mhcflurry when omitted. |
+| `CachedPredictor.from_tsv(path, columns=..., prediction_method_name=..., predictor_version=...)` | Generic tab- or comma-delimited. |
+| `CachedPredictor.from_dataframe(df, ...)` | In-memory DataFrame. |
+| `CachedPredictor(fallback=live_predictor)` | Empty cache, lazy identity discovery — pure read-through over a live model. |
+
+Constructor-level knobs:
+
+| Parameter | Description |
+|-----------|-------------|
+| `fallback` | Live predictor to route misses through. Result is merged back into the cache. |
+| `also_accept_versions` | Set of version strings treated as interchangeable with the cache's own version (opt-in equivalence for rc → final, etc.). |
+
+Helper: `topiary.mhcflurry_composite_version()` returns
+`"<package_version>+release-<model_release>"` for the locally-installed
+mhcflurry. Automatically used by `from_mhcflurry` when no explicit
+`predictor_version` is passed.
+
 ## Kind accessors
 
 | Accessor | Kind | Default field |

--- a/docs/cached.md
+++ b/docs/cached.md
@@ -1,0 +1,219 @@
+# Cached predictions
+
+Running an MHC predictor twice on the same peptide is wasted work.
+`CachedPredictor` serves predictions from a pre-computed table — an
+external predictor's output, a previous topiary run, or shards from
+parallel jobs — and plugs into `TopiaryPredictor(models=…)` the same
+way a live predictor does.
+
+Use it when you want to:
+
+- Iterate on filters / ranking / the DSL without re-running a slow predictor.
+- Pin scores for reproducibility (papers, benchmarks).
+- Predict per-allele / per-sample in parallel jobs, persist each shard, merge later.
+- Ingest predictions from a tool topiary doesn't natively run.
+
+## Basic usage
+
+Load a cache, pass it as the model to `TopiaryPredictor`, go:
+
+```python
+from topiary import CachedPredictor, TopiaryPredictor
+
+cache = CachedPredictor.from_topiary_output("run.parquet")
+predictor = TopiaryPredictor(models=cache)
+df = predictor.predict_from_variants(variants)
+```
+
+The cache answers `predict_proteins_dataframe` and
+`predict_peptides_dataframe` calls from the table, so every
+`predict_from_*` method on `TopiaryPredictor` works unchanged.
+
+## Loaders
+
+### From topiary's own prediction output
+
+Round-trip a prior `TopiaryPredictor` run through Parquet (preferred)
+or TSV:
+
+```python
+# Save
+first_run_df.to_parquet("run.parquet", index=False)
+
+# Reload on subsequent iterations
+cache = CachedPredictor.from_topiary_output("run.parquet")
+```
+
+Schema: every column `_predict_raw*` produces is preserved. Topiary
+overlay columns (`fragment_id`, `wt_peptide`, etc.) are kept in the
+file but ignored on lookup — the cache is the predictor output, not
+the full pipeline output.
+
+### From mhcflurry output
+
+```python
+cache = CachedPredictor.from_mhcflurry("mhcflurry_predictions.csv")
+```
+
+The loader maps mhcflurry's `mhcflurry_affinity` /
+`mhcflurry_affinity_percentile` / `mhcflurry_presentation_score`
+columns onto topiary's canonical `affinity` / `percentile_rank` /
+`score`. `predictor_version` is auto-composed from the installed
+mhcflurry — see [mhcflurry version composition](#mhcflurry-version-composition)
+below.
+
+### Generic TSV / CSV with column mapping
+
+For any tab- or comma-delimited file that doesn't match a format
+topiary ships a dedicated loader for:
+
+```python
+cache = CachedPredictor.from_tsv(
+    "third_party.tsv",
+    columns={
+        "peptide": "Peptide",
+        "allele": "HLA",
+        "affinity": "IC50_nM",
+        "percentile_rank": "Rank%",
+    },
+    prediction_method_name="netchop",
+    predictor_version="3.1",
+)
+```
+
+`columns` maps canonical cache columns to the column names in your
+file. `prediction_method_name` and `predictor_version` are required
+when the file doesn't embed that identity.
+
+Pass `sep=","` for CSV files.
+
+### From an in-memory DataFrame
+
+```python
+cache = CachedPredictor.from_dataframe(
+    df,
+    prediction_method_name="custom",
+    predictor_version="v7",
+)
+```
+
+For programmatic construction — tests, scripts that built predictions
+some other way, or intermediates in a larger pipeline.
+
+## Version invariant
+
+**A single `CachedPredictor` holds predictions from exactly one
+`(prediction_method_name, predictor_version)` pair.** Scores from
+different model versions aren't interchangeable — even percentile
+ranks aren't directly comparable across versions. Mixing them would
+produce an output that passes every downstream filter invisibly.
+
+Enforcement:
+
+- **On construction**: a DataFrame with multiple `(name, version)`
+  pairs raises. `None` / `NaN` / empty-string values are also
+  rejected — silent "I don't know" would mask the invariant.
+- **On fallback attachment** (below): the fallback's `(name, version)`
+  must equal the cache's, verified on the first fallback call.
+- **On concat / `from_directory`** (sharding — upcoming): every shard
+  must agree.
+
+### Explicit opt-in equivalence
+
+Sometimes two similar versions do produce identical predictions —
+release candidate → final, or a timestamp-only model-data reflash.
+Opt in explicitly:
+
+```python
+cache = CachedPredictor.from_mhcflurry(
+    "path.csv",
+    predictor_version="2.2.0rc2",
+    also_accept_versions={"2.2.0rc1", "2.2.0"},
+)
+```
+
+A fallback or shard passes if its version equals the cache's *or* is
+in `also_accept_versions`. Names are still strict — mixing mhcflurry
+and NetMHCpan is a real type mismatch, not a version wiggle.
+
+## mhcflurry version composition
+
+Unlike NetMHCpan (which bakes models into the binary), mhcflurry
+fetches model weights separately via `mhcflurry-downloads fetch`.
+Two systems on the same mhcflurry *package* version can produce
+different predictions if they have different model bundles installed.
+`predictor_version` must capture both.
+
+`topiary.mhcflurry_composite_version()` introspects the installed
+mhcflurry and returns a composite string like
+`"2.2.1+release-2.2.0"`. `CachedPredictor.from_mhcflurry(path)`
+calls it automatically when you omit `predictor_version` — **you
+never have to enumerate model bundles manually**:
+
+```python
+# Auto-composed from the local install
+cache = CachedPredictor.from_mhcflurry("predictions.csv")
+
+# Explicit override if you want a custom label
+cache = CachedPredictor.from_mhcflurry(
+    "predictions.csv",
+    predictor_version="my-project-20260414",
+)
+```
+
+The helper raises with a clear message if mhcflurry isn't installed
+or no model release is configured.
+
+Other tools (NetMHCpan, NetMHCIIpan, etc.) don't need this — their
+binary version is their full identity.
+
+## Fallback: delegate misses to a live predictor
+
+If you want a cache that falls back to a live predictor for peptides
+not yet in the table:
+
+```python
+from mhctools import MHCflurry
+live = MHCflurry(alleles=[...])
+
+cache = CachedPredictor.from_mhcflurry(
+    "partial.csv",
+    fallback=live,
+)
+
+predictor = TopiaryPredictor(models=cache)
+df = predictor.predict_from_variants(variants)   # misses delegate
+```
+
+Semantics:
+
+- **Miss routed to `fallback`**, and the fallback's output is merged
+  into the cache so subsequent queries for the same
+  `(peptide, allele, peptide_length)` serve locally. Caching hits
+  is always the right default — there's no separate flag.
+- **Same version invariant**: the fallback's `(name, version)` must
+  equal the cache's (or be in `also_accept_versions`), checked on the
+  first fallback call.
+- **Pure read-through mode** — empty cache, fallback-only — is
+  supported: `CachedPredictor(fallback=live)`. The cache starts
+  empty; identity is discovered from the fallback's first output.
+- **No fallback** (default): misses raise `KeyError` with the missed
+  peptides listed.
+
+## Persisting a cache
+
+```python
+cache.save("cache.parquet")   # or .tsv / .tsv.gz / .csv
+```
+
+Writes the cache's internal table using the same schema the loaders
+expect. Round-trips cleanly through `from_topiary_output`.
+
+## When *not* to use
+
+- You've never run the predictor on these peptides — just use the
+  live predictor directly; there's nothing to cache yet.
+- You want to mix predictions from multiple model versions in one
+  pipeline. Don't. If you think you need this, revisit whether the
+  versions are actually interchangeable; if they are, use
+  `also_accept_versions`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Predict which peptides from protein sequences will be presented by MHC molecules
 - **Peptide properties** — charge, hydrophobicity, aromaticity, manufacturability, TCR-facing residue analysis
 - **Multiple input modes** — VCF/MAF variants, FASTA, CSV, gene names, Ensembl lookups, CTA gene sets, LENS reports
 - **Universal protein-fragment abstraction** — `ProteinFragment` carries antigens from any origin (somatic variants, structural variants, ERVs, CTAs, viral, allergen, autoantigen, synthetic) through one prediction pipeline
+- **Cached predictions** — `CachedPredictor` loads pre-computed scores (mhcflurry CSV, topiary's own output, generic TSV) so you can iterate on filters and ranking without re-running the predictor
 - **Tissue-aware exclusion** — exclude peptides from vital-organ proteomes
 - **Tab completion** — `pip install 'topiary[completion]'`
 
@@ -56,4 +57,4 @@ df = predictor.predict_from_named_sequences({
 })
 ```
 
-See the [Quickstart](quickstart.md) for more examples, [Protein Fragments](fragments.md) for the universal antigen abstraction, [Ranking DSL](ranking.md) for the expression system, and [API Reference](api.md) for full details.
+See the [Quickstart](quickstart.md) for more examples, [Protein Fragments](fragments.md) for the universal antigen abstraction, [Cached Predictions](cached.md) for running from pre-computed scores, [Ranking DSL](ranking.md) for the expression system, and [API Reference](api.md) for full details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -202,3 +202,29 @@ df = predictor.predict_from_fragments(fragments)
 # synthetic. fragment_id threads through so downstream tools (vaxrank,
 # vaccine-window selection) can group peptides back to their fragment.
 ```
+
+### From cached predictions (skip the predictor call)
+
+Use a pre-computed prediction table instead of running the predictor
+live — for reproducibility, iterating on filters/ranking without
+paying the predictor cost, or ingesting output from another tool.
+
+```python
+from topiary import CachedPredictor, TopiaryPredictor
+
+# Load from topiary's own saved output, mhcflurry CSV,
+# or a generic TSV/CSV with column mapping.
+cache = CachedPredictor.from_topiary_output("run.parquet")
+# cache = CachedPredictor.from_mhcflurry("mhcflurry.csv")
+# cache = CachedPredictor.from_tsv("third_party.tsv", columns={...},
+#                                  prediction_method_name="netchop",
+#                                  predictor_version="3.1")
+
+predictor = TopiaryPredictor(models=cache)
+df = predictor.predict_from_variants(variants)
+```
+
+Every cache holds exactly one `(predictor_name, predictor_version)`
+pair — mixing versions is rejected. Full details, including
+mhcflurry's composite-version auto-composition and cache-plus-fallback
+mode, in [Cached Predictions](cached.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - Protein Fragments: fragments.md
+  - Cached Predictions: cached.md
   - Ranking DSL: ranking.md
   - Peptide Properties: properties.md
   - Expression Semantics: expression-semantics.md

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -1,0 +1,329 @@
+"""Tests for topiary.cached.CachedPredictor — core invariants, loader
+round-trips, fallback + version enforcement, and integration with
+:class:`TopiaryPredictor`."""
+
+import pandas as pd
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import CachedPredictor, TopiaryPredictor
+
+
+ALLELES = ["HLA-A*02:01"]
+
+
+def _row(
+    peptide="SIINFEKLA",
+    allele="HLA-A*02:01",
+    *,
+    score=0.5,
+    affinity=150.0,
+    percentile_rank=2.0,
+    predictor_name="random",
+    predictor_version="1.0",
+):
+    return {
+        "peptide": peptide,
+        "allele": allele,
+        "peptide_length": len(peptide),
+        "score": score,
+        "affinity": affinity,
+        "percentile_rank": percentile_rank,
+        "prediction_method_name": predictor_name,
+        "predictor_version": predictor_version,
+    }
+
+
+def _df(rows):
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Construction + invariant
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_dataframe_minimal(self):
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        assert cache.prediction_method_name == "random"
+        assert cache.predictor_version == "1.0"
+        assert cache.alleles == ["HLA-A*02:01"]
+        assert cache.default_peptide_lengths == [9]
+
+    def test_from_dataframe_backfills_from_args(self):
+        df = _df([_row()]).drop(
+            columns=["prediction_method_name", "predictor_version"],
+        )
+        cache = CachedPredictor.from_dataframe(
+            df,
+            prediction_method_name="mhcflurry",
+            predictor_version="2.1.0",
+        )
+        assert cache.prediction_method_name == "mhcflurry"
+        assert cache.predictor_version == "2.1.0"
+
+    def test_from_dataframe_derives_peptide_length(self):
+        df = _df([_row()]).drop(columns=["peptide_length"])
+        cache = CachedPredictor.from_dataframe(df)
+        assert cache.default_peptide_lengths == [9]
+
+    def test_missing_required_columns_raises(self):
+        df = _df([_row()]).drop(columns=["prediction_method_name"])
+        with pytest.raises(ValueError, match="missing required columns"):
+            CachedPredictor(df)
+
+    def test_empty_df_raises(self):
+        df = pd.DataFrame(columns=list(_row().keys()))
+        with pytest.raises(ValueError, match="empty DataFrame"):
+            CachedPredictor(df)
+
+
+class TestVersionInvariant:
+    def test_mixed_versions_reject(self):
+        rows = [
+            _row(peptide="SIINFEKLA", predictor_version="1.0"),
+            _row(peptide="SIINFEKLB", predictor_version="1.1"),
+        ]
+        with pytest.raises(ValueError, match="multiple"):
+            CachedPredictor(_df(rows))
+
+    def test_mixed_predictor_names_reject(self):
+        rows = [
+            _row(peptide="SIINFEKLA", predictor_name="random"),
+            _row(peptide="SIINFEKLB", predictor_name="mhcflurry"),
+        ]
+        with pytest.raises(ValueError, match="multiple"):
+            CachedPredictor(_df(rows))
+
+    def test_version_preserved_in_output_rows(self):
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert (out["prediction_method_name"] == "random").all()
+        assert (out["predictor_version"] == "1.0").all()
+
+
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+
+class TestPredictPeptides:
+    def test_hit_returns_row(self):
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert len(out) == 1
+        assert out.iloc[0]["peptide"] == "SIINFEKLA"
+        assert out.iloc[0]["affinity"] == 150.0
+
+    def test_miss_raises_without_fallback(self):
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        with pytest.raises(KeyError, match="missed"):
+            cache.predict_peptides_dataframe(["QQQQQQQQQ"])
+
+    def test_multiple_alleles_cross_product(self):
+        rows = [
+            _row(peptide="SIINFEKLA", allele="HLA-A*02:01"),
+            _row(peptide="SIINFEKLA", allele="HLA-B*07:02"),
+            _row(peptide="GILGFVFTL", allele="HLA-A*02:01"),
+            _row(peptide="GILGFVFTL", allele="HLA-B*07:02"),
+        ]
+        cache = CachedPredictor.from_dataframe(_df(rows))
+        out = cache.predict_peptides_dataframe(["SIINFEKLA", "GILGFVFTL"])
+        assert len(out) == 4
+        assert set(out["allele"]) == {"HLA-A*02:01", "HLA-B*07:02"}
+        assert set(out["peptide"]) == {"SIINFEKLA", "GILGFVFTL"}
+
+
+class TestPredictProteins:
+    def test_sliding_window_hits(self):
+        # 9-mer sliding window over 'MASIINFEKLG' → positions 0..2
+        rows = [
+            _row(peptide="MASIINFEK"),
+            _row(peptide="ASIINFEKL"),
+            _row(peptide="SIINFEKLG"),
+        ]
+        cache = CachedPredictor.from_dataframe(_df(rows))
+        out = cache.predict_proteins_dataframe({"prot": "MASIINFEKLG"})
+        assert len(out) == 3
+        assert sorted(out["offset"].tolist()) == [0, 1, 2]
+        assert (out["source_sequence_name"] == "prot").all()
+
+    def test_sliding_window_miss_raises(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(peptide="MASIINFEK")]),
+        )
+        # Second window 'ASIINFEKL' isn't in the cache
+        with pytest.raises(KeyError):
+            cache.predict_proteins_dataframe({"prot": "MASIINFEKLG"})
+
+
+# ---------------------------------------------------------------------------
+# Fallback
+# ---------------------------------------------------------------------------
+
+
+def _matched_fallback(name="random", version=None):
+    """A live predictor whose output will match the cache's (name, version)
+    once we re-tag its output."""
+    return _TaggedRandomPredictor(
+        alleles=ALLELES,
+        default_peptide_lengths=[9],
+        predictor_name=name,
+        predictor_version=version,
+    )
+
+
+class _TaggedRandomPredictor(RandomBindingPredictor):
+    """RandomBindingPredictor that stamps caller-chosen
+    ``prediction_method_name`` / ``predictor_version`` on its output —
+    lets us test the version-match invariant deterministically."""
+
+    def __init__(self, *, predictor_name, predictor_version, **kwargs):
+        super().__init__(**kwargs)
+        self._stamp_name = predictor_name
+        self._stamp_version = predictor_version
+
+    def _stamp(self, df):
+        df = df.copy()
+        df["prediction_method_name"] = self._stamp_name
+        df["predictor_version"] = self._stamp_version
+        return df
+
+    def predict_peptides_dataframe(self, peptides):
+        return self._stamp(super().predict_peptides_dataframe(peptides))
+
+    def predict_proteins_dataframe(self, name_to_seq):
+        return self._stamp(super().predict_proteins_dataframe(name_to_seq))
+
+
+class TestFallback:
+    def test_fallback_fills_miss(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row()]),
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        out = cache.predict_peptides_dataframe(["GILGFVFTL"])
+        assert len(out) == 1
+        assert out.iloc[0]["peptide"] == "GILGFVFTL"
+
+    def test_fallback_populates_cache(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row()]),
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        cache.predict_peptides_dataframe(["GILGFVFTL"])
+        # Second call should NOT hit fallback (we can verify by
+        # observing the cache's internal df grew and contains it).
+        assert ("GILGFVFTL", "HLA-A*02:01", 9) in cache._index
+        assert len(cache._df) == 2
+
+    def test_fallback_version_mismatch_rejects(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(predictor_version="1.0")]),
+            fallback=_matched_fallback(name="random", version="2.0"),
+        )
+        with pytest.raises(ValueError, match="version mismatch"):
+            cache.predict_peptides_dataframe(["GILGFVFTL"])
+
+    def test_fallback_predictor_name_mismatch_rejects(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(predictor_name="random", predictor_version="1.0")]),
+            fallback=_matched_fallback(name="mhcflurry", version="1.0"),
+        )
+        with pytest.raises(ValueError, match="version mismatch"):
+            cache.predict_peptides_dataframe(["GILGFVFTL"])
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+class TestLoaders:
+    def test_from_topiary_output_roundtrip_tsv(self, tmp_path):
+        path = tmp_path / "cache.tsv"
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        cache.save(path)
+        reloaded = CachedPredictor.from_topiary_output(path)
+        assert reloaded.prediction_method_name == "random"
+        assert reloaded.predictor_version == "1.0"
+        out = reloaded.predict_peptides_dataframe(["SIINFEKLA"])
+        assert out.iloc[0]["affinity"] == 150.0
+
+    def test_from_topiary_output_roundtrip_parquet(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        path = tmp_path / "cache.parquet"
+        cache = CachedPredictor.from_dataframe(_df([_row()]))
+        cache.save(path)
+        reloaded = CachedPredictor.from_topiary_output(path)
+        assert reloaded.prediction_method_name == "random"
+
+    def test_from_tsv_with_column_mapping(self, tmp_path):
+        # Simulate a third-party TSV with non-canonical column names
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA",
+            "allele": "HLA-A*02:01",
+            "ic50_nM": 150.0,
+            "rank": 2.0,
+        }])
+        path = tmp_path / "third_party.tsv"
+        df.to_csv(path, sep="\t", index=False)
+        cache = CachedPredictor.from_tsv(
+            path,
+            columns={"affinity": "ic50_nM", "percentile_rank": "rank"},
+            prediction_method_name="thirdparty",
+            predictor_version="0.9",
+        )
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert out.iloc[0]["affinity"] == 150.0
+        assert out.iloc[0]["percentile_rank"] == 2.0
+
+    def test_from_mhcflurry(self, tmp_path):
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA",
+            "allele": "HLA-A*02:01",
+            "mhcflurry_affinity": 100.0,
+            "mhcflurry_affinity_percentile": 1.5,
+            "mhcflurry_presentation_score": 0.8,
+        }])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.0.6")
+        assert cache.prediction_method_name == "mhcflurry"
+        assert cache.predictor_version == "2.0.6"
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert out.iloc[0]["affinity"] == 100.0
+        assert out.iloc[0]["percentile_rank"] == 1.5
+        assert out.iloc[0]["score"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# TopiaryPredictor integration
+# ---------------------------------------------------------------------------
+
+
+class TestTopiaryPredictorIntegration:
+    def test_cache_as_model_predict_from_sequences(self):
+        # Pre-populate a cache for every 9-mer of 'MASIINFEKLGGG'
+        seq = "MASIINFEKLGGG"
+        rows = [
+            _row(peptide=seq[i:i + 9])
+            for i in range(len(seq) - 8)
+        ]
+        cache = CachedPredictor.from_dataframe(_df(rows))
+        predictor = TopiaryPredictor(models=cache)
+        df = predictor.predict_from_named_sequences({"prot": seq})
+        assert len(df) == len(seq) - 8
+        assert "peptide_offset" in df.columns
+        assert "prediction_method_name" in df.columns
+
+    def test_cache_as_model_with_fallback_fills_sequence(self):
+        # Cache has only the first 9-mer; fallback covers the rest.
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(peptide="MASIINFEK")]),
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        predictor = TopiaryPredictor(models=cache)
+        df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
+        assert len(df) == 5  # 5 sliding 9-mers over the 13-aa sequence

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -2,11 +2,13 @@
 round-trips, fallback + version enforcement, and integration with
 :class:`TopiaryPredictor`."""
 
+import numpy as np
 import pandas as pd
 import pytest
 from mhctools import RandomBindingPredictor
 
 from topiary import CachedPredictor, TopiaryPredictor
+from topiary.cached import mhcflurry_composite_version
 
 
 ALLELES = ["HLA-A*02:01"]
@@ -73,9 +75,9 @@ class TestConstruction:
         with pytest.raises(ValueError, match="missing required columns"):
             CachedPredictor(df)
 
-    def test_empty_df_raises(self):
+    def test_empty_df_and_no_fallback_raises(self):
         df = pd.DataFrame(columns=list(_row().keys()))
-        with pytest.raises(ValueError, match="empty DataFrame"):
+        with pytest.raises(ValueError, match="either .df. .* or .fallback."):
             CachedPredictor(df)
 
 
@@ -231,8 +233,173 @@ class TestFallback:
             _df([_row(predictor_name="random", predictor_version="1.0")]),
             fallback=_matched_fallback(name="mhcflurry", version="1.0"),
         )
+        with pytest.raises(ValueError, match="predictor_name mismatch"):
+            cache.predict_peptides_dataframe(["GILGFVFTL"])
+
+
+# ---------------------------------------------------------------------------
+# Null / empty version rejection
+# ---------------------------------------------------------------------------
+
+
+class TestNullVersionRejection:
+    def test_none_version_rejected(self):
+        row = _row()
+        row["predictor_version"] = None
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            CachedPredictor(_df([row]))
+
+    def test_nan_version_rejected(self):
+        row = _row()
+        row["predictor_version"] = np.nan
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            CachedPredictor(_df([row]))
+
+    def test_empty_string_version_rejected(self):
+        row = _row()
+        row["predictor_version"] = ""
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            CachedPredictor(_df([row]))
+
+    def test_none_predictor_name_rejected(self):
+        row = _row()
+        row["prediction_method_name"] = None
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            CachedPredictor(_df([row]))
+
+
+# ---------------------------------------------------------------------------
+# Empty cache + fallback — lazy identity discovery
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyCacheWithFallback:
+    def test_empty_cache_plus_fallback_discovers_identity(self):
+        cache = CachedPredictor(
+            fallback=_matched_fallback(name="random", version="3.0"),
+        )
+        # Pre-query: identity is unset
+        assert cache.prediction_method_name is None
+        assert cache.predictor_version is None
+        # First query: identity is adopted from fallback output
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert len(out) == 1
+        assert cache.prediction_method_name == "random"
+        assert cache.predictor_version == "3.0"
+
+    def test_empty_cache_plus_fallback_caches_results(self):
+        cache = CachedPredictor(
+            fallback=_matched_fallback(name="random", version="3.0"),
+        )
+        cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert ("SIINFEKLA", "HLA-A*02:01", 9) in cache._index
+
+    def test_empty_df_value_and_no_fallback_still_raises(self):
+        empty = pd.DataFrame(columns=list(_row().keys()))
+        with pytest.raises(ValueError, match="either .df. .* or .fallback."):
+            CachedPredictor(empty)
+
+
+# ---------------------------------------------------------------------------
+# Version equivalence (also_accept_versions)
+# ---------------------------------------------------------------------------
+
+
+class TestAlsoAcceptVersions:
+    def test_equivalent_version_accepted(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(predictor_version="2.2.0rc2")]),
+            fallback=_matched_fallback(name="random", version="2.2.0"),
+            also_accept_versions={"2.2.0"},
+        )
+        out = cache.predict_peptides_dataframe(["GILGFVFTL"])
+        assert len(out) == 1
+        # Cache's own identity doesn't change — only acceptance widens.
+        assert cache.predictor_version == "2.2.0rc2"
+
+    def test_non_equivalent_version_still_rejects(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(predictor_version="2.2.0rc2")]),
+            fallback=_matched_fallback(name="random", version="1.0"),
+            also_accept_versions={"2.2.0"},  # different version in set
+        )
         with pytest.raises(ValueError, match="version mismatch"):
             cache.predict_peptides_dataframe(["GILGFVFTL"])
+
+    def test_default_empty_set_is_strict(self):
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(predictor_version="2.2.0rc2")]),
+            fallback=_matched_fallback(name="random", version="2.2.0"),
+        )
+        with pytest.raises(ValueError, match="version mismatch"):
+            cache.predict_peptides_dataframe(["GILGFVFTL"])
+
+
+# ---------------------------------------------------------------------------
+# mhcflurry_composite_version helper + auto-default in from_mhcflurry
+# ---------------------------------------------------------------------------
+
+
+class TestMhcflurryCompositeVersion:
+    """Tests use stubbed mhcflurry / mhcflurry.downloads modules to
+    avoid importing tensorflow (which collides with pandas' libomp on
+    macOS and isn't needed to verify the helper's composition logic)."""
+
+    @staticmethod
+    def _stub_mhcflurry(monkeypatch, *, version="2.2.1", release="2.2.0"):
+        import sys
+        import types
+        fake_mhcflurry = types.ModuleType("mhcflurry")
+        fake_mhcflurry.__version__ = version
+        fake_downloads = types.ModuleType("mhcflurry.downloads")
+        fake_downloads.get_current_release = lambda: release
+        fake_mhcflurry.downloads = fake_downloads
+        monkeypatch.setitem(sys.modules, "mhcflurry", fake_mhcflurry)
+        monkeypatch.setitem(sys.modules, "mhcflurry.downloads", fake_downloads)
+
+    def test_returns_composite_string(self, monkeypatch):
+        self._stub_mhcflurry(monkeypatch, version="2.2.1", release="2.2.0")
+        assert mhcflurry_composite_version() == "2.2.1+release-2.2.0"
+
+    def test_raises_when_mhcflurry_missing(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "mhcflurry", None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            mhcflurry_composite_version()
+
+    def test_raises_when_release_missing(self, monkeypatch):
+        self._stub_mhcflurry(monkeypatch, release="")
+        with pytest.raises(RuntimeError, match="no active model release"):
+            mhcflurry_composite_version()
+
+    def test_from_mhcflurry_autocomposes_version(self, monkeypatch, tmp_path):
+        self._stub_mhcflurry(monkeypatch, version="2.2.1", release="2.2.0")
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA",
+            "allele": "HLA-A*02:01",
+            "mhcflurry_affinity": 100.0,
+        }])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(path)  # no predictor_version
+        assert cache.prediction_method_name == "mhcflurry"
+        assert cache.predictor_version == "2.2.1+release-2.2.0"
+
+    def test_from_mhcflurry_explicit_version_overrides_autocompose(
+        self, monkeypatch, tmp_path,
+    ):
+        # Even with mhcflurry stubbed in, an explicit predictor_version wins.
+        self._stub_mhcflurry(monkeypatch, version="2.2.1", release="2.2.0")
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA", "allele": "HLA-A*02:01",
+            "mhcflurry_affinity": 100.0,
+        }])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(
+            path, predictor_version="custom-label",
+        )
+        assert cache.predictor_version == "custom-label"
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -41,7 +41,7 @@ from .sequence_helpers import (
     contains_mutant_residues,
     protein_subsequences_around_mutations,
 )
-from .cached import CachedPredictor
+from .cached import CachedPredictor, mhcflurry_composite_version
 from .protein_fragment import ProteinFragment, make_fragment_id
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
 from .io_protein_fragment import read_fragments, write_fragments, iter_fragments
@@ -54,6 +54,7 @@ __version__ = "5.4.0"
 __all__ = [
     "TopiaryPredictor",
     "CachedPredictor",
+    "mhcflurry_composite_version",
     "Affinity",
     "BinOp",
     "BoolOp",

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -41,6 +41,7 @@ from .sequence_helpers import (
     contains_mutant_residues,
     protein_subsequences_around_mutations,
 )
+from .cached import CachedPredictor
 from .protein_fragment import ProteinFragment, make_fragment_id
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
 from .io_protein_fragment import read_fragments, write_fragments, iter_fragments
@@ -52,6 +53,7 @@ __version__ = "5.4.0"
 
 __all__ = [
     "TopiaryPredictor",
+    "CachedPredictor",
     "Affinity",
     "BinOp",
     "BoolOp",

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -49,7 +49,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.4.0"
+__version__ = "5.5.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -1,0 +1,429 @@
+"""CachedPredictor — serve MHC binding predictions from a pre-computed table.
+
+Plugs into :class:`topiary.TopiaryPredictor` alongside live mhctools
+predictors.  Supports three producer paths:
+
+1. External predictor output files (mhcflurry CSV today; NetMHCpan
+   `.xls` and others via follow-up loaders).
+2. Topiary's own saved predictions (``predict_*`` output round-tripped
+   through Parquet / TSV).
+3. Caller-supplied DataFrames (programmatic / in-memory construction).
+
+All three load into the same internal index keyed by
+``(peptide, allele, peptide_length)``.
+
+Core invariant
+--------------
+A single :class:`CachedPredictor` holds predictions from exactly one
+``(prediction_method_name, predictor_version)`` pair — never mixes
+versions.  Enforced at load and on fallback-predictor attachment.
+
+Fallback semantics
+------------------
+- ``fallback=None`` (default): a miss raises ``KeyError``.
+- ``fallback=<predictor>``: misses delegate to the fallback, and the
+  result is merged back into the cache so subsequent queries for the
+  same ``(peptide, allele, peptide_length)`` are served locally.
+  The fallback's ``(prediction_method_name, predictor_version)`` must
+  match the cache's — verified lazily on the first fallback call.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional
+
+import pandas as pd
+
+
+# Columns a cache row must carry so the core invariant and lookup work.
+_REQUIRED_COLUMNS = (
+    "peptide", "allele", "peptide_length",
+    "prediction_method_name", "predictor_version",
+)
+
+# All columns the cache preserves on load and round-trip.
+_CACHE_COLUMNS = (
+    "peptide", "allele", "peptide_length",
+    "score", "affinity", "percentile_rank", "value", "kind",
+    "prediction_method_name", "predictor_version",
+)
+
+
+class CachedPredictor:
+    """Predictor that answers MHC binding queries from a pre-computed table.
+
+    Implements enough of the mhctools predictor protocol
+    (``predict_peptides_dataframe``, ``predict_proteins_dataframe``,
+    ``alleles``, ``default_peptide_lengths``) to drop into
+    :class:`topiary.TopiaryPredictor` as a model.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Normalized rows (one per ``(peptide, allele, peptide_length)``)
+        with at least the columns in ``_REQUIRED_COLUMNS``.
+    fallback : mhctools predictor or CachedPredictor, optional
+        If set, cache misses are delegated here and the results are
+        merged back into the cache.  Its
+        ``(prediction_method_name, predictor_version)`` must match the
+        cache's.
+    """
+
+    def __init__(self, df: pd.DataFrame, fallback=None):
+        self._df = self._normalize(df)
+        self.prediction_method_name, self.predictor_version = \
+            self._unique_version_pair(self._df)
+        self._index = self._build_index(self._df)
+        self.fallback = fallback
+        self._fallback_verified = False
+
+    # --- normalization + invariants ---------------------------------
+
+    @staticmethod
+    def _normalize(df: pd.DataFrame) -> pd.DataFrame:
+        missing = set(_REQUIRED_COLUMNS) - set(df.columns)
+        if missing:
+            raise ValueError(
+                f"CachedPredictor rows missing required columns: "
+                f"{sorted(missing)}.  Provide them in the DataFrame or "
+                f"pass predictor_name / predictor_version to the loader."
+            )
+        keep = [c for c in _CACHE_COLUMNS if c in df.columns]
+        out = df[keep].copy()
+        out["peptide"] = out["peptide"].astype(str)
+        out["allele"] = out["allele"].astype(str)
+        out["peptide_length"] = out["peptide_length"].astype(int)
+        # Version strings may look numeric ("1.0") and get coerced by
+        # pandas on TSV/CSV reload — force to str so the invariant
+        # compares the same shape on both sides of a round-trip.
+        out["prediction_method_name"] = out["prediction_method_name"].astype(str)
+        out["predictor_version"] = out["predictor_version"].astype(str)
+        return out
+
+    @staticmethod
+    def _unique_version_pair(df: pd.DataFrame) -> tuple:
+        pairs = df[["prediction_method_name", "predictor_version"]].drop_duplicates()
+        if len(pairs) == 0:
+            raise ValueError(
+                "CachedPredictor: empty DataFrame has no "
+                "(prediction_method_name, predictor_version) pair."
+            )
+        if len(pairs) > 1:
+            pair_list = ", ".join(
+                f"({r.prediction_method_name!r}, {r.predictor_version!r})"
+                for r in pairs.itertuples(index=False)
+            )
+            raise ValueError(
+                f"CachedPredictor rows span multiple "
+                f"(prediction_method_name, predictor_version) pairs: "
+                f"{pair_list}.  A single cache must hold predictions from "
+                f"exactly one model version."
+            )
+        row = pairs.iloc[0]
+        return row["prediction_method_name"], row["predictor_version"]
+
+    @staticmethod
+    def _build_index(df: pd.DataFrame) -> dict:
+        return {
+            (str(r["peptide"]), str(r["allele"]), int(r["peptide_length"])):
+                r.to_dict()
+            for _, r in df.iterrows()
+        }
+
+    # --- mhctools protocol ------------------------------------------
+
+    @property
+    def alleles(self):
+        a = set(self._df["allele"].unique().tolist())
+        if self.fallback is not None:
+            a.update(getattr(self.fallback, "alleles", []))
+        return sorted(a)
+
+    @property
+    def default_peptide_lengths(self):
+        lengths = set(int(x) for x in self._df["peptide_length"].unique().tolist())
+        if self.fallback is not None:
+            lengths.update(getattr(self.fallback, "default_peptide_lengths", []))
+        return sorted(lengths)
+
+    def _cache_alleles(self):
+        return sorted(set(self._df["allele"].unique().tolist()))
+
+    def predict_peptides_dataframe(
+        self, peptides: Iterable[str],
+    ) -> pd.DataFrame:
+        """Return one row per ``(peptide, allele)`` for each input peptide
+        crossed with every allele in the cache.
+
+        Misses go to ``self.fallback`` if set, else raise ``KeyError``.
+        """
+        peptides = [str(p) for p in peptides]
+        cache_alleles = self._cache_alleles()
+        rows = []
+        misses = []
+        for peptide in peptides:
+            length = len(peptide)
+            for allele in cache_alleles:
+                row = self._index.get((peptide, allele, length))
+                if row is None:
+                    misses.append(peptide)
+                    break  # defer: fallback call covers all alleles at once
+                rows.append(row)
+
+        if misses:
+            missed_unique = sorted(set(misses))
+            fb_rows = self._fallback_resolve(missed_unique)
+            rows.extend(fb_rows)
+
+        if not rows:
+            return pd.DataFrame(columns=list(_CACHE_COLUMNS))
+        return pd.DataFrame(rows).reindex(columns=list(_CACHE_COLUMNS))
+
+    # mhctools compat: some code paths probe for ``predict_dataframe``.
+    predict_dataframe = predict_peptides_dataframe
+
+    def predict_proteins_dataframe(
+        self, name_to_sequence: Mapping[str, str],
+    ) -> pd.DataFrame:
+        """Sliding-window lookup — generate peptides from each input
+        sequence at every ``default_peptide_lengths``, then resolve
+        through :meth:`predict_peptides_dataframe`.
+        """
+        unique_peptides = set()
+        per_peptide_positions: dict[str, list[tuple[str, int, int]]] = {}
+        for name, seq in name_to_sequence.items():
+            for length in self.default_peptide_lengths:
+                if length > len(seq):
+                    continue
+                for offset in range(len(seq) - length + 1):
+                    peptide = seq[offset:offset + length]
+                    unique_peptides.add(peptide)
+                    per_peptide_positions.setdefault(peptide, []).append(
+                        (name, offset, length)
+                    )
+
+        if not unique_peptides:
+            return pd.DataFrame(
+                columns=list(_CACHE_COLUMNS) + [
+                    "source_sequence_name", "offset",
+                ]
+            )
+        df = self.predict_peptides_dataframe(sorted(unique_peptides))
+
+        # Expand: one row per (peptide, allele) × (name, offset) matching length.
+        expanded = []
+        for _, row in df.iterrows():
+            positions = per_peptide_positions.get(row["peptide"], [])
+            for (name, offset, length) in positions:
+                if int(row["peptide_length"]) != length:
+                    continue
+                r = row.to_dict()
+                r["source_sequence_name"] = name
+                r["offset"] = offset
+                expanded.append(r)
+
+        if not expanded:
+            return pd.DataFrame(
+                columns=list(_CACHE_COLUMNS) + [
+                    "source_sequence_name", "offset",
+                ]
+            )
+        return pd.DataFrame(expanded)
+
+    # --- fallback resolution ----------------------------------------
+
+    def _fallback_resolve(self, peptides):
+        """Run the fallback on ``peptides`` (missed peptide strings),
+        verify the version invariant, merge the results into the cache,
+        and return the new row dicts for the requested peptides."""
+        if self.fallback is None:
+            missed_preview = peptides[:5]
+            extra = "" if len(peptides) <= 5 else \
+                f" (and {len(peptides) - 5} more)"
+            raise KeyError(
+                f"CachedPredictor: {len(peptides)} peptide(s) missed and "
+                f"no fallback set.  Missed peptides: {missed_preview}{extra}."
+            )
+
+        if hasattr(self.fallback, "predict_peptides_dataframe"):
+            fb_df = self.fallback.predict_peptides_dataframe(peptides)
+        elif hasattr(self.fallback, "predict_dataframe"):
+            fb_df = self.fallback.predict_dataframe(peptides)
+        else:
+            raise TypeError(
+                f"fallback does not implement predict_peptides_dataframe "
+                f"or predict_dataframe: {type(self.fallback).__name__}"
+            )
+
+        fb_df = self._conform_predictor_output(fb_df)
+        self._verify_fallback_version(fb_df)
+        new_rows = self._normalize(fb_df)
+        for _, r in new_rows.iterrows():
+            key = (
+                str(r["peptide"]), str(r["allele"]), int(r["peptide_length"]),
+            )
+            self._index[key] = r.to_dict()
+        self._df = pd.concat([self._df, new_rows], ignore_index=True) \
+            .drop_duplicates(
+                subset=["peptide", "allele", "peptide_length"], keep="last",
+            )
+        return [r.to_dict() for _, r in new_rows.iterrows()]
+
+    @staticmethod
+    def _conform_predictor_output(df: pd.DataFrame) -> pd.DataFrame:
+        """Coerce an mhctools predictor output frame into the cache
+        column conventions: ``peptide_length`` not ``length``,
+        ``prediction_method_name`` not ``predictor_name``, and
+        ``predictor_version`` populated (NaN ok — still satisfies the
+        required-column check)."""
+        df = df.copy()
+        if "peptide_length" not in df.columns and "length" in df.columns:
+            df = df.rename(columns={"length": "peptide_length"})
+        if "peptide_length" not in df.columns and "peptide" in df.columns:
+            df["peptide_length"] = df["peptide"].str.len()
+        if ("prediction_method_name" not in df.columns
+                and "predictor_name" in df.columns):
+            df = df.rename(columns={"predictor_name": "prediction_method_name"})
+        if "predictor_version" not in df.columns:
+            df["predictor_version"] = None
+        return df
+
+    def _verify_fallback_version(self, fb_df: pd.DataFrame):
+        if self._fallback_verified:
+            return
+        fb_pair = self._unique_version_pair(fb_df)
+        cache_pair = (self.prediction_method_name, self.predictor_version)
+        if fb_pair != cache_pair:
+            raise ValueError(
+                f"CachedPredictor fallback version mismatch: cache="
+                f"({cache_pair[0]!r}, {cache_pair[1]!r}), "
+                f"fallback=({fb_pair[0]!r}, {fb_pair[1]!r}).  Mixing model "
+                f"versions is not allowed — use a fallback whose "
+                f"(prediction_method_name, predictor_version) matches the "
+                f"cache."
+            )
+        self._fallback_verified = True
+
+    # --- persistence ------------------------------------------------
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return a copy of the cache as a DataFrame (cache schema)."""
+        return self._df.copy()
+
+    def save(self, path) -> None:
+        """Write the cache as Parquet (``.parquet``/``.pq``) or TSV
+        (``.tsv``, optionally ``.tsv.gz``)."""
+        path_str = str(path)
+        if path_str.endswith((".parquet", ".pq")):
+            self._df.to_parquet(path_str, index=False)
+        elif path_str.endswith((".tsv", ".tsv.gz")):
+            self._df.to_csv(path_str, sep="\t", index=False)
+        else:
+            self._df.to_csv(path_str, index=False)
+
+    # --- loaders ----------------------------------------------------
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: pd.DataFrame,
+        *,
+        prediction_method_name: Optional[str] = None,
+        predictor_version: Optional[str] = None,
+        fallback=None,
+    ) -> "CachedPredictor":
+        """Construct from an in-memory DataFrame.
+
+        ``prediction_method_name`` / ``predictor_version`` backfill
+        columns when the DataFrame doesn't already carry them — one of
+        the two sources (column or argument) must populate each of the
+        required columns.
+        """
+        df = df.copy()
+        if ("prediction_method_name" not in df.columns
+                and prediction_method_name is not None):
+            df["prediction_method_name"] = prediction_method_name
+        if ("predictor_version" not in df.columns
+                and predictor_version is not None):
+            df["predictor_version"] = predictor_version
+        if "peptide_length" not in df.columns and "length" in df.columns:
+            df = df.rename(columns={"length": "peptide_length"})
+        if "peptide_length" not in df.columns and "peptide" in df.columns:
+            df["peptide_length"] = df["peptide"].str.len()
+        return cls(df, fallback=fallback)
+
+    @classmethod
+    def from_topiary_output(
+        cls, path, *, fallback=None,
+    ) -> "CachedPredictor":
+        """Load a DataFrame previously written by topiary's prediction
+        output (Parquet or TSV/CSV).  The expected columns match
+        topiary's ``_predict_raw*`` schema; extraneous columns are
+        dropped."""
+        path_str = str(path)
+        if path_str.endswith((".parquet", ".pq")):
+            df = pd.read_parquet(path_str)
+        elif path_str.endswith((".tsv", ".tsv.gz")):
+            df = pd.read_csv(path_str, sep="\t")
+        else:
+            df = pd.read_csv(path_str)
+        return cls.from_dataframe(df, fallback=fallback)
+
+    @classmethod
+    def from_tsv(
+        cls,
+        path,
+        *,
+        columns: Optional[Mapping[str, str]] = None,
+        sep: str = "\t",
+        prediction_method_name: Optional[str] = None,
+        predictor_version: Optional[str] = None,
+        fallback=None,
+    ) -> "CachedPredictor":
+        """Generic tab- or comma-delimited loader for third-party
+        prediction output.
+
+        ``columns`` maps canonical cache column names to the column
+        names actually present in the file, e.g.
+        ``{"affinity": "ic50", "percentile_rank": "rank"}``.
+        Pass ``sep=","`` for CSV files.
+        """
+        df = pd.read_csv(path, sep=sep)
+        if columns:
+            df = df.rename(columns={v: k for k, v in columns.items()})
+        return cls.from_dataframe(
+            df,
+            prediction_method_name=prediction_method_name,
+            predictor_version=predictor_version,
+            fallback=fallback,
+        )
+
+    @classmethod
+    def from_mhcflurry(
+        cls,
+        path,
+        *,
+        predictor_version: str,
+        fallback=None,
+    ) -> "CachedPredictor":
+        """Load mhcflurry-predict CSV output.  Maps mhcflurry's
+        ``mhcflurry_affinity`` / ``mhcflurry_affinity_percentile`` /
+        ``mhcflurry_presentation_score`` columns onto the cache's
+        canonical ``affinity`` / ``percentile_rank`` / ``score``.
+
+        ``predictor_version`` is required — mhcflurry's CSV doesn't
+        embed it and the version invariant must be satisfied."""
+        df = pd.read_csv(path)
+        col_map = {}
+        if "mhcflurry_affinity" in df.columns:
+            col_map["mhcflurry_affinity"] = "affinity"
+        if "mhcflurry_affinity_percentile" in df.columns:
+            col_map["mhcflurry_affinity_percentile"] = "percentile_rank"
+        if "mhcflurry_presentation_score" in df.columns:
+            col_map["mhcflurry_presentation_score"] = "score"
+        df = df.rename(columns=col_map)
+        return cls.from_dataframe(
+            df,
+            prediction_method_name="mhcflurry",
+            predictor_version=predictor_version,
+            fallback=fallback,
+        )

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -68,13 +68,38 @@ class CachedPredictor:
         cache's.
     """
 
-    def __init__(self, df: pd.DataFrame, fallback=None):
+    def __init__(
+        self,
+        df: Optional[pd.DataFrame] = None,
+        fallback=None,
+        *,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ):
+        self.fallback = fallback
+        self.also_accept_versions = (
+            frozenset(also_accept_versions) if also_accept_versions else frozenset()
+        )
+        self._fallback_verified = False
+
+        # Empty-cache + fallback: (name, version) discovered lazily on
+        # the first fallback call.
+        if df is None or len(df) == 0:
+            if fallback is None:
+                raise ValueError(
+                    "CachedPredictor: pass either `df` (pre-loaded rows) "
+                    "or `fallback` (a live predictor).  An empty cache "
+                    "with no fallback has no way to answer queries."
+                )
+            self._df = pd.DataFrame(columns=list(_CACHE_COLUMNS))
+            self.prediction_method_name = None
+            self.predictor_version = None
+            self._index = {}
+            return
+
         self._df = self._normalize(df)
         self.prediction_method_name, self.predictor_version = \
             self._unique_version_pair(self._df)
         self._index = self._build_index(self._df)
-        self.fallback = fallback
-        self._fallback_verified = False
 
     # --- normalization + invariants ---------------------------------
 
@@ -87,6 +112,20 @@ class CachedPredictor:
                 f"{sorted(missing)}.  Provide them in the DataFrame or "
                 f"pass predictor_name / predictor_version to the loader."
             )
+        # Reject null / empty identity columns before coercing to str
+        # ("".astype(str) → "", "None" etc. pass a naive check).
+        for col in ("prediction_method_name", "predictor_version"):
+            na_mask = df[col].isna() | (
+                df[col].astype(str).str.strip().isin(["", "None", "nan", "NaN"])
+            )
+            if na_mask.any():
+                raise ValueError(
+                    f"CachedPredictor: column {col!r} must be a non-empty "
+                    f"string on every row (got {int(na_mask.sum())} "
+                    f"null/empty value(s)).  Silent None/NaN would mask "
+                    f"the version invariant — supply a value via the "
+                    f"loader's predictor_name / predictor_version args."
+                )
         keep = [c for c in _CACHE_COLUMNS if c in df.columns]
         out = df[keep].copy()
         out["peptide"] = out["peptide"].astype(str)
@@ -152,27 +191,40 @@ class CachedPredictor:
         self, peptides: Iterable[str],
     ) -> pd.DataFrame:
         """Return one row per ``(peptide, allele)`` for each input peptide
-        crossed with every allele in the cache.
+        crossed with every allele in the cache (or in the fallback, if set).
 
-        Misses go to ``self.fallback`` if set, else raise ``KeyError``.
+        Misses are resolved through ``self.fallback`` (which merges into
+        the cache) if set; else raise ``KeyError``.
         """
         peptides = [str(p) for p in peptides]
-        cache_alleles = self._cache_alleles()
-        rows = []
-        misses = []
+        query_alleles = self._cache_alleles()
+        if self.fallback is not None:
+            query_alleles = sorted(
+                set(query_alleles)
+                | set(getattr(self.fallback, "alleles", []))
+            )
+
+        # Identify peptides with at least one missing (peptide, allele).
+        missed_peptides = set()
         for peptide in peptides:
             length = len(peptide)
-            for allele in cache_alleles:
-                row = self._index.get((peptide, allele, length))
-                if row is None:
-                    misses.append(peptide)
-                    break  # defer: fallback call covers all alleles at once
-                rows.append(row)
+            for allele in query_alleles:
+                if (peptide, allele, length) not in self._index:
+                    missed_peptides.add(peptide)
+                    break
 
-        if misses:
-            missed_unique = sorted(set(misses))
-            fb_rows = self._fallback_resolve(missed_unique)
-            rows.extend(fb_rows)
+        # Resolve misses through fallback (populates self._index in place).
+        if missed_peptides:
+            self._fallback_resolve(sorted(missed_peptides))
+
+        # Assemble output from the (updated) cache.
+        rows = []
+        for peptide in peptides:
+            length = len(peptide)
+            for allele in query_alleles:
+                row = self._index.get((peptide, allele, length))
+                if row is not None:
+                    rows.append(row)
 
         if not rows:
             return pd.DataFrame(columns=list(_CACHE_COLUMNS))
@@ -231,10 +283,12 @@ class CachedPredictor:
 
     # --- fallback resolution ----------------------------------------
 
-    def _fallback_resolve(self, peptides):
-        """Run the fallback on ``peptides`` (missed peptide strings),
-        verify the version invariant, merge the results into the cache,
-        and return the new row dicts for the requested peptides."""
+    def _fallback_resolve(self, peptides) -> None:
+        """Run the fallback on ``peptides``, verify the version invariant,
+        and merge results into ``self._df`` and ``self._index``.
+
+        No return value — the caller re-reads from ``self._index``.
+        """
         if self.fallback is None:
             missed_preview = peptides[:5]
             extra = "" if len(peptides) <= 5 else \
@@ -262,11 +316,17 @@ class CachedPredictor:
                 str(r["peptide"]), str(r["allele"]), int(r["peptide_length"]),
             )
             self._index[key] = r.to_dict()
-        self._df = pd.concat([self._df, new_rows], ignore_index=True) \
-            .drop_duplicates(
-                subset=["peptide", "allele", "peptide_length"], keep="last",
-            )
-        return [r.to_dict() for _, r in new_rows.iterrows()]
+        # Empty-cache mode: self._df is an empty all-NA frame from
+        # __init__; concatenating through it trips a pandas FutureWarning.
+        # Assign directly instead when there's nothing to preserve.
+        if len(self._df) == 0:
+            self._df = new_rows.copy()
+        else:
+            self._df = pd.concat([self._df, new_rows], ignore_index=True) \
+                .drop_duplicates(
+                    subset=["peptide", "allele", "peptide_length"],
+                    keep="last",
+                )
 
     @staticmethod
     def _conform_predictor_output(df: pd.DataFrame) -> pd.DataFrame:
@@ -291,15 +351,31 @@ class CachedPredictor:
         if self._fallback_verified:
             return
         fb_pair = self._unique_version_pair(fb_df)
+
+        # Empty-cache mode: adopt the fallback's identity on first call.
+        if self.prediction_method_name is None:
+            self.prediction_method_name, self.predictor_version = fb_pair
+            self._fallback_verified = True
+            return
+
         cache_pair = (self.prediction_method_name, self.predictor_version)
-        if fb_pair != cache_pair:
+        # Names must match exactly — different predictors are different.
+        if fb_pair[0] != cache_pair[0]:
+            raise ValueError(
+                f"CachedPredictor fallback predictor_name mismatch: "
+                f"cache={cache_pair[0]!r}, fallback={fb_pair[0]!r}."
+            )
+        # Versions match if equal OR in the caller's equivalence set.
+        if (fb_pair[1] != cache_pair[1]
+                and fb_pair[1] not in self.also_accept_versions):
             raise ValueError(
                 f"CachedPredictor fallback version mismatch: cache="
-                f"({cache_pair[0]!r}, {cache_pair[1]!r}), "
-                f"fallback=({fb_pair[0]!r}, {fb_pair[1]!r}).  Mixing model "
-                f"versions is not allowed — use a fallback whose "
-                f"(prediction_method_name, predictor_version) matches the "
-                f"cache."
+                f"({cache_pair[0]!r}, {cache_pair[1]!r}), fallback="
+                f"({fb_pair[0]!r}, {fb_pair[1]!r}).  Mixing versions is "
+                f"not allowed by default — pass "
+                f"also_accept_versions={{{fb_pair[1]!r}}} at cache "
+                f"construction to opt in to treating these as "
+                f"interchangeable."
             )
         self._fallback_verified = True
 
@@ -330,6 +406,7 @@ class CachedPredictor:
         prediction_method_name: Optional[str] = None,
         predictor_version: Optional[str] = None,
         fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
         """Construct from an in-memory DataFrame.
 
@@ -349,11 +426,14 @@ class CachedPredictor:
             df = df.rename(columns={"length": "peptide_length"})
         if "peptide_length" not in df.columns and "peptide" in df.columns:
             df["peptide_length"] = df["peptide"].str.len()
-        return cls(df, fallback=fallback)
+        return cls(
+            df, fallback=fallback, also_accept_versions=also_accept_versions,
+        )
 
     @classmethod
     def from_topiary_output(
         cls, path, *, fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
         """Load a DataFrame previously written by topiary's prediction
         output (Parquet or TSV/CSV).  The expected columns match
@@ -366,7 +446,10 @@ class CachedPredictor:
             df = pd.read_csv(path_str, sep="\t")
         else:
             df = pd.read_csv(path_str)
-        return cls.from_dataframe(df, fallback=fallback)
+        return cls.from_dataframe(
+            df, fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
 
     @classmethod
     def from_tsv(
@@ -378,6 +461,7 @@ class CachedPredictor:
         prediction_method_name: Optional[str] = None,
         predictor_version: Optional[str] = None,
         fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
         """Generic tab- or comma-delimited loader for third-party
         prediction output.
@@ -395,6 +479,7 @@ class CachedPredictor:
             prediction_method_name=prediction_method_name,
             predictor_version=predictor_version,
             fallback=fallback,
+            also_accept_versions=also_accept_versions,
         )
 
     @classmethod
@@ -402,16 +487,30 @@ class CachedPredictor:
         cls,
         path,
         *,
-        predictor_version: str,
+        predictor_version: Optional[str] = None,
         fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
-        """Load mhcflurry-predict CSV output.  Maps mhcflurry's
-        ``mhcflurry_affinity`` / ``mhcflurry_affinity_percentile`` /
+        """Load mhcflurry-predict CSV output.
+
+        Maps mhcflurry's ``mhcflurry_affinity`` /
+        ``mhcflurry_affinity_percentile`` /
         ``mhcflurry_presentation_score`` columns onto the cache's
         canonical ``affinity`` / ``percentile_rank`` / ``score``.
 
-        ``predictor_version`` is required — mhcflurry's CSV doesn't
-        embed it and the version invariant must be satisfied."""
+        **mhcflurry-specific version note.** Unlike NetMHCpan (which
+        bakes models into the binary), mhcflurry fetches model weights
+        separately via ``mhcflurry-downloads fetch``.  Two systems with
+        the same package version can produce different predictions if
+        they have different model bundles installed.  The cache's
+        ``predictor_version`` must capture both.
+
+        When ``predictor_version`` is omitted, the loader auto-composes
+        it via :func:`mhcflurry_composite_version` — e.g.
+        ``"2.2.1+release-2.2.0"``.  Users never have to enumerate the
+        installed model bundle manually.  Pass an explicit string only
+        when you need a custom label.
+        """
         df = pd.read_csv(path)
         col_map = {}
         if "mhcflurry_affinity" in df.columns:
@@ -421,9 +520,63 @@ class CachedPredictor:
         if "mhcflurry_presentation_score" in df.columns:
             col_map["mhcflurry_presentation_score"] = "score"
         df = df.rename(columns=col_map)
+        if predictor_version is None:
+            predictor_version = mhcflurry_composite_version()
         return cls.from_dataframe(
             df,
             prediction_method_name="mhcflurry",
             predictor_version=predictor_version,
             fallback=fallback,
+            also_accept_versions=also_accept_versions,
         )
+
+
+def mhcflurry_composite_version() -> str:
+    """Compose mhcflurry's package version + active model-release
+    identifier into a single string for :attr:`CachedPredictor.predictor_version`.
+
+    Returns a string like ``"2.2.1+release-2.2.0"`` — the Python
+    package version joined to the mhcflurry model-data release
+    currently installed via ``mhcflurry-downloads fetch``.  Two
+    systems whose :func:`mhcflurry_composite_version` outputs match
+    should produce interchangeable mhcflurry predictions.
+
+    The helper introspects the locally-installed mhcflurry; the user
+    never has to enumerate model bundles manually.
+
+    Raises
+    ------
+    RuntimeError
+        If mhcflurry isn't installed, or no model release is configured
+        (run ``mhcflurry-downloads fetch`` first).
+    """
+    try:
+        import mhcflurry
+        import mhcflurry.downloads
+    except ImportError as e:
+        raise RuntimeError(
+            "mhcflurry is not installed — cannot derive a composite "
+            "version.  Install mhcflurry or pass predictor_version "
+            "explicitly."
+        ) from e
+    pkg = getattr(mhcflurry, "__version__", None)
+    if not pkg:
+        raise RuntimeError(
+            "mhcflurry is installed but exposes no __version__; cannot "
+            "derive a composite version — pass predictor_version "
+            "explicitly."
+        )
+    try:
+        release = mhcflurry.downloads.get_current_release()
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not read mhcflurry's current model release: {e!r}.  "
+            f"Pass predictor_version explicitly."
+        ) from e
+    if not release:
+        raise RuntimeError(
+            "mhcflurry has no active model release.  Run "
+            "`mhcflurry-downloads fetch` or pass predictor_version "
+            "explicitly."
+        )
+    return f"{pkg}+release-{release}"


### PR DESCRIPTION
## Summary

First PR implementing #128 (pluggable prediction sources). Ships the \`CachedPredictor\` class, the core \`(prediction_method_name, predictor_version)\` invariant, fallback semantics, and four loaders. Does **not** include sharding (\`concat\` / \`from_directory\`) or the NetMHCpan .xls parser — separate follow-up PRs.

No version bump, no PyPI release: the feature lands across multiple PRs; release once #128 is substantially complete.

## What's in

- **\`topiary/cached.py\`** — \`CachedPredictor\` class. Implements the mhctools predictor protocol (\`predict_peptides_dataframe\`, \`predict_proteins_dataframe\`, \`alleles\`, \`default_peptide_lengths\`) by looking up rows in a normalized DataFrame keyed on \`(peptide, allele, peptide_length)\`.
- **Core invariant**: a single cache holds predictions from exactly one \`(prediction_method_name, predictor_version)\` pair. Enforced at construction (mixed rows → \`ValueError\`) and on first fallback call (lazy version-check against the fallback's output).
- **Fallback**: \`fallback=None\` → miss raises \`KeyError\` with missed peptides listed. \`fallback=<predictor>\` → miss delegates and the result is merged back into the cache. No \`populate_on_miss\` flag — caching fallback hits is always the right default.
- **Loaders**: \`from_dataframe\`, \`from_topiary_output\` (Parquet / TSV), \`from_tsv\` (generic w/ column mapping), \`from_mhcflurry\` (maps \`mhcflurry_*\` columns onto canonical names).
- **\`save(path)\`** round-trip for Parquet / TSV / CSV so caches persist across sessions.
- **\`topiary.CachedPredictor\`** exported at the top level.

## What's deferred

- \`from_netmhcpan\` (.xls parsing — both Class-I and Class-II formats)
- \`concat([...])\`, \`from_directory(...)\`, overlap-resolution policy
- CHANGELOG entry (deferred to the release-prep PR when #128 lands in full)

## Test plan

- [x] \`python -m pytest tests/test_cached_predictor.py\` — 23 passed
- [x] \`./test.sh\` — 1075 passed, 3 skipped (up from 1052)
- [x] \`./lint.sh\` — clean
- [ ] CI green

Part 1 of #128.