### PR TITLE
Add NetMHC-family cache loaders (part of #128)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,11 @@ pre-computed table. Pass as `models=cache` to `TopiaryPredictor`. See
 |--------|--------|
 | `CachedPredictor.from_topiary_output(path)` | Parquet / TSV / CSV previously written from a topiary run. |
 | `CachedPredictor.from_mhcflurry(path)` | mhcflurry-predict CSV output. `predictor_version` auto-composed from the installed mhcflurry when omitted. |
+| `CachedPredictor.from_netmhcpan_stdout(path, mode=...)` | NetMHCpan stdout capture (auto-detects 2.8 / 3 / 4 / 4.1). |
+| `CachedPredictor.from_netmhc_stdout(path, version=...)` | Classic NetMHC stdout (3 / 4 / 4.1). |
+| `CachedPredictor.from_netmhcpan_cons_stdout(path)` | NetMHCcons stdout. |
+| `CachedPredictor.from_netmhciipan_stdout(path, version=...)` | NetMHCIIpan stdout (legacy / 4 / 4.3). |
+| `CachedPredictor.from_netmhcstabpan_stdout(path)` | NetMHCstabpan stdout (pMHC stability). |
 | `CachedPredictor.from_tsv(path, columns=..., prediction_method_name=..., predictor_version=...)` | Generic tab- or comma-delimited. |
 | `CachedPredictor.from_dataframe(df, ...)` | In-memory DataFrame. |
 | `CachedPredictor(fallback=live_predictor)` | Empty cache, lazy identity discovery — pure read-through over a live model. |

--- a/docs/cached.md
+++ b/docs/cached.md
@@ -49,6 +49,35 @@ overlay columns (`fragment_id`, `wt_peptide`, etc.) are kept in the
 file but ignored on lookup — the cache is the predictor output, not
 the full pipeline output.
 
+### From NetMHC-family stdout captures
+
+The DTU NetMHC suite (NetMHCpan, NetMHC, NetMHCcons, NetMHCIIpan,
+NetMHCstabpan) prints binding predictions to stdout when run from
+the command line. If you've captured that output to a file, load
+it directly — topiary reuses the parsers shipped by
+[mhctools](https://github.com/openvax/mhctools) so every NetMHC
+version they support is covered here too.
+
+```python
+cache = CachedPredictor.from_netmhcpan_stdout(
+    "netmhcpan_run.out",
+    mode="binding_affinity",     # or "elution_score" on 4+
+)
+cache = CachedPredictor.from_netmhc_stdout("netmhc_run.out", version="4")
+cache = CachedPredictor.from_netmhcpan_cons_stdout("cons_run.out")
+cache = CachedPredictor.from_netmhciipan_stdout("ii_run.out", version="4.3")
+cache = CachedPredictor.from_netmhcstabpan_stdout("stab_run.out")
+```
+
+Each loader parses the version out of the stdout preamble (e.g.
+`NetMHCpan version 4.1b`) and stamps it on `predictor_version`.
+Pass `predictor_version="..."` if you want a different label, or
+if your capture stripped the preamble.
+
+The loaders parse the *stdout text* format. NetMHC's `-xlsfile`
+tab-delimited output is a different format and isn't supported
+today — open an issue if you need it.
+
 ### From mhcflurry output
 
 ```python

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -540,3 +540,107 @@ class TestTopiaryPredictorIntegration:
         predictor = TopiaryPredictor(models=cache)
         df = predictor.predict_from_named_sequences({"prot": "MASIINFEKLGGG"})
         assert len(df) == 5  # 5 sliding 9-mers over the 13-aa sequence
+
+
+# ---------------------------------------------------------------------------
+# NetMHC-family loaders (via mhctools.parsing.*_stdout)
+# ---------------------------------------------------------------------------
+
+
+_NETMHCPAN_41_STDOUT = """NetMHCpan version 4.1b
+# Rank Threshold for Strong binding peptides   0.500
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*02:01  SIINFEKLA SIINFEKLA  0  0  0  0  0  SIINFEKLA            seq1 0.5000000    1.000 0.500000    2.000 150.00 <=WB
+   2 HLA-A*02:01  GILGFVFTL GILGFVFTL  0  0  0  0  0  GILGFVFTL            seq1 0.9000000    0.100 0.950000    0.500  25.00 <=SB
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein seq1. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 1. Number of peptides 2
+
+"""
+
+
+_NETMHC_4_STDOUT = """# NetMHC version 4.0
+
+# Input is in FSA format
+
+# Peptide length 9
+
+-----------------------------------------------------------------------------------
+ pos\tHLA\tpeptide\tCore\tOffset\tI_pos\tI_len\tD_pos\tD_len\tiCore\tIdentity\t1-log50k\t nM \tRank\tBindLevel
+-----------------------------------------------------------------------------------
+   1 HLA-A0201     SIINFEKLA     SIINFEKLA  0  0  0  0  0     SIINFEKLA       seq1     0.456    234.5     2.5 <= WB
+-----------------------------------------------------------------------------------
+
+Protein seq1. Allele HLA-A0201. Number of high binders 0. Number of weak binders 1. Number of peptides 1
+"""
+
+
+_NETMHCSTABPAN_STDOUT = """# NetMHCstabpan version 1.0
+
+# Threshold for Strong binding peptides (%Rank)\t0.500
+# Threshold for Weak binding peptides (%Rank)\t2.000
+--------------------------------------------------------------------------------------------------
+ Pos          HLA         Peptide       Identity       Pred    Thalf(h)     %Rank_Stab BindLevel
+--------------------------------------------------------------------------------------------------
+   1  HLA-A*02:01       SIINFEKLA           seq1      0.600        4.50         2.500 <=WB
+--------------------------------------------------------------------------------------------------
+
+Protein seq1. Allele HLA-A*02:01. Number of high binders 0. Number of weak binders 1. Number of peptides 1
+"""
+
+
+class TestNetMHCLoaders:
+    def _write(self, tmp_path, name, text):
+        p = tmp_path / name
+        p.write_text(text)
+        return p
+
+    def test_from_netmhcpan_stdout(self, tmp_path):
+        path = self._write(tmp_path, "pan.out", _NETMHCPAN_41_STDOUT)
+        cache = CachedPredictor.from_netmhcpan_stdout(path)
+        assert cache.prediction_method_name == "netmhcpan"
+        # Version should be parsed from the "NetMHCpan version 4.1b" header.
+        assert cache.predictor_version == "4.1b"
+        assert cache.alleles == ["HLA-A*02:01"]
+        assert cache.default_peptide_lengths == [9]
+        out = cache.predict_peptides_dataframe(["SIINFEKLA", "GILGFVFTL"])
+        assert len(out) == 2
+        assert set(out["peptide"]) == {"SIINFEKLA", "GILGFVFTL"}
+
+    def test_from_netmhcpan_stdout_explicit_version(self, tmp_path):
+        path = self._write(tmp_path, "pan.out", _NETMHCPAN_41_STDOUT)
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            path, predictor_version="custom-label",
+        )
+        assert cache.predictor_version == "custom-label"
+
+    def test_from_netmhc_stdout_v4(self, tmp_path):
+        path = self._write(tmp_path, "netmhc.out", _NETMHC_4_STDOUT)
+        cache = CachedPredictor.from_netmhc_stdout(path, version="4")
+        assert cache.prediction_method_name == "netmhc"
+        # Version parsed from "NetMHC version 4.0"
+        assert cache.predictor_version == "4.0"
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert len(out) == 1
+
+    def test_from_netmhc_stdout_unsupported_version_rejects(self, tmp_path):
+        path = self._write(tmp_path, "x.out", _NETMHC_4_STDOUT)
+        with pytest.raises(ValueError, match="not supported"):
+            CachedPredictor.from_netmhc_stdout(path, version="5")
+
+    def test_from_netmhcstabpan_stdout(self, tmp_path):
+        path = self._write(tmp_path, "stab.out", _NETMHCSTABPAN_STDOUT)
+        cache = CachedPredictor.from_netmhcstabpan_stdout(path)
+        assert cache.prediction_method_name == "netmhcstabpan"
+        assert cache.predictor_version == "1.0"
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert len(out) == 1
+
+    def test_from_netmhciipan_stdout_unsupported_version_rejects(self, tmp_path):
+        # Use the NetMHCpan sample as a stand-in — we only want to hit
+        # the version guard before any parsing happens.
+        path = self._write(tmp_path, "ii.out", _NETMHCPAN_41_STDOUT)
+        with pytest.raises(ValueError, match="not supported"):
+            CachedPredictor.from_netmhciipan_stdout(path, version="99")

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -3,8 +3,8 @@
 Plugs into :class:`topiary.TopiaryPredictor` alongside live mhctools
 predictors.  Supports three producer paths:
 
-1. External predictor output files (mhcflurry CSV today; NetMHCpan
-   `.xls` and others via follow-up loaders).
+1. External predictor output files (mhcflurry CSV, NetMHC-family
+   stdout captures, generic TSV/CSV with column mapping).
 2. Topiary's own saved predictions (``predict_*`` output round-tripped
    through Parquet / TSV).
 3. Caller-supplied DataFrames (programmatic / in-memory construction).
@@ -29,6 +29,7 @@ Fallback semantics
 """
 from __future__ import annotations
 
+import re
 from typing import Iterable, Mapping, Optional
 
 import pandas as pd
@@ -580,6 +581,224 @@ class CachedPredictor:
             fallback=fallback,
             also_accept_versions=also_accept_versions,
         )
+
+    # --- NetMHC-family loaders ---
+    # Thin adapters over mhctools.parsing.*_stdout functions.  They
+    # read an NetMHC-tool stdout capture, run the mhctools parser,
+    # convert the resulting list[BindingPrediction] into a DataFrame
+    # shaped for the cache, and hand off to from_dataframe.
+
+    @classmethod
+    def from_netmhcpan_stdout(
+        cls,
+        path,
+        *,
+        mode: str = "binding_affinity",
+        predictor_version: Optional[str] = None,
+        fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ) -> "CachedPredictor":
+        """Load a NetMHCpan stdout capture (2.8 / 3 / 4 / 4.1).
+
+        Uses ``mhctools.parsing.parse_netmhcpan_stdout`` which auto-
+        detects the version.  ``mode`` picks between
+        ``"binding_affinity"`` (default) and ``"elution_score"`` for
+        NetMHCpan 4+; ignored on earlier versions.  When
+        ``predictor_version`` is omitted, the version string is
+        parsed from the stdout preamble (e.g. ``"4.1b"``).
+        """
+        from mhctools.parsing import parse_netmhcpan_stdout
+        text = _read_text(path)
+        preds = parse_netmhcpan_stdout(text, mode=mode)
+        if predictor_version is None:
+            predictor_version = _version_from_header(text) or "unknown"
+        return cls.from_dataframe(
+            _bindings_to_dataframe(preds),
+            prediction_method_name="netmhcpan",
+            predictor_version=predictor_version,
+            fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
+
+    @classmethod
+    def from_netmhc_stdout(
+        cls,
+        path,
+        *,
+        version: str = "4",
+        predictor_version: Optional[str] = None,
+        fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ) -> "CachedPredictor":
+        """Load a classic NetMHC stdout capture (3 / 4 / 4.1).
+
+        ``version`` selects the parser: ``"3"``, ``"4"``, or ``"4.1"``.
+        """
+        from mhctools import parsing as _p
+        parsers = {
+            "3": _p.parse_netmhc3_stdout,
+            "4": _p.parse_netmhc4_stdout,
+            "4.1": _p.parse_netmhc41_stdout,
+        }
+        if version not in parsers:
+            raise ValueError(
+                f"NetMHC version {version!r} not supported — choose "
+                f"from {sorted(parsers)}."
+            )
+        text = _read_text(path)
+        preds = parsers[version](text)
+        if predictor_version is None:
+            predictor_version = _version_from_header(text) or version
+        return cls.from_dataframe(
+            _bindings_to_dataframe(preds),
+            prediction_method_name="netmhc",
+            predictor_version=predictor_version,
+            fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
+
+    @classmethod
+    def from_netmhcpan_cons_stdout(
+        cls,
+        path,
+        *,
+        predictor_version: Optional[str] = None,
+        fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ) -> "CachedPredictor":
+        """Load a NetMHCcons stdout capture (consensus of multiple
+        methods)."""
+        from mhctools.parsing import parse_netmhccons_stdout
+        text = _read_text(path)
+        preds = parse_netmhccons_stdout(text)
+        if predictor_version is None:
+            predictor_version = _version_from_header(text) or "unknown"
+        return cls.from_dataframe(
+            _bindings_to_dataframe(preds),
+            prediction_method_name="netmhccons",
+            predictor_version=predictor_version,
+            fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
+
+    @classmethod
+    def from_netmhciipan_stdout(
+        cls,
+        path,
+        *,
+        version: str = "4.3",
+        mode: str = "elution_score",
+        predictor_version: Optional[str] = None,
+        fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ) -> "CachedPredictor":
+        """Load a NetMHCIIpan stdout capture (class II).
+
+        ``version`` selects the parser: ``"legacy"``, ``"4"``, or
+        ``"4.3"`` (default — latest).  ``mode`` picks between
+        ``"elution_score"`` (default, NetMHCIIpan 4+) and
+        ``"binding_affinity"``.
+        """
+        from mhctools import parsing as _p
+        parsers = {
+            "legacy": _p.parse_netmhciipan_stdout,
+            "4": _p.parse_netmhciipan4_stdout,
+            "4.3": _p.parse_netmhciipan43_stdout,
+        }
+        if version not in parsers:
+            raise ValueError(
+                f"NetMHCIIpan version {version!r} not supported — "
+                f"choose from {sorted(parsers)}."
+            )
+        text = _read_text(path)
+        parser = parsers[version]
+        # The legacy parser doesn't take mode; guard the call.
+        if version == "legacy":
+            preds = parser(text)
+        else:
+            preds = parser(text, mode=mode)
+        if predictor_version is None:
+            predictor_version = _version_from_header(text) or version
+        return cls.from_dataframe(
+            _bindings_to_dataframe(preds),
+            prediction_method_name="netmhciipan",
+            predictor_version=predictor_version,
+            fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
+
+    @classmethod
+    def from_netmhcstabpan_stdout(
+        cls,
+        path,
+        *,
+        predictor_version: Optional[str] = None,
+        fallback=None,
+        also_accept_versions: Optional[Iterable[str]] = None,
+    ) -> "CachedPredictor":
+        """Load a NetMHCstabpan stdout capture (pMHC stability)."""
+        from mhctools.parsing import parse_netmhcstabpan
+        text = _read_text(path)
+        preds = parse_netmhcstabpan(text)
+        if predictor_version is None:
+            predictor_version = _version_from_header(text) or "unknown"
+        return cls.from_dataframe(
+            _bindings_to_dataframe(preds),
+            prediction_method_name="netmhcstabpan",
+            predictor_version=predictor_version,
+            fallback=fallback,
+            also_accept_versions=also_accept_versions,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers used by the NetMHC loaders
+# ---------------------------------------------------------------------------
+
+
+def _read_text(path) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _bindings_to_dataframe(preds) -> pd.DataFrame:
+    """Convert an mhctools ``list[BindingPrediction]`` into a DataFrame
+    shaped for :class:`CachedPredictor`.  Uses ``length`` (the
+    mhctools attribute name) → ``peptide_length``.
+    """
+    rows = [
+        {
+            "peptide": p.peptide,
+            "allele": p.allele,
+            "peptide_length": p.length,
+            "score": p.score,
+            "affinity": p.affinity,
+            "percentile_rank": p.percentile_rank,
+            "value": getattr(p, "value", None),
+            # prediction_method_name is set per-loader by from_dataframe's
+            # backfill from the classmethod's caller.  Left unset here so
+            # the classmethod's explicit value wins.
+        }
+        for p in preds
+    ]
+    return pd.DataFrame(rows)
+
+
+# NetMHC-family tools embed their version in the stdout preamble,
+# e.g. "NetMHCpan version 4.1b" or "# NetMHCstabpan version 1.0".
+# Capture the token after "version" (ignoring surrounding whitespace
+# and case) — this is the stamp we put in predictor_version.
+_NETMHC_VERSION_RE = re.compile(
+    r"(?:NetMHCpan|NetMHCIIpan|NetMHCcons|NetMHCstabpan|NetMHC)\s+version\s+(\S+)",
+    re.IGNORECASE,
+)
+
+
+def _version_from_header(text: str) -> Optional[str]:
+    """Parse a NetMHC-family version string (e.g. ``"4.1b"``) from
+    the stdout preamble.  Returns ``None`` if no version line found."""
+    m = _NETMHC_VERSION_RE.search(text[:2000])
+    return m.group(1) if m else None
 
 
 def mhcflurry_composite_version() -> str:


### PR DESCRIPTION
## Summary

Five new \`CachedPredictor\` classmethods that load stdout captures from the DTU NetMHC suite.  No new parsing code — each method wraps an existing \`mhctools.parsing.*_stdout\` function (which returns a \`list[BindingPrediction]\`) and converts the output into a DataFrame shaped for the cache.

\`\`\`python
CachedPredictor.from_netmhcpan_stdout(path, mode=\"binding_affinity\")  # auto-detects 2.8 / 3 / 4 / 4.1
CachedPredictor.from_netmhc_stdout(path, version=\"4\")                  # 3 / 4 / 4.1
CachedPredictor.from_netmhcpan_cons_stdout(path)
CachedPredictor.from_netmhciipan_stdout(path, version=\"4.3\")           # legacy / 4 / 4.3
CachedPredictor.from_netmhcstabpan_stdout(path)
\`\`\`

Each loader parses the tool version out of the stdout preamble (e.g. \`NetMHCpan version 4.1b\`) and stamps it on \`predictor_version\`; explicit \`predictor_version=\"...\"\` overrides when needed.

## Caveat

Parses stdout text, not the \`-xlsfile\` tab-delimited output NetMHC tools can also produce.  Flagged in \`docs/cached.md\`; separate issue if there's demand.

## Test plan

- [x] 6 new tests with embedded stdout snippets (no fixture files committed)
- [x] \`./test.sh\` — 1099 passed, 3 skipped (up from 1093)
- [x] \`./lint.sh\` — clean
- [x] \`mkdocs build --strict\` — clean
- [ ] CI green

Part of #128.  Remaining for #128 closure: sharding (\`concat\` / \`from_directory\` with overlap-resolution policy).