### PR TITLE
CachedPredictor vaxrank-review polish (#130 follow-up)

### DIFF
--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -236,6 +236,27 @@ class TestFallback:
         with pytest.raises(ValueError, match="predictor_name mismatch"):
             cache.predict_peptides_dataframe(["GILGFVFTL"])
 
+    def test_partial_allele_cache_preserves_existing_rows(self):
+        """Regression for vaxrank review concern #1: when a cache has
+        peptide P for allele A but not B, a fallback call triggered by
+        the (P, B) miss returns rows for ALL the fallback's alleles
+        including A.  The pre-loaded (P, A) row must not be overwritten
+        by the fallback's output."""
+        cache = CachedPredictor.from_dataframe(
+            _df([_row(
+                peptide="SIINFEKLA", allele="HLA-A*02:01",
+                affinity=42.0,  # sentinel we can check survives
+            )]),
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        # Trigger fallback: SIINFEKLA is a hit for A*02:01 but the
+        # fallback's own alleles may include it too, so without the
+        # preserve-existing guard, the random-predictor output would
+        # overwrite the 42.0 sentinel.
+        cache.predict_peptides_dataframe(["SIINFEKLA"])
+        preserved = cache._index[("SIINFEKLA", "HLA-A*02:01", 9)]
+        assert preserved["affinity"] == 42.0
+
 
 # ---------------------------------------------------------------------------
 # Null / empty version rejection
@@ -298,6 +319,31 @@ class TestEmptyCacheWithFallback:
         empty = pd.DataFrame(columns=list(_row().keys()))
         with pytest.raises(ValueError, match="either .df. .* or .fallback."):
             CachedPredictor(empty)
+
+    def test_save_before_any_query_raises(self, tmp_path):
+        """Regression for vaxrank review concern #5: saving an
+        un-queried empty-cache-plus-fallback would write a schema-only
+        file that can't be round-tripped through from_topiary_output.
+        Fail fast instead."""
+        cache = CachedPredictor(
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        path = tmp_path / "cache.tsv"
+        with pytest.raises(ValueError, match="no rows to persist"):
+            cache.save(path)
+        assert not path.exists()
+
+    def test_save_works_after_fallback_populates(self, tmp_path):
+        """Once identity is locked in and rows exist, save() proceeds."""
+        cache = CachedPredictor(
+            fallback=_matched_fallback(name="random", version="1.0"),
+        )
+        cache.predict_peptides_dataframe(["SIINFEKLA"])
+        path = tmp_path / "cache.tsv"
+        cache.save(path)
+        assert path.exists()
+        reloaded = CachedPredictor.from_topiary_output(path)
+        assert reloaded.prediction_method_name == "random"
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -66,6 +66,23 @@ class CachedPredictor:
         merged back into the cache.  Its
         ``(prediction_method_name, predictor_version)`` must match the
         cache's.
+
+    Notes
+    -----
+    **Peptide-length coverage.**  ``default_peptide_lengths`` is derived
+    from the lengths actually present in the cache (union with the
+    fallback's lengths when one is set).  A cache loaded from a file
+    that only contains 9-mers will silently scan only 9-mer windows in
+    ``predict_proteins_dataframe``.  If your source table was intended
+    to cover multiple lengths but doesn't, you won't notice it here —
+    check ``cache.default_peptide_lengths`` after loading.
+
+    **Thread safety.**  :meth:`predict_peptides_dataframe` and
+    :meth:`predict_proteins_dataframe` mutate internal state (the
+    ``(peptide, allele, peptide_length)`` index and the backing
+    DataFrame) when a fallback is configured.  The class is **not
+    thread-safe**; wrap calls in a lock if the cache is shared across
+    worker threads.
     """
 
     def __init__(
@@ -311,22 +328,40 @@ class CachedPredictor:
         fb_df = self._conform_predictor_output(fb_df)
         self._verify_fallback_version(fb_df)
         new_rows = self._normalize(fb_df)
-        for _, r in new_rows.iterrows():
+
+        # Filter to only keys not already in the cache.  The fallback
+        # typically predicts across all its alleles for each missed
+        # peptide; without this guard, a partial-allele cache (peptide
+        # P present for allele A, missing for allele B) would see its
+        # (P, A) row silently overwritten by the fallback's output
+        # when (P, B) triggers a fallback call.  Preserve user intent.
+        def _is_new(row):
+            key = (
+                str(row["peptide"]),
+                str(row["allele"]),
+                int(row["peptide_length"]),
+            )
+            return key not in self._index
+
+        novel_mask = new_rows.apply(_is_new, axis=1)
+        novel_rows = new_rows[novel_mask]
+        for _, r in novel_rows.iterrows():
             key = (
                 str(r["peptide"]), str(r["allele"]), int(r["peptide_length"]),
             )
             self._index[key] = r.to_dict()
+
+        if len(novel_rows) == 0:
+            return
         # Empty-cache mode: self._df is an empty all-NA frame from
         # __init__; concatenating through it trips a pandas FutureWarning.
         # Assign directly instead when there's nothing to preserve.
         if len(self._df) == 0:
-            self._df = new_rows.copy()
+            self._df = novel_rows.copy()
         else:
-            self._df = pd.concat([self._df, new_rows], ignore_index=True) \
-                .drop_duplicates(
-                    subset=["peptide", "allele", "peptide_length"],
-                    keep="last",
-                )
+            self._df = pd.concat(
+                [self._df, novel_rows], ignore_index=True,
+            )
 
     @staticmethod
     def _conform_predictor_output(df: pd.DataFrame) -> pd.DataFrame:
@@ -387,7 +422,23 @@ class CachedPredictor:
 
     def save(self, path) -> None:
         """Write the cache as Parquet (``.parquet``/``.pq``) or TSV
-        (``.tsv``, optionally ``.tsv.gz``)."""
+        (``.tsv``, optionally ``.tsv.gz``).
+
+        Raises ``ValueError`` if the cache has no identity yet — an
+        empty cache built with only a fallback hasn't learned its
+        ``(prediction_method_name, predictor_version)`` until the
+        first query runs.  Saving in that state would produce a
+        schema-only file that can't be round-tripped through
+        :meth:`from_topiary_output`.
+        """
+        if self.prediction_method_name is None or len(self._df) == 0:
+            raise ValueError(
+                "CachedPredictor.save(): no rows to persist.  An empty "
+                "cache built with `fallback=` learns its "
+                "(prediction_method_name, predictor_version) identity "
+                "from the fallback's output on the first query.  Run "
+                "at least one query that populates the cache, then save."
+            )
         path_str = str(path)
         if path_str.endswith((".parquet", ".pq")):
             self._df.to_parquet(path_str, index=False)


### PR DESCRIPTION
Addresses 4 concrete concerns from the vaxrank-consumer review on #130 (comment 4246617648).  Small, localized, no public-API changes — all four items Alex flagged as \"mostly docs/edge cases.\"  Concern #3 (_index memory footprint on whole-proteome caches) is deferred to a benchmark-driven follow-up.

## Fixes

1. **Partial-allele cache preservation.**  \`_fallback_resolve\` now filters fallback output to keys not already in the index before merging.  A cache that pre-loaded peptide P for allele A but not B used to silently see its (P, A) row overwritten when (P, B) triggered the fallback; now the pre-loaded data is preserved.

2. **Docstring note on silent peptide-length lock-in.**  A cache loaded from a single-length source file will silently scan only that length in \`predict_proteins_dataframe\`.  Class docstring now flags it and tells users to check \`default_peptide_lengths\` after loading.

3. **Thread-safety disclaimer.**  \`_fallback_resolve\` mutates shared state; one-line note in the class docstring.

4. **\`save()\` raises on an empty never-queried cache.**  \`CachedPredictor(fallback=p).save(path)\` used to write a schema-only file that \`from_topiary_output\` couldn't round-trip.  Now fails fast with an actionable message.

## Test plan

- [x] 3 new regression tests in \`tests/test_cached_predictor.py\` (41 total, up from 38)
- [x] \`./test.sh\` — 1093 passed, 3 skipped (up from 1090)
- [x] \`./lint.sh\` — clean
- [ ] CI green