### PR TITLE
Add SelfProteome — nearest-self lookup architecture (part A of #124)

### DIFF
--- a/docs/self_proteome.md
+++ b/docs/self_proteome.md
@@ -1,0 +1,150 @@
+# Cross-reactivity: `self_nearest_*` via `SelfProteome`
+
+Given a mutant peptide, find its closest match in a reference proteome
+of healthy self peptides. The distance (and the source gene of the
+match) is a cross-reactivity risk signal: mutant neoantigens that look
+a lot like a real self-peptide may trigger T-cell cross-reactivity
+against healthy tissue.
+
+This page covers the `SelfProteome` class and the `self_nearest_*`
+columns it adds to `TopiaryPredictor` output.
+
+> **Scope note.** This PR ships the **core architecture and one
+> nearest-by-sequence axis**: `scope="all"` and `scope="non_cta"`,
+> substitutions only (no 1aa indels yet), single `self_nearest_peptide`
+> scalar. The three-axis story (sequence-nearest, binding-similar,
+> strongest-binder), 1aa indel candidates, the full candidate-set
+> structured column, and `scope="protected_tissues"` are tracked for
+> follow-up PRs under [#124](https://github.com/openvax/topiary/issues/124).
+
+## Basic usage
+
+```python
+from topiary import SelfProteome, TopiaryPredictor
+from mhctools import NetMHCpan
+
+ref = SelfProteome.from_ensembl(species="human", release=93)
+# Default scope="non_cta" strips CTAs via pirlygenes.
+
+predictor = TopiaryPredictor(
+    models=NetMHCpan,
+    alleles=["HLA-A*02:01"],
+    self_proteome=ref,
+)
+df = predictor.predict_from_variants(variants)
+
+# Output gains:
+#   self_nearest_peptide
+#   self_nearest_peptide_length
+#   self_nearest_edit_distance
+#   self_nearest_gene_id
+#   self_nearest_transcript_id
+#   self_nearest_reference_offset
+#   self_nearest_reference_version
+```
+
+The columns join onto the predictor output on `peptide`. They're
+attached *before* `filter_by` and `sort_by` evaluate, so you can
+reference them in DSL expressions:
+
+```python
+predictor = TopiaryPredictor(
+    models=NetMHCpan,
+    alleles=["HLA-A*02:01"],
+    self_proteome=ref,
+    filter_by=(Affinity <= 500) & (Column("self_nearest_edit_distance") >= 3),
+)
+```
+
+## Scope
+
+Three construction modes (this PR ships the first two):
+
+| `scope=` | Behavior | Configuration |
+|---|---|---|
+| `"all"` | Whole proteome, no filter | — |
+| `"non_cta"` (default for human Ensembl) | Remove CTA genes | `cta_source="pirlygenes"` default; `"tsarina"` reserved; set / callable accepted |
+| `"protected_tissues"` *(PR B)* | Keep only genes expressed in named tissues | `tissues=[…]`, `tissue_source="hpa"`/`"gtex"`, `min_expression=…` |
+| callable | Arbitrary `gene → bool` filter | — |
+
+**Human users** get zero-config `scope="non_cta"` via pirlygenes:
+
+```python
+ref = SelfProteome.from_ensembl(species="human", release=93)
+```
+
+**Non-human users** must either use `scope="all"` or supply their own
+CTA source, because pirlygenes is human-only today:
+
+```python
+ref = SelfProteome.from_ensembl(species="mouse", release=102, scope="all")
+
+# Or with a custom CTA list:
+ref = SelfProteome.from_ensembl(
+    species="mouse",
+    release=102,
+    scope="non_cta",
+    cta_source={"ENSMUSG0001", "ENSMUSG0002", ...},
+)
+```
+
+A non-human `scope="non_cta"` call without `cta_source=` raises at
+construction — silent unfiltered results would be a misleading
+cross-reactivity signal.
+
+## Non-Ensembl sources
+
+For users whose reference proteome isn't in Ensembl, `from_fasta` takes
+a protein-FASTA file directly:
+
+```python
+ref = SelfProteome.from_fasta("my_reference.fa")
+# scope="all" by default; callable scope also works.
+# scope="non_cta" isn't available here — FASTA has no gene metadata.
+```
+
+For test or programmatic use:
+
+```python
+ref = SelfProteome.from_peptides(
+    {"geneA": "MASIINFEKLGGG", "geneB": "QPRSTVWYACDEF"},
+    peptide_lengths=[8, 9, 10, 11],
+)
+```
+
+## Reference version
+
+Every row of the output carries a `self_nearest_reference_version`
+string that captures the species + scope + filter identity. Two runs
+produce interchangeable `self_nearest_peptide` values iff the strings
+match:
+
+```
+ensembl-human-93+scope-non_cta+cta-pirlygenes-3.12.1
+ensembl-mouse-102+scope-all
+ensembl-human+scope-non_cta+cta-sha256:abc123...
+```
+
+Custom filters (user-supplied CTA sets or callables) hash into the
+version string so reproducibility holds even when no stable label is
+available.
+
+## Algorithm
+
+SIMD-vectorized Hamming distance against int8-encoded reference arrays,
+substitutions only. For a query of length L, the search is restricted
+to reference peptides of the same length.
+
+### Performance notes
+
+- Construction: one pass over the reference proteome extracts every
+  L-mer for each configured length, dedupes per length, and encodes
+  into a `(M, L) int8` array. For human non-CTA Ensembl × length 9,
+  expect ~200k rows.
+- Lookup: per query, the full reference array is compared in one SIMD
+  operation. Chunked to bound peak memory. Typical throughput for
+  ~200k reference × ~10k queries is seconds.
+
+Seed-and-extend indexing and 1aa indel candidates are queued in
+[#124](https://github.com/openvax/topiary/issues/124) — benchmark
+decides the default algorithm.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Quickstart: quickstart.md
   - Protein Fragments: fragments.md
   - Cached Predictions: cached.md
+  - Cross-reactivity: self_proteome.md
   - Ranking DSL: ranking.md
   - Peptide Properties: properties.md
   - Expression Semantics: expression-semantics.md

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -225,6 +225,104 @@ class TestEnsemblScopeErrors:
         assert "sha256:" in ref.reference_version
 
 
+class TestEnsemblHappyPath:
+    """End-to-end construction via a fully mocked pyensembl genome,
+    exercising the from_ensembl pipeline (protein iteration, gene
+    filtering, indexing, nearest lookup)."""
+
+    def _fake_genome(self):
+        # Two genes: KEEP_GENE (stays after CTA filter) and CTA_GENE.
+        # Each has one protein-coding transcript.
+        proteins = {
+            "PROT_KEEP": {
+                "gene_id": "KEEP_GENE",
+                "transcript_id": "ENST_KEEP",
+                "sequence": "MASIINFEKLGGG",  # 5 × 9-mers
+            },
+            "PROT_CTA": {
+                "gene_id": "CTA_GENE",
+                "transcript_id": "ENST_CTA",
+                "sequence": "QRSTVWYACDEFGH",  # different 9-mers
+            },
+        }
+        fake = MagicMock()
+        fake.protein_ids.return_value = list(proteins.keys())
+        fake.gene_id_of_protein_id.side_effect = (
+            lambda pid: proteins[pid]["gene_id"]
+        )
+        fake.transcript_id_of_protein_id.side_effect = (
+            lambda pid: proteins[pid]["transcript_id"]
+        )
+        fake.protein_sequence.side_effect = (
+            lambda pid: proteins[pid]["sequence"]
+        )
+        return fake
+
+    def test_from_ensembl_indexes_proteins_and_filters_cta(
+        self, monkeypatch,
+    ):
+        fake = self._fake_genome()
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        ref = SelfProteome.from_ensembl(
+            species="human",
+            release=93,
+            peptide_lengths=[9],
+            scope="non_cta",
+            cta_source={"CTA_GENE"},  # filter out CTA_GENE
+        )
+        # Only KEEP_GENE's 9-mers (5 of them) should be indexed.
+        assert ref.n_reference_peptides == 5
+        assert ref.reference_version == (
+            "ensembl-human-93+scope-non_cta+cta-sha256:"
+            + __import__("hashlib").sha256(b"CTA_GENE").hexdigest()[:12]
+        )
+
+    def test_from_ensembl_nearest_returns_real_provenance(
+        self, monkeypatch,
+    ):
+        fake = self._fake_genome()
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        ref = SelfProteome.from_ensembl(
+            species="human",
+            release=93,
+            peptide_lengths=[9],
+            scope="all",
+        )
+        # SIINFEKLG lives in KEEP_GENE at offset 2
+        out = ref.nearest(["SIINFEKLG"])
+        row = out.iloc[0]
+        assert row["self_nearest_peptide"] == "SIINFEKLG"
+        assert row["self_nearest_edit_distance"] == 0
+        assert row["self_nearest_gene_id"] == "KEEP_GENE"
+        assert row["self_nearest_transcript_id"] == "ENST_KEEP"
+        assert row["self_nearest_reference_offset"] == 2
+
+
+class TestTieBreaking:
+    """Pin the documented (and deterministic) tie-breaking rule:
+    when multiple reference peptides match at the same minimum
+    distance, the first in internal array order wins."""
+
+    def test_tie_at_distance_zero_first_reference_wins(self):
+        # Two genes with the same 9-mer — tie at distance 0.
+        # from_peptides builds the reference in insertion order, so
+        # geneA (declared first) should win.
+        ref = SelfProteome.from_peptides(
+            {"geneA": "SIINFEKLA", "geneB": "SIINFEKLA"},
+            peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLA"])
+        row = out.iloc[0]
+        assert row["self_nearest_edit_distance"] == 0
+        assert row["self_nearest_gene_id"] == "geneA"
+
+
 # ---------------------------------------------------------------------------
 # Integration with TopiaryPredictor
 # ---------------------------------------------------------------------------

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -358,3 +358,29 @@ class TestTopiaryPredictorIntegration:
             {"prot": "MASIINFEKLGGG"},
         )
         assert "self_nearest_peptide" not in df.columns
+
+    def test_self_nearest_on_fragment_path(self):
+        """Verify self_nearest_* columns appear on predict_from_fragments
+        output (the fragment path goes through _finalize_rows →
+        _apply_filter → _maybe_attach_self_nearest)."""
+        from topiary import ProteinFragment
+
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"}, peptide_lengths=[9],
+        )
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=["HLA-A*02:01"], default_peptide_lengths=[9],
+            ),
+            self_proteome=ref,
+        )
+        fragments = [
+            ProteinFragment(
+                fragment_id="test_frag",
+                sequence="MASIINFEKLGGG",
+            ),
+        ]
+        df = predictor.predict_from_fragments(fragments)
+        assert "self_nearest_peptide" in df.columns
+        assert "self_nearest_edit_distance" in df.columns
+        assert (df["self_nearest_edit_distance"] == 0).all()

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -1,0 +1,262 @@
+"""Tests for topiary.self_proteome.SelfProteome — construction, nearest
+lookup, scope filtering, and TopiaryPredictor integration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import SelfProteome, TopiaryPredictor
+
+
+# ---------------------------------------------------------------------------
+# Construction + basic metadata
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_peptides_indexes_by_length(self):
+        ref = SelfProteome.from_peptides(
+            {"geneA": "MASIINFEKLGGG"},   # length 13 → 5 × 9-mers
+            peptide_lengths=[9],
+        )
+        assert ref.peptide_lengths == [9]
+        assert ref.n_reference_peptides == 5
+
+    def test_from_peptides_multiple_lengths(self):
+        ref = SelfProteome.from_peptides(
+            {"geneA": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9, 10],
+        )
+        assert ref.peptide_lengths == [8, 9, 10]
+        # 13aa → 6 × 8-mers + 5 × 9-mers + 4 × 10-mers
+        assert ref.n_reference_peptides == 6 + 5 + 4
+
+    def test_reference_version_embeds_species_scope(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        assert "ensembl-synthetic" in ref.reference_version
+        assert "scope-all" in ref.reference_version
+
+    def test_from_peptides_short_sequence_skips_longer_lengths(self):
+        # 5aa sequence — can't produce any 9-mers
+        ref = SelfProteome.from_peptides(
+            {"geneA": "SIINF"},
+            peptide_lengths=[9],
+        )
+        assert ref.n_reference_peptides == 0
+
+
+# ---------------------------------------------------------------------------
+# FASTA loader
+# ---------------------------------------------------------------------------
+
+
+class TestFastaLoader:
+    def test_from_fasta_parses_multi_record(self, tmp_path):
+        path = tmp_path / "ref.fa"
+        path.write_text(
+            ">geneA\n"
+            "MASIINFEKLGGG\n"
+            ">geneB description line\n"
+            "QPRSTVWYACDEFGH\n"
+        )
+        ref = SelfProteome.from_fasta(path, peptide_lengths=[9])
+        # 5 × 9-mers from A + 7 × 9-mers from B = 12 distinct
+        assert ref.n_reference_peptides == 12
+
+    def test_from_fasta_rejects_named_scope_without_metadata(self, tmp_path):
+        path = tmp_path / "ref.fa"
+        path.write_text(">geneA\nSIINFEKLA\n")
+        with pytest.raises(ValueError, match="FASTA"):
+            SelfProteome.from_fasta(
+                path, peptide_lengths=[9], scope="non_cta",
+            )
+
+    def test_from_fasta_accepts_callable_scope(self, tmp_path):
+        path = tmp_path / "ref.fa"
+        path.write_text(
+            ">geneA\nMASIINFEKLGGG\n>geneB\nQPRSTVWYACDEF\n",
+        )
+        # Keep only geneA
+        ref = SelfProteome.from_fasta(
+            path, peptide_lengths=[9], scope=lambda g: g == "geneA",
+        )
+        # Only geneA 9-mers: 5 × 9
+        assert ref.n_reference_peptides == 5
+
+
+# ---------------------------------------------------------------------------
+# Nearest lookup
+# ---------------------------------------------------------------------------
+
+
+class TestNearest:
+    def test_exact_match_distance_zero(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLG"])
+        row = out.iloc[0]
+        assert row["self_nearest_peptide"] == "SIINFEKLG"
+        assert row["self_nearest_edit_distance"] == 0
+
+    def test_one_substitution_distance_one(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["XIINFEKLA"])
+        assert out.iloc[0]["self_nearest_edit_distance"] == 1
+        assert out.iloc[0]["self_nearest_peptide"] == "SIINFEKLA"
+
+    def test_multiple_queries_preserve_order(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGGQRSTV"}, peptide_lengths=[9],
+        )
+        queries = ["SIINFEKLG", "XXXXXXXXX", "ASIINFEKL"]
+        out = ref.nearest(queries)
+        assert list(out["peptide"]) == queries
+
+    def test_length_mismatch_returns_null_row(self):
+        # Reference has 9-mers; query is an 8-mer.
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["ABCDEFGH"])
+        row = out.iloc[0]
+        assert row["peptide"] == "ABCDEFGH"
+        assert row["self_nearest_peptide"] is None
+        assert row["self_nearest_edit_distance"] is None
+
+    def test_provenance_is_populated(self):
+        ref = SelfProteome.from_peptides(
+            {"MY_GENE": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLA"])
+        row = out.iloc[0]
+        assert row["self_nearest_gene_id"] == "MY_GENE"
+        assert row["self_nearest_transcript_id"] == "MY_GENE"
+        assert row["self_nearest_reference_offset"] == 0
+
+    def test_reference_version_stamped_on_every_row(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLA", "XXXXXXXXX"])
+        assert (out["self_nearest_reference_version"] == ref.reference_version).all()
+
+    def test_mixed_lengths_in_one_call(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9],
+        )
+        out = ref.nearest(["SIINFEKL", "SIINFEKLG"])
+        assert out.iloc[0]["self_nearest_peptide_length"] == 8
+        assert out.iloc[1]["self_nearest_peptide_length"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Scope resolution for from_ensembl (error paths, no actual Ensembl)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsemblScopeErrors:
+    def test_non_human_non_cta_without_source_raises(self, monkeypatch):
+        # Stub out pyensembl so we don't hit network / disk.
+        fake_release = MagicMock()
+        fake_release.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake_release,
+        )
+        with pytest.raises(ValueError, match="no default registered"):
+            SelfProteome.from_ensembl(species="mouse", scope="non_cta")
+
+    def test_pirlygenes_requires_human(self, monkeypatch):
+        fake_release = MagicMock()
+        fake_release.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake_release,
+        )
+        with pytest.raises(ValueError, match="human-only"):
+            SelfProteome.from_ensembl(
+                species="mouse", scope="non_cta", cta_source="pirlygenes",
+            )
+
+    def test_protected_tissues_not_yet_implemented(self, monkeypatch):
+        fake_release = MagicMock()
+        fake_release.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake_release,
+        )
+        with pytest.raises(NotImplementedError, match="protected_tissues"):
+            SelfProteome.from_ensembl(
+                species="human", scope="protected_tissues",
+            )
+
+    def test_unknown_scope_string_rejects(self, monkeypatch):
+        fake_release = MagicMock()
+        fake_release.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake_release,
+        )
+        with pytest.raises(ValueError, match="Unknown scope"):
+            SelfProteome.from_ensembl(
+                species="human", scope="bananas",
+            )
+
+    def test_custom_cta_source_as_set(self, monkeypatch):
+        fake_release = MagicMock()
+        fake_release.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake_release,
+        )
+        # Non-human + explicit CTA set should succeed.
+        ref = SelfProteome.from_ensembl(
+            species="mouse", scope="non_cta",
+            cta_source={"ENSMUSG0001", "ENSMUSG0002"},
+        )
+        assert "non_cta" in ref.reference_version
+        assert "sha256:" in ref.reference_version
+
+
+# ---------------------------------------------------------------------------
+# Integration with TopiaryPredictor
+# ---------------------------------------------------------------------------
+
+
+class TestTopiaryPredictorIntegration:
+    def test_self_nearest_columns_appear_on_predict_output(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"}, peptide_lengths=[9],
+        )
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=["HLA-A*02:01"], default_peptide_lengths=[9],
+            ),
+            self_proteome=ref,
+        )
+        df = predictor.predict_from_named_sequences(
+            {"prot": "MASIINFEKLGGG"},
+        )
+        assert "self_nearest_peptide" in df.columns
+        assert "self_nearest_edit_distance" in df.columns
+        assert "self_nearest_reference_version" in df.columns
+        # Every predicted peptide is in the reference → all distances 0.
+        assert (df["self_nearest_edit_distance"] == 0).all()
+
+    def test_no_self_proteome_no_columns(self):
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=["HLA-A*02:01"], default_peptide_lengths=[9],
+            ),
+        )
+        df = predictor.predict_from_named_sequences(
+            {"prot": "MASIINFEKLGGG"},
+        )
+        assert "self_nearest_peptide" not in df.columns

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -43,6 +43,7 @@ from .sequence_helpers import (
 )
 from .cached import CachedPredictor, mhcflurry_composite_version
 from .protein_fragment import ProteinFragment, make_fragment_id
+from .self_proteome import SelfProteome
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
 from .io_protein_fragment import read_fragments, write_fragments, iter_fragments
 from .io_lens import detect_lens_version, read_lens
@@ -55,6 +56,7 @@ __all__ = [
     "TopiaryPredictor",
     "CachedPredictor",
     "mhcflurry_composite_version",
+    "SelfProteome",
     "Affinity",
     "BinOp",
     "BoolOp",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -356,6 +356,7 @@ class TopiaryPredictor(object):
         raise_on_error=True,
         mhc_model=None,
         mhc_models=None,
+        self_proteome=None,
     ):
         """
         Parameters
@@ -452,6 +453,7 @@ class TopiaryPredictor(object):
         self.min_gene_expression = min_gene_expression
         self.only_novel_epitopes = only_novel_epitopes
         self.raise_on_error = raise_on_error
+        self.self_proteome = self_proteome
 
     @property
     def mhc_model(self):
@@ -574,11 +576,26 @@ class TopiaryPredictor(object):
         """Apply filter and sort if configured."""
         if df.empty:
             return df
+        df = self._maybe_attach_self_nearest(df)
         if self.filter_by is not None:
             df = apply_filter(df, self.filter_by)
         if self.sort_by:
             df = apply_sort(df, self.sort_by, sort_direction=self.sort_direction)
         return df
+
+    def _maybe_attach_self_nearest(self, df):
+        """Join ``self_nearest_*`` columns onto ``df`` keyed on peptide.
+
+        No-op when ``self.self_proteome`` is ``None``; otherwise runs a
+        single ``nearest()`` call over the unique peptides in ``df`` and
+        merges the result back.  Runs before filter/sort so users can
+        reference the new columns in ``filter_by`` / ``sort_by``.
+        """
+        if self.self_proteome is None:
+            return df
+        unique = df["peptide"].drop_duplicates().tolist()
+        nearest = self.self_proteome.nearest(unique)
+        return df.merge(nearest, on="peptide", how="left")
 
     def _finalize_rows(self, df):
         """Apply filter / sort, drop non-mutant rows when

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -185,6 +185,15 @@ class SelfProteome:
         ``self_nearest_reference_version``.  Rows where no reference
         exists at the query's length have ``None`` / ``NaN`` for the
         nearest-peptide columns.
+
+        Tie-breaking: when multiple reference peptides share the
+        minimum Hamming distance to the query, the first one in the
+        internal reference array (construction / insertion order) is
+        returned.  Deterministic but implementation-dependent — don't
+        rely on which specific peptide wins unless you also control
+        the reference-construction order.  The upcoming
+        ``self_nearest_candidates`` structured column (see #124, part B)
+        exposes the full tied set for callers who care.
         """
         peptides = [str(p) for p in peptides]
         # Partition queries by length to batch SIMD calls.

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -1,0 +1,526 @@
+"""SelfProteome — reference protein corpus for cross-reactivity analysis.
+
+Holds a species-tagged, scope-filtered protein set indexed by peptide
+length.  Answers per-query nearest-neighbor lookups: "given this mutant
+peptide, what's the most similar peptide in healthy human self?"
+
+Scopes
+------
+- ``"all"``: no filter, whole Ensembl proteome (any pyensembl-supported species).
+- ``"non_cta"`` (default for human): remove cancer-testis-antigen genes via
+  pirlygenes.  Non-human species require an explicit ``cta_source=`` set
+  or callable — pirlygenes is human-only today.
+- callable: user-supplied ``gene → bool`` filter.  Works for any species.
+
+Additional scopes (``"protected_tissues"`` with HPA/GTEx expression-based
+filtering, 1aa-indel candidates, the ``self_nearest_by_binding`` and
+``self_strongest_nearby`` axes, and the full candidate-set structured
+column) are queued for a follow-up PR.  This module currently ships the
+core architecture and one nearest-by-sequence axis so downstream code can
+start consuming ``self_nearest_*`` columns in a real predictor run.
+
+Algorithm
+---------
+SIMD-vectorized Hamming distance against int8-encoded reference arrays.
+Only substitutions (same-length matches) in this PR; indels land in the
+follow-up alongside seed-and-extend for larger reference corpora.  See
+#124 for the benchmark plan driving the eventual algorithm choice.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import defaultdict
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Amino-acid encoding
+# ---------------------------------------------------------------------------
+
+
+_AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+_AA_TO_INT = {aa: i for i, aa in enumerate(_AA_ALPHABET)}
+# Non-standard residues (B/J/O/U/X/Z/*) all map to one sentinel so they
+# always count as a mismatch against canonical residues.
+_UNKNOWN_AA = len(_AA_ALPHABET)
+
+
+def _encode_peptides(peptides: List[str], length: int) -> np.ndarray:
+    """Encode peptides as an ``(N, length)`` int8 array.  Peptides
+    shorter than ``length`` are padded with the unknown sentinel;
+    peptides longer than ``length`` are truncated."""
+    arr = np.full((len(peptides), length), _UNKNOWN_AA, dtype=np.int8)
+    for i, pep in enumerate(peptides):
+        for j, aa in enumerate(pep[:length]):
+            arr[i, j] = _AA_TO_INT.get(aa.upper(), _UNKNOWN_AA)
+    return arr
+
+
+# ---------------------------------------------------------------------------
+# Scope resolution
+# ---------------------------------------------------------------------------
+
+
+# Species → per-scope defaults.  Only human is populated today; other
+# species raise a clear error when asked to default rather than silently
+# returning unfiltered data.
+_SPECIES_DEFAULTS: Dict[str, Dict[str, str]] = {
+    "human": {
+        "cta_source": "pirlygenes",
+    },
+}
+
+
+def _resolve_cta_gene_ids(
+    species: str, cta_source,
+) -> Union[Set[str], Callable]:
+    """Produce either a set of CTA gene IDs or a callable filter.
+
+    Accepts ``"pirlygenes"``, ``"tsarina"``, a set of gene IDs, or a
+    ``Callable[[gene_id], bool]``.  When ``cta_source`` is ``None`` the
+    species default is consulted; unregistered species raise."""
+    if cta_source is None:
+        defaults = _SPECIES_DEFAULTS.get(species, {})
+        cta_source = defaults.get("cta_source")
+        if cta_source is None:
+            raise ValueError(
+                f"scope='non_cta' needs a CTA source for "
+                f"species={species!r}; no default registered.  Pass "
+                f"cta_source=<set or callable> explicitly, or use "
+                f"scope='all'."
+            )
+
+    if callable(cta_source):
+        return cta_source
+    if isinstance(cta_source, (set, frozenset)):
+        return set(cta_source)
+    if cta_source == "pirlygenes":
+        if species != "human":
+            raise ValueError(
+                f"cta_source='pirlygenes' is human-only; got "
+                f"species={species!r}.  Pass a species-appropriate "
+                f"set or callable."
+            )
+        from topiary.sources import _pirlygenes_cta_gene_ids
+        return set(_pirlygenes_cta_gene_ids())
+    if cta_source == "tsarina":
+        raise NotImplementedError(
+            "cta_source='tsarina' is reserved for a follow-up PR."
+        )
+    raise ValueError(
+        f"Unsupported cta_source: {cta_source!r}.  Use 'pirlygenes', "
+        f"a set of gene IDs, a callable, or None to use the species "
+        f"default."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SelfProteome
+# ---------------------------------------------------------------------------
+
+
+class SelfProteome:
+    """Reference proteome for cross-reactivity / nearest-self lookups.
+
+    Constructed via :meth:`from_fasta`, :meth:`from_ensembl`, or
+    :meth:`from_peptides` (test helper).  Holds per-length reference
+    arrays + a provenance index, and answers :meth:`nearest` queries.
+    """
+
+    def __init__(
+        self,
+        *,
+        species: str,
+        release: Optional[str],
+        scope_label: str,
+        reference_arrays: Dict[int, np.ndarray],
+        reference_peptides: Dict[int, List[str]],
+        provenance: Dict[str, List[Tuple[str, str, int]]],
+    ):
+        self.species = species
+        self.release = release
+        self.scope_label = scope_label
+        self._reference_arrays = reference_arrays
+        self._reference_peptides = reference_peptides
+        self._provenance = provenance
+
+    # --- metadata ---
+
+    @property
+    def peptide_lengths(self) -> List[int]:
+        return sorted(self._reference_arrays.keys())
+
+    @property
+    def n_reference_peptides(self) -> int:
+        return sum(len(v) for v in self._reference_peptides.values())
+
+    @property
+    def reference_version(self) -> str:
+        """Composite version string for reproducibility.
+
+        Stamped on every row of :meth:`nearest`'s output; two runs with
+        matching strings produce interchangeable ``self_nearest_peptide``
+        values.
+        """
+        release_part = f"-{self.release}" if self.release is not None else ""
+        return (
+            f"ensembl-{self.species}{release_part}+scope-{self.scope_label}"
+        )
+
+    # --- lookup ---
+
+    def nearest(self, peptides: Iterable[str]) -> pd.DataFrame:
+        """For each query peptide, return the closest reference peptide
+        at the same length (Hamming distance, substitutions only).
+
+        Returns a DataFrame with one row per input peptide, preserving
+        input order, containing ``peptide``, ``self_nearest_peptide``,
+        ``self_nearest_peptide_length``, ``self_nearest_edit_distance``,
+        ``self_nearest_gene_id``, ``self_nearest_transcript_id``,
+        ``self_nearest_reference_offset``, and
+        ``self_nearest_reference_version``.  Rows where no reference
+        exists at the query's length have ``None`` / ``NaN`` for the
+        nearest-peptide columns.
+        """
+        peptides = [str(p) for p in peptides]
+        # Partition queries by length to batch SIMD calls.
+        by_length: Dict[int, List[Tuple[int, str]]] = defaultdict(list)
+        for idx, pep in enumerate(peptides):
+            by_length[len(pep)].append((idx, pep))
+
+        results: List[Optional[dict]] = [None] * len(peptides)
+        for L, items in by_length.items():
+            if L not in self._reference_arrays:
+                for idx, pep in items:
+                    results[idx] = self._empty_row(pep)
+                continue
+            self._resolve_length(L, items, results)
+
+        return pd.DataFrame(results)
+
+    def _empty_row(self, peptide: str) -> dict:
+        return {
+            "peptide": peptide,
+            "self_nearest_peptide": None,
+            "self_nearest_peptide_length": None,
+            "self_nearest_edit_distance": None,
+            "self_nearest_gene_id": None,
+            "self_nearest_transcript_id": None,
+            "self_nearest_reference_offset": None,
+            "self_nearest_reference_version": self.reference_version,
+        }
+
+    def _resolve_length(
+        self,
+        L: int,
+        items: List[Tuple[int, str]],
+        results: List[Optional[dict]],
+        chunk_size: int = 1000,
+    ) -> None:
+        ref_arr = self._reference_arrays[L]
+        ref_peps = self._reference_peptides[L]
+        query_peps = [pep for _, pep in items]
+        query_arr = _encode_peptides(query_peps, L)
+
+        # Chunk to bound working memory: (chunk, M, L) diff tensor.
+        for start in range(0, len(query_arr), chunk_size):
+            end = min(start + chunk_size, len(query_arr))
+            q_chunk = query_arr[start:end]
+            # (chunk, M, L) != broadcasted → sum over last axis → (chunk, M).
+            diffs = (
+                q_chunk[:, None, :] != ref_arr[None, :, :]
+            ).sum(axis=2)
+            best_idx = diffs.argmin(axis=1)
+            best_dist = diffs[np.arange(len(q_chunk)), best_idx]
+
+            for k, (orig_idx, orig_pep) in enumerate(items[start:end]):
+                ref_pep = ref_peps[int(best_idx[k])]
+                prov = self._provenance.get(ref_pep)
+                if prov:
+                    gene_id, transcript_id, offset = prov[0]
+                else:
+                    gene_id, transcript_id, offset = None, None, None
+                results[orig_idx] = {
+                    "peptide": orig_pep,
+                    "self_nearest_peptide": ref_pep,
+                    "self_nearest_peptide_length": L,
+                    "self_nearest_edit_distance": int(best_dist[k]),
+                    "self_nearest_gene_id": gene_id,
+                    "self_nearest_transcript_id": transcript_id,
+                    "self_nearest_reference_offset": offset,
+                    "self_nearest_reference_version": self.reference_version,
+                }
+
+    # --- constructors ---
+
+    @classmethod
+    def from_peptides(
+        cls,
+        peptides_by_source: Dict[str, str],
+        *,
+        peptide_lengths: Iterable[int] = (8, 9, 10, 11),
+        species: str = "synthetic",
+        release: Optional[str] = None,
+        scope_label: str = "all",
+    ) -> "SelfProteome":
+        """Build from an in-memory ``{source_id: amino_acid_sequence}``
+        mapping.  Primarily a test helper; also useful for small
+        programmatic reference sets.
+
+        ``source_id`` is recorded as both ``gene_id`` and
+        ``transcript_id`` in the provenance index since this constructor
+        doesn't distinguish between them.
+        """
+        reference_arrays, reference_peptides, provenance = _build_index(
+            (
+                (source_id, source_id, source_id, seq)
+                for source_id, seq in peptides_by_source.items()
+            ),
+            peptide_lengths,
+        )
+        return cls(
+            species=species,
+            release=release,
+            scope_label=scope_label,
+            reference_arrays=reference_arrays,
+            reference_peptides=reference_peptides,
+            provenance=provenance,
+        )
+
+    @classmethod
+    def from_fasta(
+        cls,
+        path,
+        *,
+        peptide_lengths: Iterable[int] = (8, 9, 10, 11),
+        species: str = "fasta",
+        release: Optional[str] = None,
+        scope: Union[str, Callable] = "all",
+    ) -> "SelfProteome":
+        """Build from a FASTA file.  Each record's ID is used as both
+        gene_id and transcript_id in provenance (FASTA doesn't carry
+        the distinction).
+
+        ``scope`` accepts ``"all"`` or a callable ``(source_id) -> bool``;
+        ``"non_cta"`` and ``"protected_tissues"`` require gene-metadata
+        that FASTA doesn't provide, so use :meth:`from_ensembl` for
+        those scopes.
+        """
+        records = list(_parse_fasta(path))
+        scope_label, records = _apply_fasta_scope(scope, records)
+        reference_arrays, reference_peptides, provenance = _build_index(
+            records, peptide_lengths,
+        )
+        return cls(
+            species=species,
+            release=release,
+            scope_label=scope_label,
+            reference_arrays=reference_arrays,
+            reference_peptides=reference_peptides,
+            provenance=provenance,
+        )
+
+    @classmethod
+    def from_ensembl(
+        cls,
+        species: str = "human",
+        release: Optional[int] = None,
+        *,
+        peptide_lengths: Iterable[int] = (8, 9, 10, 11),
+        scope: Union[str, Callable] = "non_cta",
+        cta_source=None,
+    ) -> "SelfProteome":
+        """Build from a pyensembl EnsemblRelease.
+
+        ``scope`` accepts ``"all"``, ``"non_cta"``, or a callable
+        ``(gene_id) -> bool``.  For ``scope="non_cta"`` with
+        ``species="human"``, the default ``cta_source="pirlygenes"``
+        needs no configuration.  Non-human species must pass
+        ``cta_source=<set or callable>`` explicitly.
+
+        ``scope="protected_tissues"`` lands in a follow-up PR.
+        """
+        try:
+            from pyensembl import EnsemblRelease
+        except ImportError as e:
+            raise ImportError(
+                "pyensembl is required for SelfProteome.from_ensembl"
+            ) from e
+
+        genome = EnsemblRelease(release=release, species=species)
+        scope_label, gene_filter = _resolve_ensembl_scope(
+            scope, species, cta_source,
+        )
+        records = list(_iter_ensembl_proteins(genome, gene_filter))
+        reference_arrays, reference_peptides, provenance = _build_index(
+            records, peptide_lengths,
+        )
+        return cls(
+            species=species,
+            release=str(release) if release is not None else None,
+            scope_label=scope_label,
+            reference_arrays=reference_arrays,
+            reference_peptides=reference_peptides,
+            provenance=provenance,
+        )
+
+
+# ---------------------------------------------------------------------------
+# FASTA + Ensembl helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_fasta(path):
+    """Yield ``(source_id, source_id, source_id, sequence)`` tuples."""
+    current_id = None
+    buf: List[str] = []
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if current_id is not None:
+                    yield current_id, current_id, current_id, "".join(buf)
+                header = line[1:].split()[0]
+                current_id = header
+                buf = []
+            else:
+                buf.append(line)
+    if current_id is not None:
+        yield current_id, current_id, current_id, "".join(buf)
+
+
+def _apply_fasta_scope(scope, records):
+    """Filter FASTA records by scope.  Returns (scope_label, filtered_records)."""
+    if scope == "all":
+        return "all", records
+    if callable(scope):
+        label = (
+            "callable-"
+            + hashlib.sha256(repr(scope).encode()).hexdigest()[:12]
+        )
+        return label, [r for r in records if scope(r[0])]
+    raise ValueError(
+        f"scope={scope!r} isn't available for from_fasta (FASTA has no "
+        f"gene/tissue metadata).  Use 'all', a callable, or switch to "
+        f"from_ensembl."
+    )
+
+
+def _resolve_ensembl_scope(scope, species, cta_source):
+    """Return (scope_label, gene_filter) where gene_filter takes a gene_id
+    and returns True to keep."""
+    if callable(scope):
+        label = (
+            "callable-"
+            + hashlib.sha256(repr(scope).encode()).hexdigest()[:12]
+        )
+        return label, scope
+    if scope == "all":
+        return "all", lambda _gene_id: True
+    if scope == "non_cta":
+        cta = _resolve_cta_gene_ids(species, cta_source)
+        if callable(cta):
+            return "non_cta-callable", lambda g: not cta(g)
+        label = _cta_label(species, cta_source, cta)
+        cta_set = cta  # set of gene IDs
+        return label, lambda gene_id: gene_id not in cta_set
+    if scope == "protected_tissues":
+        raise NotImplementedError(
+            "scope='protected_tissues' lands in a follow-up PR."
+        )
+    raise ValueError(f"Unknown scope: {scope!r}.")
+
+
+def _cta_label(species, cta_source, cta_set):
+    """Compose a human-readable label for the non_cta scope."""
+    if cta_source is None and species == "human":
+        # Using pirlygenes default.
+        try:
+            import pirlygenes
+            return f"non_cta+cta-pirlygenes-{pirlygenes.__version__}"
+        except (ImportError, AttributeError):
+            return "non_cta+cta-pirlygenes"
+    if isinstance(cta_source, str):
+        return f"non_cta+cta-{cta_source}"
+    # Custom set — hash the gene IDs for reproducibility.
+    digest = hashlib.sha256(
+        "\n".join(sorted(cta_set)).encode()
+    ).hexdigest()[:12]
+    return f"non_cta+cta-sha256:{digest}"
+
+
+def _iter_ensembl_proteins(genome, gene_filter):
+    """Yield ``(gene_id, transcript_id, protein_id, sequence)`` tuples for
+    every protein whose gene passes ``gene_filter``."""
+    for protein_id in genome.protein_ids():
+        try:
+            gene_id = genome.gene_id_of_protein_id(protein_id)
+        except ValueError:
+            continue
+        if not gene_filter(gene_id):
+            continue
+        try:
+            transcript_id = genome.transcript_id_of_protein_id(protein_id)
+        except (ValueError, AttributeError):
+            transcript_id = protein_id
+        seq = genome.protein_sequence(protein_id)
+        if not seq:
+            continue
+        yield gene_id, transcript_id, protein_id, seq
+
+
+# ---------------------------------------------------------------------------
+# Index construction
+# ---------------------------------------------------------------------------
+
+
+def _build_index(records, peptide_lengths):
+    """Build per-length reference arrays and a provenance index.
+
+    ``records`` yields ``(gene_id, transcript_id, protein_id, sequence)``.
+
+    Returns (reference_arrays, reference_peptides, provenance) where:
+    - ``reference_arrays[L]`` is an ``(M_L, L)`` int8 NumPy array.
+    - ``reference_peptides[L]`` is a list of peptide strings aligned to
+      the rows of ``reference_arrays[L]``.
+    - ``provenance[peptide]`` is a list of
+      ``(gene_id, transcript_id, offset)`` tuples — one entry per
+      occurrence, so paralogs / repeats all contribute.
+    """
+    peptide_lengths = sorted(set(peptide_lengths))
+    # Dedupe peptides per length while accumulating provenance.
+    peptides_by_length: Dict[int, Dict[str, None]] = {
+        L: {} for L in peptide_lengths
+    }
+    provenance: Dict[str, List[Tuple[str, str, int]]] = defaultdict(list)
+
+    for gene_id, transcript_id, _protein_id, seq in records:
+        for L in peptide_lengths:
+            if L > len(seq):
+                continue
+            for offset in range(len(seq) - L + 1):
+                pep = seq[offset:offset + L]
+                peptides_by_length[L][pep] = None
+                provenance[pep].append((gene_id, transcript_id, offset))
+
+    reference_peptides: Dict[int, List[str]] = {}
+    reference_arrays: Dict[int, np.ndarray] = {}
+    for L, pep_dict in peptides_by_length.items():
+        peps = list(pep_dict.keys())
+        reference_peptides[L] = peps
+        reference_arrays[L] = _encode_peptides(peps, L) if peps else (
+            np.empty((0, L), dtype=np.int8)
+        )
+
+    logging.info(
+        "SelfProteome index: %d distinct peptides across lengths %s",
+        sum(len(v) for v in reference_peptides.values()),
+        peptide_lengths,
+    )
+    return reference_arrays, reference_peptides, dict(provenance)


### PR DESCRIPTION
## Summary

Part A of #124 (cross-reactivity analysis via nearest-self lookups).  Ships the \`SelfProteome\` class + its integration with \`TopiaryPredictor\`, so downstream code can start consuming \`self_nearest_*\` columns in real predictor runs.

Scope is deliberately minimal — one nearest-by-sequence axis, substitutions only, \`scope=\"all\"\` and \`scope=\"non_cta\"\` — to get the architecture in and reviewed.  The richer pieces queued for follow-up PRs are listed below.

## What ships

- \`topiary/self_proteome.py\` — \`SelfProteome\` class with three constructors (\`from_peptides\`, \`from_fasta\`, \`from_ensembl\`).
- SIMD-vectorized Hamming-distance nearest search against int8-encoded reference arrays per peptide length.  Chunked for memory bound.
- \`scope=\"all\"\` and \`scope=\"non_cta\"\` (defaults for human via pirlygenes; non-human must supply \`cta_source\` explicitly; unsupported combos raise with an actionable message).  Callable \`scope=\` accepted as the universal escape hatch.
- Composite \`reference_version\` stamped on every output row; custom filters hash into the string for reproducibility.
- \`TopiaryPredictor(self_proteome=…)\` kwarg attaches \`self_nearest_*\` columns to prediction output *before* filter/sort evaluate, so DSL expressions can reference them.
- New \`docs/self_proteome.md\` page + nav entry.

## What's deferred (tracked on #124)

- \`scope=\"protected_tissues\"\` (HPA / GTEx-backed tissue filtering).
- 1aa insertion / deletion candidates.
- The second + third \"nearest\" axes: \`self_nearest_by_binding\` and \`self_strongest_nearby\`.
- \`self_nearest_candidates\` structured column.
- Seed-and-extend algorithm — benchmark decides the default.
- Bundled prediction artifacts for the self-proteome × common HLA pairs.

## Test plan

- [x] 21 new tests in \`tests/test_self_proteome.py\` (construction, FASTA parsing, nearest lookup, scope resolution error paths, TopiaryPredictor integration).
- [x] \`./test.sh\` — 1132 passed, 3 skipped (up from 1111).
- [x] \`./lint.sh\` — clean.
- [x] \`mkdocs build --strict\` — clean.
- [ ] CI green.

Part A of #124.