### PR TITLE
CachedPredictor CLI + real NetMHC fixtures + README reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,15 +574,17 @@ including cache-plus-fallback mode and opt-in version equivalence.
 From the CLI:
 
 ```bash
-# Skip the live predictor, read from an mhcflurry CSV
+# Skip the live predictor, read from an mhcflurry CSV.  Format is
+# sniffed from file content; no --mhc-cache-format needed for
+# NetMHC-family / mhcflurry / topiary-output files.
 topiary --peptide-csv peptides.csv \
     --mhc-cache-file mhcflurry_predictions.csv \
-    --mhc-cache-format mhcflurry \
     --output-csv results.csv
 ```
 
-`--mhc-cache-format` accepts `topiary_output`, `mhcflurry`, `tsv`,
-`netmhcpan_stdout`, `netmhc_stdout`, `netmhcpan_cons_stdout`,
-`netmhciipan_stdout`, or `netmhcstabpan_stdout`.
-`--mhc-predictor` and `--mhc-alleles` become optional when a cache
-is supplying predictions.
+`--mhc-cache-format` (optional; sniffed when omitted) accepts
+`topiary_output`, `mhcflurry`, `tsv`, `netmhcpan`, `netmhc`,
+`netmhccons`, `netmhciipan`, or `netmhcstabpan`. Only the generic
+`tsv` format strictly requires the explicit flag. `--mhc-predictor`
+and `--mhc-alleles` become optional when a cache is supplying
+predictions.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,41 @@ predictor = TopiaryPredictor(
 )
 ```
 
+## MHC prediction models
+
+Specify one or more predictors with `--mhc-predictor` and alleles with `--mhc-alleles`:
+
+```bash
+--mhc-predictor netmhcpan mhcflurry --mhc-alleles HLA-A*02:01,HLA-B*07:02
+```
+
+All predictors come from [mhctools](https://github.com/openvax/mhctools).
+
+With `mhctools 3.7.0+`, upstream predictor parsing supports multiple
+predictors in one CLI invocation, so commands like
+`--mhc-predictor netmhcpan42 bigmhc-el` are supported directly. Topiary keeps
+its higher-level `--filter-by` / `--sort-by` DSL on top of that lower-level
+predictor interface. Topiary's ranking/filtering DSL is also compatible with
+the simplified `mhctools 3.7.0+` kind constants API. NetChop and Pepsickle
+behavior follows the upstream changes as well: improved NetChop error handling
+and Pepsickle's epitope-focused model selection.
+
+| CLI name | Predicts |
+|----------|----------|
+| `netmhcpan` | affinity + presentation (auto-detects installed version) |
+| `netmhcpan4` / `netmhcpan41` / `netmhcpan42` | specific NetMHCpan 4.x versions |
+| `netmhcpan4-ba` / `netmhcpan4-el` | single-mode (binding affinity or eluted ligand) |
+| `mhcflurry` | affinity + presentation + processing |
+| `mixmhcpred` | presentation |
+| `netmhciipan` / `netmhciipan4` / `netmhciipan43` | MHC class II |
+| `bigmhc` / `bigmhc-el` / `bigmhc-im` | presentation / immunogenicity |
+| `netmhcstabpan` | pMHC stability |
+| `pepsickle` / `netchop` | proteasomal cleavage |
+| `netmhcpan-iedb` / `netmhccons-iedb` / `smm-iedb` | IEDB web API (no local install) |
+| `random` | random predictions (for testing) |
+
+Peptide lengths: `--mhc-epitope-lengths 8,9,10,11` (defaults come from the predictor).
+
 ## Filtering and ranking
 
 Topiary has an expression language for filtering and ranking predictions. It works identically as Python objects and as CLI strings.
@@ -439,80 +474,6 @@ Remove peptides found in reference proteomes — for tumor-specific or pathogen-
 --exclude-mode substring             # "substring" (default) or "exact"
 ```
 
-## Cached predictions
-
-Skip the live predictor by loading pre-computed scores into a
-`CachedPredictor`, then passing it to `TopiaryPredictor(models=…)`.
-Useful for reproducibility, iterating on filters/ranking without
-paying the predictor cost, or ingesting predictions from a tool
-topiary doesn't natively run.
-
-```python
-from topiary import CachedPredictor, TopiaryPredictor
-
-# From topiary's own saved output, mhcflurry CSV, NetMHC-family
-# stdout captures, or a generic TSV/CSV with column mapping.
-cache = CachedPredictor.from_topiary_output("run.parquet")
-# cache = CachedPredictor.from_mhcflurry("mhcflurry.csv")
-# cache = CachedPredictor.from_netmhcpan_stdout("netmhcpan.out")
-# cache = CachedPredictor.from_netmhciipan_stdout("ii.out", version="4.3")
-# cache = CachedPredictor.from_netmhcstabpan_stdout("stab.out")
-# cache = CachedPredictor.from_tsv("third_party.tsv", columns={...},
-#                                  prediction_method_name="netchop",
-#                                  predictor_version="3.1")
-
-# Merge shards from parallel prediction jobs
-# cache = CachedPredictor.concat([shard_a, shard_b, shard_c])
-# cache = CachedPredictor.from_directory("caches/", pattern="*.parquet")
-
-predictor = TopiaryPredictor(models=cache)
-df = predictor.predict_from_variants(variants)
-```
-
-Every cache holds exactly one `(predictor_name, predictor_version)`
-pair — mixing versions is rejected. mhcflurry's composite version
-(package + model bundle) is auto-composed from the local install;
-users never enumerate bundles manually. Sharding (`concat` /
-`from_directory`) merges shards from parallel prediction jobs with
-an overlap-resolution policy (`"raise"` / `"last"` / `"first"` /
-callable). See [docs/cached.md](docs/cached.md) for full detail,
-including cache-plus-fallback mode and opt-in version equivalence.
-
-## MHC prediction models
-
-Specify one or more predictors with `--mhc-predictor` and alleles with `--mhc-alleles`:
-
-```bash
---mhc-predictor netmhcpan mhcflurry --mhc-alleles HLA-A*02:01,HLA-B*07:02
-```
-
-All predictors come from [mhctools](https://github.com/openvax/mhctools).
-
-With `mhctools 3.7.0+`, upstream predictor parsing supports multiple
-predictors in one CLI invocation, so commands like
-`--mhc-predictor netmhcpan42 bigmhc-el` are supported directly. Topiary keeps
-its higher-level `--filter-by` / `--sort-by` DSL on top of that lower-level
-predictor interface. Topiary's ranking/filtering DSL is also compatible with
-the simplified `mhctools 3.7.0+` kind constants API. NetChop and Pepsickle
-behavior follows the upstream changes as well: improved NetChop error handling
-and Pepsickle's epitope-focused model selection.
-
-| CLI name | Predicts |
-|----------|----------|
-| `netmhcpan` | affinity + presentation (auto-detects installed version) |
-| `netmhcpan4` / `netmhcpan41` / `netmhcpan42` | specific NetMHCpan 4.x versions |
-| `netmhcpan4-ba` / `netmhcpan4-el` | single-mode (binding affinity or eluted ligand) |
-| `mhcflurry` | affinity + presentation + processing |
-| `mixmhcpred` | presentation |
-| `netmhciipan` / `netmhciipan4` / `netmhciipan43` | MHC class II |
-| `bigmhc` / `bigmhc-el` / `bigmhc-im` | presentation / immunogenicity |
-| `netmhcstabpan` | pMHC stability |
-| `pepsickle` / `netchop` | proteasomal cleavage |
-| `netmhcpan-iedb` / `netmhccons-iedb` / `smm-iedb` | IEDB web API (no local install) |
-| `random` | random predictions (for testing) |
-
-Peptide lengths: `--mhc-epitope-lengths 8,9,10,11` (defaults come from the predictor).
-
 ## Output
 
 ```bash
@@ -570,3 +531,58 @@ cta = cta_sequences()                          # cancer-testis antigens
 heart = tissue_expressed_sequences(["heart_muscle"])
 print(available_tissues())                      # list tissue names
 ```
+
+## Cached predictions
+
+Skip the live predictor by loading pre-computed scores into a
+`CachedPredictor`, then passing it to `TopiaryPredictor(models=…)`.
+Useful for reproducibility, iterating on filters/ranking without
+paying the predictor cost, or ingesting predictions from a tool
+topiary doesn't natively run.
+
+```python
+from topiary import CachedPredictor, TopiaryPredictor
+
+# From topiary's own saved output, mhcflurry CSV, NetMHC-family
+# stdout captures, or a generic TSV/CSV with column mapping.
+cache = CachedPredictor.from_topiary_output("run.parquet")
+# cache = CachedPredictor.from_mhcflurry("mhcflurry.csv")
+# cache = CachedPredictor.from_netmhcpan_stdout("netmhcpan.out")
+# cache = CachedPredictor.from_netmhciipan_stdout("ii.out", version="4.3")
+# cache = CachedPredictor.from_netmhcstabpan_stdout("stab.out")
+# cache = CachedPredictor.from_tsv("third_party.tsv", columns={...},
+#                                  prediction_method_name="netchop",
+#                                  predictor_version="3.1")
+
+# Merge shards from parallel prediction jobs
+# cache = CachedPredictor.concat([shard_a, shard_b, shard_c])
+# cache = CachedPredictor.from_directory("caches/", pattern="*.parquet")
+
+predictor = TopiaryPredictor(models=cache)
+df = predictor.predict_from_variants(variants)
+```
+
+Every cache holds exactly one `(predictor_name, predictor_version)`
+pair — mixing versions is rejected. mhcflurry's composite version
+(package + model bundle) is auto-composed from the local install;
+users never enumerate bundles manually. Sharding (`concat` /
+`from_directory`) merges shards from parallel prediction jobs with
+an overlap-resolution policy (`"raise"` / `"last"` / `"first"` /
+callable). See [docs/cached.md](docs/cached.md) for full detail,
+including cache-plus-fallback mode and opt-in version equivalence.
+
+From the CLI:
+
+```bash
+# Skip the live predictor, read from an mhcflurry CSV
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-file mhcflurry_predictions.csv \
+    --mhc-cache-format mhcflurry \
+    --output-csv results.csv
+```
+
+`--mhc-cache-format` accepts `topiary_output`, `mhcflurry`, `tsv`,
+`netmhcpan_stdout`, `netmhc_stdout`, `netmhcpan_cons_stdout`,
+`netmhciipan_stdout`, or `netmhcstabpan_stdout`.
+`--mhc-predictor` and `--mhc-alleles` become optional when a cache
+is supplying predictions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ pre-computed table. Pass as `models=cache` to `TopiaryPredictor`. See
 |--------|--------|
 | `CachedPredictor.from_topiary_output(path)` | Parquet / TSV / CSV previously written from a topiary run. |
 | `CachedPredictor.from_mhcflurry(path)` | mhcflurry-predict CSV output. `predictor_version` auto-composed from the installed mhcflurry when omitted. |
-| `CachedPredictor.from_netmhcpan_stdout(path, mode=...)` | NetMHCpan stdout capture (auto-detects 2.8 / 3 / 4 / 4.1). |
+| `CachedPredictor.from_netmhcpan_stdout(path)` | NetMHCpan stdout capture (auto-detects 2.8 / 3 / 4 / 4.1).  Returns every kind present in the output — `-BA` runs surface both `pMHC_affinity` and `pMHC_presentation` rows per (peptide, allele). |
 | `CachedPredictor.from_netmhc_stdout(path, version=...)` | Classic NetMHC stdout (3 / 4 / 4.1). |
 | `CachedPredictor.from_netmhcpan_cons_stdout(path)` | NetMHCcons stdout. |
 | `CachedPredictor.from_netmhciipan_stdout(path, version=...)` | NetMHCIIpan stdout (legacy / 4 / 4.3). |

--- a/docs/cached.md
+++ b/docs/cached.md
@@ -59,10 +59,7 @@ it directly — topiary reuses the parsers shipped by
 version they support is covered here too.
 
 ```python
-cache = CachedPredictor.from_netmhcpan_stdout(
-    "netmhcpan_run.out",
-    mode="binding_affinity",     # or "elution_score" on 4+
-)
+cache = CachedPredictor.from_netmhcpan_stdout("netmhcpan_run.out")
 cache = CachedPredictor.from_netmhc_stdout("netmhc_run.out", version="4")
 cache = CachedPredictor.from_netmhcpan_cons_stdout("cons_run.out")
 cache = CachedPredictor.from_netmhciipan_stdout("ii_run.out", version="4.3")
@@ -73,6 +70,13 @@ Each loader parses the version out of the stdout preamble (e.g.
 `NetMHCpan version 4.1b`) and stamps it on `predictor_version`.
 Pass `predictor_version="..."` if you want a different label, or
 if your capture stripped the preamble.
+
+**Multi-kind output**: NetMHCpan run with `-BA` (which produces
+both eluted-ligand and binding-affinity scores per peptide) is
+loaded as **both** kinds in the cache — `pMHC_affinity` and
+`pMHC_presentation` rows for each `(peptide, allele)`. The new
+6-tuple index key distinguishes them, and downstream topiary DSL
+scopes (`Affinity.*` vs `Presentation.*`) read the right rows.
 
 The loaders parse the *stdout text* format. NetMHC's `-xlsfile`
 tab-delimited output is a different format and isn't supported
@@ -338,7 +342,6 @@ Full flag reference:
 | `--mhc-cache-predictor-version V` | Override `predictor_version`. Auto-inferred for NetMHC stdout captures (parsed from preamble) and mhcflurry (composite from local install). |
 | `--mhc-cache-tsv-column CANONICAL=FILE_COL` | Repeatable. Column-name mapping for `tsv` format. |
 | `--mhc-cache-tsv-sep SEP` | Separator for `tsv`. Default tab. |
-| `--mhc-cache-netmhcpan-mode MODE` | `binding_affinity` (default) or `elution_score` for NetMHCpan 4+. |
 | `--mhc-cache-netmhc-version V` | `3`, `4`, or `4.1` for classic NetMHC output. Default `4`. |
 | `--mhc-cache-netmhciipan-version V` | `legacy`, `4`, or `4.3` for NetMHCIIpan. Default `4.3`. |
 | `--mhc-cache-netmhciipan-mode MODE` | `binding_affinity` or `elution_score` (default) for NetMHCIIpan 4+. |

--- a/docs/cached.md
+++ b/docs/cached.md
@@ -286,26 +286,30 @@ Every loader is exposed through `topiary`'s command-line interface via
 (variant effects, filtering, ranking, output formatting) against the
 cached predictions — the live predictor is never invoked.
 
+`--mhc-cache-format` is optional for NetMHC-family stdout captures,
+mhcflurry CSVs, and topiary's own output — topiary sniffs the format
+from file content. Only the generic `tsv` path needs an explicit
+`--mhc-cache-format tsv` (generic tables don't carry identifying
+signatures).
+
 ```bash
-# NetMHCpan stdout capture
+# NetMHCpan stdout capture — format sniffed from the preamble
 topiary --peptide-csv peptides.csv \
     --mhc-cache-file netmhcpan_run.out \
-    --mhc-cache-format netmhcpan_stdout \
     --output-csv results.csv
 
-# mhcflurry CSV (predictor_version auto-composed from local install)
+# mhcflurry CSV — format sniffed from column names; predictor_version
+# auto-composed from the local install
 topiary --peptide-csv peptides.csv \
     --mhc-cache-file mhcflurry_predictions.csv \
-    --mhc-cache-format mhcflurry \
     --output-csv results.csv
 
-# Topiary's own saved output (Parquet or TSV round-trip)
+# Topiary's own saved output (Parquet or TSV round-trip) — sniffed
 topiary --peptide-csv peptides.csv \
     --mhc-cache-file prior_run.parquet \
-    --mhc-cache-format topiary_output \
     --output-csv results.csv
 
-# Generic TSV with column mapping
+# Generic TSV with column mapping — format must be explicit
 topiary --peptide-csv peptides.csv \
     --mhc-cache-file third_party.tsv \
     --mhc-cache-format tsv \
@@ -329,7 +333,7 @@ Full flag reference:
 | `--mhc-cache-file PATH` | Single cache file. Requires `--mhc-cache-format`. |
 | `--mhc-cache-directory PATH` | Directory of shards; each file loaded via `from_topiary_output` and concatenated. Alternative to `--mhc-cache-file`. |
 | `--mhc-cache-directory-pattern GLOB` | Pattern for `--mhc-cache-directory`. Default `*`. |
-| `--mhc-cache-format FORMAT` | One of `topiary_output`, `mhcflurry`, `tsv`, `netmhcpan_stdout`, `netmhc_stdout`, `netmhcpan_cons_stdout`, `netmhciipan_stdout`, `netmhcstabpan_stdout`. |
+| `--mhc-cache-format FORMAT` | Optional — sniffed from file content when omitted (see above). One of `topiary_output`, `mhcflurry`, `tsv`, `netmhcpan`, `netmhc`, `netmhccons`, `netmhciipan`, `netmhcstabpan`. Only `tsv` strictly requires the explicit flag. |
 | `--mhc-cache-predictor-name NAME` | Override `prediction_method_name` (required for `tsv` when not in the file). |
 | `--mhc-cache-predictor-version V` | Override `predictor_version`. Auto-inferred for NetMHC stdout captures (parsed from preamble) and mhcflurry (composite from local install). |
 | `--mhc-cache-tsv-column CANONICAL=FILE_COL` | Repeatable. Column-name mapping for `tsv` format. |

--- a/docs/cached.md
+++ b/docs/cached.md
@@ -279,6 +279,69 @@ cache.save("cache.parquet")   # or .tsv / .tsv.gz / .csv
 Writes the cache's internal table using the same schema the loaders
 expect. Round-trips cleanly through `from_topiary_output`.
 
+## From the CLI
+
+Every loader is exposed through `topiary`'s command-line interface via
+`--mhc-cache-*` flags. The CLI runs the entire prediction pipeline
+(variant effects, filtering, ranking, output formatting) against the
+cached predictions — the live predictor is never invoked.
+
+```bash
+# NetMHCpan stdout capture
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-file netmhcpan_run.out \
+    --mhc-cache-format netmhcpan_stdout \
+    --output-csv results.csv
+
+# mhcflurry CSV (predictor_version auto-composed from local install)
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-file mhcflurry_predictions.csv \
+    --mhc-cache-format mhcflurry \
+    --output-csv results.csv
+
+# Topiary's own saved output (Parquet or TSV round-trip)
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-file prior_run.parquet \
+    --mhc-cache-format topiary_output \
+    --output-csv results.csv
+
+# Generic TSV with column mapping
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-file third_party.tsv \
+    --mhc-cache-format tsv \
+    --mhc-cache-predictor-name netchop \
+    --mhc-cache-predictor-version 3.1 \
+    --mhc-cache-tsv-column affinity=IC50_nM \
+    --mhc-cache-tsv-column percentile_rank=Rank \
+    --output-csv results.csv
+
+# Sharded: merge every file in a directory
+topiary --peptide-csv peptides.csv \
+    --mhc-cache-directory ./caches \
+    --mhc-cache-directory-pattern '*.parquet' \
+    --output-csv results.csv
+```
+
+Full flag reference:
+
+| Flag | Purpose |
+|---|---|
+| `--mhc-cache-file PATH` | Single cache file. Requires `--mhc-cache-format`. |
+| `--mhc-cache-directory PATH` | Directory of shards; each file loaded via `from_topiary_output` and concatenated. Alternative to `--mhc-cache-file`. |
+| `--mhc-cache-directory-pattern GLOB` | Pattern for `--mhc-cache-directory`. Default `*`. |
+| `--mhc-cache-format FORMAT` | One of `topiary_output`, `mhcflurry`, `tsv`, `netmhcpan_stdout`, `netmhc_stdout`, `netmhcpan_cons_stdout`, `netmhciipan_stdout`, `netmhcstabpan_stdout`. |
+| `--mhc-cache-predictor-name NAME` | Override `prediction_method_name` (required for `tsv` when not in the file). |
+| `--mhc-cache-predictor-version V` | Override `predictor_version`. Auto-inferred for NetMHC stdout captures (parsed from preamble) and mhcflurry (composite from local install). |
+| `--mhc-cache-tsv-column CANONICAL=FILE_COL` | Repeatable. Column-name mapping for `tsv` format. |
+| `--mhc-cache-tsv-sep SEP` | Separator for `tsv`. Default tab. |
+| `--mhc-cache-netmhcpan-mode MODE` | `binding_affinity` (default) or `elution_score` for NetMHCpan 4+. |
+| `--mhc-cache-netmhc-version V` | `3`, `4`, or `4.1` for classic NetMHC output. Default `4`. |
+| `--mhc-cache-netmhciipan-version V` | `legacy`, `4`, or `4.3` for NetMHCIIpan. Default `4.3`. |
+| `--mhc-cache-netmhciipan-mode MODE` | `binding_affinity` or `elution_score` (default) for NetMHCIIpan 4+. |
+
+`--mhc-predictor` and `--mhc-alleles` become optional when a cache is
+in use — the cache supplies the predictions and its allele set.
+
 ## When *not* to use
 
 - You've never run the predictor on these peptides — just use the

--- a/tests/data/netmhc_fixtures/netmhc_40_SLLQHLIGL.out
+++ b/tests/data/netmhc_fixtures/netmhc_40_SLLQHLIGL.out
@@ -1,0 +1,66 @@
+# /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/bin/netMHC -p /tmp/test_peptide.txt -a HLA-A0201,HLA-A2402,HLA-B0702
+# Wed Apr 15 13:02:03 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# -p       1                    Switch on if input is a list of peptides (Peptide format)
+# -a       HLA-A0201,HLA-A2402,HLA-B0702 HLA allele name
+# Command line parameters set to:
+#	[-a line]            HLA-A0201,HLA-A2402,HLA-B0702 HLA allele name
+#	[-f filename]                             Input file (by default in FASTA format)
+#	[-p]                 1                    Switch on if input is a list of peptides (Peptide format)
+#	[-l string]          9                    Peptide length (multiple lengths separated by comma e.g. 8,9,10)
+#	[-s]                 0                    Sort output on decreasing affinity
+#	[-rth float]         0.500000             Threshold for high binding peptides (%Rank)
+#	[-rlt float]         2.000000             Threshold for low binding peptides (%Rank)
+#	[-listMHC]           0                    Print list of alleles included in netMHC
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHC_out.xls       File name for xls output
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/data/threshold/%s.thr Format for threshold filenames
+#	[-hlalist filename]  /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/data/allelelist File with covered HLA names
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64 Home directory for NetMHC
+#	[-tdir filename]     /tmp/netmhc-bundle-temp Temporary directory (Default $$)
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/data/synlists/%s.synlist Format of synlist file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/data/version File with version information
+#	[-w]                 0                    w option for webface
+
+# NetMHC version 4.0
+
+# Read 132 elements on pairlist /Users/iskander/code/netmhc-bundle/netMHC-4.0/Darwin_arm64/data/allelelist
+# Input is in PEPTIDE format
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  pos          HLA      peptide         Core Offset  I_pos  I_len  D_pos  D_len        iCore        Identity 1-log50k(aff) Affinity(nM)    %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    0    HLA-A0201    SLLQHLIGL    SLLQHLIGL      0      0      0      0      0    SLLQHLIGL         PEPLIST         0.761        13.22     0.17 <= SB
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A0201. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  pos          HLA      peptide         Core Offset  I_pos  I_len  D_pos  D_len        iCore        Identity 1-log50k(aff) Affinity(nM)    %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    0    HLA-A2402    SLLQHLIGL    SLLQHLIGL      0      0      0      0      0    SLLQHLIGL         PEPLIST         0.059     26393.42    19.00
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A2402. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  pos          HLA      peptide         Core Offset  I_pos  I_len  D_pos  D_len        iCore        Identity 1-log50k(aff) Affinity(nM)    %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    0    HLA-B0702    SLLQHLIGL    SLLQHLIGL      0      0      0      0      0    SLLQHLIGL         PEPLIST         0.149     10019.89     7.00
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B0702. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhccons_SLLQHLIGL.out
+++ b/tests/data/netmhc_fixtures/netmhccons_SLLQHLIGL.out
@@ -1,0 +1,3 @@
+env: python2: No such file or directory
+python2:: Too many arguments.
+The two methods NetMHCpan and NetMHC produced different outputs, number of peptides not the same

--- a/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL.out
@@ -1,0 +1,82 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A02:01,HLA-A24:02,HLA-B07:02
+# Wed Apr 15 13:02:02 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01,HLA-A24:02,HLA-B07:02 HLA allele
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A02:01,HLA-A24:02,HLA-B07:02 HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                0                    Make Binding affinity prediction
+
+# NetMHCpan version 4.0
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanhWwRDv
+# Input is in PEPTIDE format
+
+# Make Eluted ligand likelihood predictions
+
+HLA-A02:01 : Distance to training data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-A*02:01       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.9474990  0.0378 <= SB
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+
+HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-A*24:02       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0195320  5.4104
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+
+HLA-B07:02 : Distance to training data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-B*07:02       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0076970  5.4641
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_A0201.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_A0201.out
@@ -1,0 +1,54 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A02:01
+# Wed Apr 15 13:14:56 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01           HLA allele
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A02:01           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                0                    Make Binding affinity prediction
+
+# NetMHCpan version 4.0
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanYgBoFA
+# Input is in PEPTIDE format
+
+# Make Eluted ligand likelihood predictions
+
+HLA-A02:01 : Distance to training data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-A*02:01       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.9474990  0.0378 <= SB
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_A2402.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_A2402.out
@@ -1,0 +1,54 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A24:02
+# Wed Apr 15 13:14:57 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A24:02           HLA allele
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A24:02           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                0                    Make Binding affinity prediction
+
+# NetMHCpan version 4.0
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanGlm9rO
+# Input is in PEPTIDE format
+
+# Make Eluted ligand likelihood predictions
+
+HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-A*24:02       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0195320  5.4104
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_B0702.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_40_SLLQHLIGL_B0702.out
@@ -1,0 +1,54 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-B07:02
+# Wed Apr 15 13:14:58 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-B07:02           HLA allele
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-B07:02           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.0/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                0                    Make Binding affinity prediction
+
+# NetMHCpan version 4.0
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanx7aq8v
+# Input is in PEPTIDE format
+
+# Make Eluted ligand likelihood predictions
+
+HLA-B07:02 : Distance to training data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------
+  Pos          HLA         Peptide       Core Of Gp Gl Ip Il        Icore        Identity     Score   %Rank  BindLevel
+-----------------------------------------------------------------------------------
+    1  HLA-B*07:02       SLLQHLIGL  SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0076970  5.4641
+-----------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL.out
@@ -1,0 +1,83 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A02:01,HLA-A24:02,HLA-B07:02 -BA
+# Wed Apr 15 13:02:01 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01,HLA-A24:02,HLA-B07:02 MHC allele
+# -BA      1                    Include Binding affinity prediction
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/MHC_pseudo.dat File with MHC pseudo sequences
+#	[-hlaseq filename]                        File with full length MHC sequences
+#	[-a line]            HLA-A02:01,HLA-A24:02,HLA-B07:02 MHC allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output (%rank) [<0 print all]
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                1                    Include Binding affinity prediction
+
+# NetMHCpan version 4.1b
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpan6Nd8D5
+# Input is in PEPTIDE format
+
+# Make both EL and BA predictions
+
+HLA-A02:01 : Distance to training data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*02:01      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.9497530    0.024 0.798762    0.105     8.82 <= SB
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+
+HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*24:02      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0061450    5.037 0.104534    8.318 16134.95
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------
+
+HLA-B07:02 : Distance to training data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-B*07:02      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0109810    4.894 0.141668    6.774 10796.33
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_A0201.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_A0201.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A02:01 -BA
+# Wed Apr 15 13:14:56 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01           MHC allele
+# -BA      1                    Include Binding affinity prediction
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/MHC_pseudo.dat File with MHC pseudo sequences
+#	[-hlaseq filename]                        File with full length MHC sequences
+#	[-a line]            HLA-A02:01           MHC allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output (%rank) [<0 print all]
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                1                    Include Binding affinity prediction
+
+# NetMHCpan version 4.1b
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpane69LG2
+# Input is in PEPTIDE format
+
+# Make both EL and BA predictions
+
+HLA-A02:01 : Distance to training data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*02:01      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.9497530    0.024 0.798762    0.105     8.82 <= SB
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_A2402.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_A2402.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-A24:02 -BA
+# Wed Apr 15 13:14:57 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A24:02           MHC allele
+# -BA      1                    Include Binding affinity prediction
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/MHC_pseudo.dat File with MHC pseudo sequences
+#	[-hlaseq filename]                        File with full length MHC sequences
+#	[-a line]            HLA-A24:02           MHC allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output (%rank) [<0 print all]
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                1                    Include Binding affinity prediction
+
+# NetMHCpan version 4.1b
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanoIlQxK
+# Input is in PEPTIDE format
+
+# Make both EL and BA predictions
+
+HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*24:02      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0061450    5.037 0.104534    8.318 16134.95
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_B0702.out
+++ b/tests/data/netmhc_fixtures/netmhcpan_41_SLLQHLIGL_B0702.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/bin/netMHCpan -p /tmp/test_peptide.txt -a HLA-B07:02 -BA
+# Wed Apr 15 13:14:58 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-B07:02           MHC allele
+# -BA      1                    Include Binding affinity prediction
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/synlist.bin Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanXXXXXX Temporary directory (made with mkdtemp)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/MHC_pseudo.dat File with MHC pseudo sequences
+#	[-hlaseq filename]                        File with full length MHC sequences
+#	[-a line]            HLA-B07:02           MHC allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s]                 0                    Sort output on descending affinity
+#	[-p]                 1                    Use peptide input
+#	[-rth float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          8,9,10,11            Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCpan_out.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output (%rank) [<0 print all]
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/threshold/%s.thr.%s Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-allname filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-4.1/Darwin_arm64/data/allelenames File with print names for alleles
+#	[-BA]                1                    Include Binding affinity prediction
+
+# NetMHCpan version 4.1b
+
+# Tmpdir made /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T//netMHCpanZxERIi
+# Input is in PEPTIDE format
+
+# Make both EL and BA predictions
+
+HLA-B07:02 : Distance to training data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-B*07:02      SLLQHLIGL SLLQHLIGL  0  0  0  0  0    SLLQHLIGL         PEPLIST 0.0109810    4.894 0.141668    6.774 10796.33
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL.out
+++ b/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL.out
@@ -1,0 +1,83 @@
+# /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/bin/netMHCstabpan -p /tmp/test_peptide.txt -a HLA-A02:01,HLA-A24:02,HLA-B07:02 -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan
+# Wed Apr 15 13:02:03 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01,HLA-A24:02,HLA-B07:02 HLA allele
+# -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/syn/synaps Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T/ Temporary directory (Default $$)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A02:01,HLA-A24:02,HLA-B07:02 HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s int]             -1                   Sort output on descending [0] stability, [1] affinity, [2] combined, [-1] no sorting
+#	[-p]                 1                    Use peptide input
+#	[-rht float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          9                    Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCstabpan.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/threshold/%s.thr Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-affpred filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+#	[-waff float]        0.800000             Relative Weight on affinity
+#	[-ia]                0                    Include affinity predictions
+#	[-s1 int]            -1                   Sort option only used by www
+#	[-s2 int]            -1                   Sort option only used by www
+
+# NetMHCstabpan version 1.0
+
+# Input is in PEPTIDE format
+
+HLA-A02:01 : Distance to traning data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-A*02:01    SLLQHLIGL         PEPLIST      0.906       7.04       0.40      <= SB
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------
+
+HLA-A24:02 : Distance to traning data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-A*24:02    SLLQHLIGL         PEPLIST      0.029       0.20      14.00
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------
+
+HLA-B07:02 : Distance to traning data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-B*07:02    SLLQHLIGL         PEPLIST      0.031       0.20      25.00
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_A0201.out
+++ b/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_A0201.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/bin/netMHCstabpan -p /tmp/test_peptide.txt -a HLA-A02:01 -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan
+# Wed Apr 15 13:14:56 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A02:01           HLA allele
+# -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/syn/synaps Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T/ Temporary directory (Default $$)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A02:01           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s int]             -1                   Sort output on descending [0] stability, [1] affinity, [2] combined, [-1] no sorting
+#	[-p]                 1                    Use peptide input
+#	[-rht float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          9                    Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCstabpan.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/threshold/%s.thr Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-affpred filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+#	[-waff float]        0.800000             Relative Weight on affinity
+#	[-ia]                0                    Include affinity predictions
+#	[-s1 int]            -1                   Sort option only used by www
+#	[-s2 int]            -1                   Sort option only used by www
+
+# NetMHCstabpan version 1.0
+
+# Input is in PEPTIDE format
+
+HLA-A02:01 : Distance to traning data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-A*02:01    SLLQHLIGL         PEPLIST      0.906       7.04       0.40      <= SB
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 1. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_A2402.out
+++ b/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_A2402.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/bin/netMHCstabpan -p /tmp/test_peptide.txt -a HLA-A24:02 -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan
+# Wed Apr 15 13:14:57 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-A24:02           HLA allele
+# -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/syn/synaps Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T/ Temporary directory (Default $$)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-A24:02           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s int]             -1                   Sort output on descending [0] stability, [1] affinity, [2] combined, [-1] no sorting
+#	[-p]                 1                    Use peptide input
+#	[-rht float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          9                    Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCstabpan.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/threshold/%s.thr Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-affpred filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+#	[-waff float]        0.800000             Relative Weight on affinity
+#	[-ia]                0                    Include affinity predictions
+#	[-s1 int]            -1                   Sort option only used by www
+#	[-s2 int]            -1                   Sort option only used by www
+
+# NetMHCstabpan version 1.0
+
+# Input is in PEPTIDE format
+
+HLA-A24:02 : Distance to traning data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-A*24:02    SLLQHLIGL         PEPLIST      0.029       0.20      14.00
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------

--- a/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_B0702.out
+++ b/tests/data/netmhc_fixtures/netmhcstabpan_SLLQHLIGL_B0702.out
@@ -1,0 +1,55 @@
+# /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/bin/netMHCstabpan -p /tmp/test_peptide.txt -a HLA-B07:02 -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan
+# Wed Apr 15 13:14:58 2026
+# User: iskander
+# PWD : /Users/iskander/code/topiary
+# Host: Darwin dhcp-10-25-19-110.wireless-1x.unc.edu 25.4.0 x86_64
+# -p       1                    Use peptide input
+# -a       HLA-B07:02           HLA allele
+# -affpred /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+# Command line parameters set to:
+#	[-rdir filename]     /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64 Home directory for NetMHpan
+#	[-syn filename]      /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/syn/synaps Synaps file
+#	[-v]                 0                    Verbose mode
+#	[-dirty]             0                    Dirty mode, leave tmp dir+files
+#	[-tdir filename]     /var/folders/qm/qf74v01n2s12j3w0h1yrx4l00000gn/T/ Temporary directory (Default $$)
+#	[-hlapseudo filename] /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/MHC_pseudo.dat File with HLA pseudo sequences
+#	[-hlaseq filename]                        File with full length HLA sequences
+#	[-a line]            HLA-B07:02           HLA allele
+#	[-f filename]                             File name with input
+#	[-w]                 0                    w option for webface
+#	[-s int]             -1                   Sort output on descending [0] stability, [1] affinity, [2] combined, [-1] no sorting
+#	[-p]                 1                    Use peptide input
+#	[-rht float]         0.500000             Rank Threshold for high binding peptides
+#	[-rlt float]         2.000000             Rank Threshold for low binding peptides
+#	[-l string]          9                    Peptide length [8-11] (multiple length with ,)
+#	[-xls]               0                    Save output to xls file
+#	[-xlsfile filename]  NetMHCstabpan.xls    Filename for xls dump
+#	[-t float]           -99.900002           Threshold for output
+#	[-thrfmt filename]   /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/threshold/%s.thr Format for threshold filenames
+#	[-expfix]            0                    Exclude prefix from synlist
+#	[-version filename]  /Users/iskander/code/netmhc-bundle/netMHCstabpan-1.0/Darwin_arm64/data/version File with version information
+#	[-inptype int]       0                    Input type [0] FASTA [1] Peptide
+#	[-listMHC]           0                    Print list of alleles included in netMHCpan
+#	[-affpred filename]  /Users/iskander/code/netmhc-bundle/netMHCpan-2.8/netMHCpan MHC affinity predictor
+#	[-waff float]        0.800000             Relative Weight on affinity
+#	[-ia]                0                    Include affinity predictions
+#	[-s1 int]            -1                   Sort option only used by www
+#	[-s2 int]            -1                   Sort option only used by www
+
+# NetMHCstabpan version 1.0
+
+# Input is in PEPTIDE format
+
+HLA-B07:02 : Distance to traning data  0.000 (using nearest neighbor HLA-B07:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+-----------------------------------------------------------------------------------------------------
+ pos      HLA         peptide         Identity       Pred     Thalf(h) %Rank_Stab BindLevel
+-----------------------------------------------------------------------------------------------------
+    0  HLA-B*07:02    SLLQHLIGL         PEPLIST      0.031       0.20      25.00
+-----------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-B*07:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+-----------------------------------------------------------------------------------------------------

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -2,6 +2,8 @@
 round-trips, fallback + version enforcement, and integration with
 :class:`TopiaryPredictor`."""
 
+import pathlib
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -771,3 +773,90 @@ class TestFromDirectory:
         )
         # sorted(["a.tsv", "b.tsv"]) → b wins (affinity=999.0)
         assert merged._df.iloc[0]["affinity"] == 999.0
+
+
+# ---------------------------------------------------------------------------
+# Real NetMHC-family fixtures captured from the netmhc-bundle binaries
+# on peptide SLLQHLIGL at HLA-A*02:01 / A*24:02 / B*07:02.
+# ---------------------------------------------------------------------------
+
+_FIXTURE_DIR = (
+    pathlib.Path(__file__).parent / "data" / "netmhc_fixtures"
+)
+
+
+@pytest.mark.skipif(
+    not _FIXTURE_DIR.exists(),
+    reason="NetMHC fixtures not available",
+)
+class TestRealNetMHCFixtures:
+    """Parse the committed real-binary outputs end-to-end through
+    each loader.  Values are the ground-truth numbers produced by
+    the corresponding NetMHC binary for SLLQHLIGL — regressions here
+    mean either our loader broke or we regenerated fixtures with a
+    different version."""
+
+    def test_netmhcpan_41_A0201_real_values(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out",
+        )
+        assert cache.prediction_method_name == "netmhcpan"
+        assert cache.predictor_version == "4.1b"
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        row = out.iloc[0]
+        assert row["peptide"] == "SLLQHLIGL"
+        assert row["allele"] == "HLA-A*02:01"
+        assert row["affinity"] == pytest.approx(8.82, rel=1e-3)
+        assert row["percentile_rank"] == pytest.approx(0.105, rel=1e-2)
+
+    def test_netmhcpan_41_A2402_real_values(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A2402.out",
+        )
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        row = out.iloc[0]
+        assert row["allele"] == "HLA-A*24:02"
+        # Weak binder at A*24:02 — affinity ~16000 nM
+        assert row["affinity"] > 10000
+
+    def test_netmhcpan_41_B0702_real_values(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_B0702.out",
+        )
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        row = out.iloc[0]
+        assert row["allele"] == "HLA-B*07:02"
+
+    def test_netmhcpan_40_real_values(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_40_SLLQHLIGL_A0201.out",
+        )
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        assert out.iloc[0]["peptide"] == "SLLQHLIGL"
+
+    def test_netmhc_classic_multi_allele_real(self):
+        # NetMHC classic 4.0 happens to handle multi-allele output fine
+        # via mhctools' parse_netmhc4_stdout.
+        cache = CachedPredictor.from_netmhc_stdout(
+            _FIXTURE_DIR / "netmhc_40_SLLQHLIGL.out",
+            version="4",
+        )
+        # All three alleles populated from one multi-allele run.
+        assert set(cache.alleles) == {
+            "HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02",
+        }
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        assert len(out) == 3
+        # A*02:01 should be the strongest binder (lowest IC50)
+        by_allele = out.set_index("allele")
+        assert by_allele.loc["HLA-A*02:01", "affinity"] < by_allele.loc[
+            "HLA-A*24:02", "affinity"
+        ]
+
+    def test_netmhcstabpan_real_values(self):
+        cache = CachedPredictor.from_netmhcstabpan_stdout(
+            _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL_A0201.out",
+        )
+        assert cache.prediction_method_name == "netmhcstabpan"
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        assert len(out) == 1

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -508,6 +508,11 @@ class TestLoaders:
         assert cache.prediction_method_name == "mhcflurry"
         assert cache.predictor_version == "2.0.6"
         out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        # TODO(multi-kind): today from_mhcflurry collapses to a single
+        # row per (peptide, allele), preferring presentation over
+        # affinity when both columns are populated.  Multi-kind cache
+        # support is tracked as a follow-up.
+        assert len(out) == 1
         assert out.iloc[0]["affinity"] == 100.0
         assert out.iloc[0]["percentile_rank"] == 1.5
         assert out.iloc[0]["score"] == 0.8

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -224,7 +224,7 @@ class TestFallback:
         # Second call should NOT hit fallback (we can verify by
         # observing the cache's internal df grew and contains it).
         assert (
-            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity", None, None,
+            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity", "", "",
         ) in cache._index
         assert len(cache._df) == 2
 
@@ -263,7 +263,7 @@ class TestFallback:
         # overwrite the 42.0 sentinel.
         cache.predict_peptides_dataframe(["SIINFEKLA"])
         preserved = cache._index[
-            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", None, None)
+            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
         ]
         assert preserved["affinity"] == 42.0
 
@@ -324,7 +324,7 @@ class TestEmptyCacheWithFallback:
         )
         cache.predict_peptides_dataframe(["SIINFEKLA"])
         assert (
-            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", None, None,
+            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "",
         ) in cache._index
 
     def test_empty_df_value_and_no_fallback_still_raises(self):

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -23,6 +23,7 @@ def _row(
     score=0.5,
     affinity=150.0,
     percentile_rank=2.0,
+    kind="pMHC_affinity",
     predictor_name="random",
     predictor_version="1.0",
 ):
@@ -30,6 +31,7 @@ def _row(
         "peptide": peptide,
         "allele": allele,
         "peptide_length": len(peptide),
+        "kind": kind,
         "score": score,
         "affinity": affinity,
         "percentile_rank": percentile_rank,
@@ -192,6 +194,8 @@ class _TaggedRandomPredictor(RandomBindingPredictor):
         df = df.copy()
         df["prediction_method_name"] = self._stamp_name
         df["predictor_version"] = self._stamp_version
+        if "kind" not in df.columns:
+            df["kind"] = "pMHC_affinity"
         return df
 
     def predict_peptides_dataframe(self, peptides):
@@ -219,7 +223,9 @@ class TestFallback:
         cache.predict_peptides_dataframe(["GILGFVFTL"])
         # Second call should NOT hit fallback (we can verify by
         # observing the cache's internal df grew and contains it).
-        assert ("GILGFVFTL", "HLA-A*02:01", 9) in cache._index
+        assert (
+            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity"
+        ) in cache._index
         assert len(cache._df) == 2
 
     def test_fallback_version_mismatch_rejects(self):
@@ -256,7 +262,9 @@ class TestFallback:
         # preserve-existing guard, the random-predictor output would
         # overwrite the 42.0 sentinel.
         cache.predict_peptides_dataframe(["SIINFEKLA"])
-        preserved = cache._index[("SIINFEKLA", "HLA-A*02:01", 9)]
+        preserved = cache._index[
+            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity")
+        ]
         assert preserved["affinity"] == 42.0
 
 
@@ -315,7 +323,9 @@ class TestEmptyCacheWithFallback:
             fallback=_matched_fallback(name="random", version="3.0"),
         )
         cache.predict_peptides_dataframe(["SIINFEKLA"])
-        assert ("SIINFEKLA", "HLA-A*02:01", 9) in cache._index
+        assert (
+            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity"
+        ) in cache._index
 
     def test_empty_df_value_and_no_fallback_still_raises(self):
         empty = pd.DataFrame(columns=list(_row().keys()))
@@ -475,12 +485,15 @@ class TestLoaders:
         assert reloaded.prediction_method_name == "random"
 
     def test_from_tsv_with_column_mapping(self, tmp_path):
-        # Simulate a third-party TSV with non-canonical column names
+        # Simulate a third-party TSV with non-canonical column names.
+        # kind column is required — single-kind table simulated by
+        # stamping every row with the same kind value.
         df = pd.DataFrame([{
             "peptide": "SIINFEKLA",
             "allele": "HLA-A*02:01",
             "ic50_nM": 150.0,
             "rank": 2.0,
+            "kind": "pMHC_affinity",
         }])
         path = tmp_path / "third_party.tsv"
         df.to_csv(path, sep="\t", index=False)
@@ -494,7 +507,9 @@ class TestLoaders:
         assert out.iloc[0]["affinity"] == 150.0
         assert out.iloc[0]["percentile_rank"] == 2.0
 
-    def test_from_mhcflurry(self, tmp_path):
+    def test_from_mhcflurry_affinity_plus_presentation(self, tmp_path):
+        """mhcflurry CSV with both affinity + presentation columns
+        emits two kinds, one row per kind per (peptide, allele)."""
         df = pd.DataFrame([{
             "peptide": "SIINFEKLA",
             "allele": "HLA-A*02:01",
@@ -504,18 +519,55 @@ class TestLoaders:
         }])
         path = tmp_path / "mhcflurry.csv"
         df.to_csv(path, index=False)
-        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.0.6")
-        assert cache.prediction_method_name == "mhcflurry"
-        assert cache.predictor_version == "2.0.6"
+        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.2.0")
         out = cache.predict_peptides_dataframe(["SIINFEKLA"])
-        # TODO(multi-kind): today from_mhcflurry collapses to a single
-        # row per (peptide, allele), preferring presentation over
-        # affinity when both columns are populated.  Multi-kind cache
-        # support is tracked as a follow-up.
+        assert len(out) == 2
+        by_kind = out.set_index("kind")
+        assert by_kind.loc["pMHC_affinity", "affinity"] == 100.0
+        assert by_kind.loc["pMHC_affinity", "percentile_rank"] == 1.5
+        assert by_kind.loc["pMHC_presentation", "score"] == 0.8
+
+    def test_from_mhcflurry_full_presentation_pipeline(self, tmp_path):
+        """Full class1_presentation pipeline — affinity + presentation
+        + processing in one row → 3 kinds out."""
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA",
+            "allele": "HLA-A*02:01",
+            "n_flank": "ABC",
+            "c_flank": "XYZ",
+            "mhcflurry_affinity": 100.0,
+            "mhcflurry_affinity_percentile": 1.5,
+            "mhcflurry_presentation_score": 0.8,
+            "mhcflurry_presentation_percentile": 0.6,
+            "mhcflurry_processing_score": 0.45,
+        }])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.2.0")
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        assert len(out) == 3
+        by_kind = out.set_index("kind")
+        assert by_kind.loc["pMHC_affinity", "affinity"] == 100.0
+        assert by_kind.loc["pMHC_presentation", "percentile_rank"] == 0.6
+        assert by_kind.loc["antigen_processing", "score"] == 0.45
+        # n_flank / c_flank carry through on every kind's row.
+        assert (out["n_flank"] == "ABC").all()
+        assert (out["c_flank"] == "XYZ").all()
+
+    def test_from_mhcflurry_affinity_only(self, tmp_path):
+        """Affinity-only mhcflurry output emits only the affinity kind."""
+        df = pd.DataFrame([{
+            "peptide": "SIINFEKLA",
+            "allele": "HLA-A*02:01",
+            "mhcflurry_affinity": 100.0,
+            "mhcflurry_affinity_percentile": 1.5,
+        }])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.2.0")
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
         assert len(out) == 1
-        assert out.iloc[0]["affinity"] == 100.0
-        assert out.iloc[0]["percentile_rank"] == 1.5
-        assert out.iloc[0]["score"] == 0.8
+        assert out.iloc[0]["kind"] == "pMHC_affinity"
 
 
 # ---------------------------------------------------------------------------
@@ -605,6 +657,9 @@ class TestNetMHCLoaders:
         return p
 
     def test_from_netmhcpan_stdout(self, tmp_path):
+        """NetMHCpan 4.1 -BA stdout carries both affinity + elution
+        score per (peptide, allele).  parse_netmhcpan_to_preds surfaces
+        both; the cache stores one row per (peptide, allele, kind)."""
         path = self._write(tmp_path, "pan.out", _NETMHCPAN_41_STDOUT)
         cache = CachedPredictor.from_netmhcpan_stdout(path)
         assert cache.prediction_method_name == "netmhcpan"
@@ -613,8 +668,10 @@ class TestNetMHCLoaders:
         assert cache.alleles == ["HLA-A*02:01"]
         assert cache.default_peptide_lengths == [9]
         out = cache.predict_peptides_dataframe(["SIINFEKLA", "GILGFVFTL"])
-        assert len(out) == 2
+        # Two peptides × two kinds (affinity + presentation) = 4 rows.
+        assert len(out) == 4
         assert set(out["peptide"]) == {"SIINFEKLA", "GILGFVFTL"}
+        assert set(out["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
 
     def test_from_netmhcpan_stdout_explicit_version(self, tmp_path):
         path = self._write(tmp_path, "pan.out", _NETMHCPAN_41_STDOUT)

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -224,7 +224,7 @@ class TestFallback:
         # Second call should NOT hit fallback (we can verify by
         # observing the cache's internal df grew and contains it).
         assert (
-            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity"
+            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity", None, None,
         ) in cache._index
         assert len(cache._df) == 2
 
@@ -263,7 +263,7 @@ class TestFallback:
         # overwrite the 42.0 sentinel.
         cache.predict_peptides_dataframe(["SIINFEKLA"])
         preserved = cache._index[
-            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity")
+            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", None, None)
         ]
         assert preserved["affinity"] == 42.0
 
@@ -324,7 +324,7 @@ class TestEmptyCacheWithFallback:
         )
         cache.predict_peptides_dataframe(["SIINFEKLA"])
         assert (
-            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity"
+            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", None, None,
         ) in cache._index
 
     def test_empty_df_value_and_no_fallback_still_raises(self):
@@ -553,6 +553,38 @@ class TestLoaders:
         # n_flank / c_flank carry through on every kind's row.
         assert (out["n_flank"] == "ABC").all()
         assert (out["c_flank"] == "XYZ").all()
+
+    def test_from_mhcflurry_same_peptide_different_flanks(self, tmp_path):
+        """Same peptide in two protein contexts (different n_flank /
+        c_flank) with mhcflurry's processing predictor should produce
+        two distinct cache rows — flanks are part of the input for
+        antigen_processing and pMHC_presentation kinds, so they're
+        part of the cache key."""
+        df = pd.DataFrame([
+            {
+                "peptide": "SIINFEKLA",
+                "allele": "HLA-A*02:01",
+                "n_flank": "ABC",
+                "c_flank": "XYZ",
+                "mhcflurry_processing_score": 0.30,
+            },
+            {
+                "peptide": "SIINFEKLA",
+                "allele": "HLA-A*02:01",
+                "n_flank": "DEF",
+                "c_flank": "UVW",
+                "mhcflurry_processing_score": 0.75,
+            },
+        ])
+        path = tmp_path / "mhcflurry.csv"
+        df.to_csv(path, index=False)
+        cache = CachedPredictor.from_mhcflurry(path, predictor_version="2.2.0")
+        out = cache.predict_peptides_dataframe(["SIINFEKLA"])
+        # Both flank contexts preserved — would have collided under
+        # the old 4-tuple key, last write winning silently.
+        assert len(out) == 2
+        assert set(out["n_flank"]) == {"ABC", "DEF"}
+        assert set(out["score"]) == {0.30, 0.75}
 
     def test_from_mhcflurry_affinity_only(self, tmp_path):
         """Affinity-only mhcflurry output emits only the affinity kind."""

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -777,7 +777,16 @@ class TestFromDirectory:
 
 # ---------------------------------------------------------------------------
 # Real NetMHC-family fixtures captured from the netmhc-bundle binaries
-# on peptide SLLQHLIGL at HLA-A*02:01 / A*24:02 / B*07:02.
+# on peptide SLLQHLIGL at HLA-A*02:01 / A*24:02 / B*07:02 (substituted
+# for B*07:01 which NetMHCpan doesn't recognize).
+#
+# Numeric assertions below (``affinity == 8.82`` etc.) pin the specific
+# NetMHC binary versions used to generate the fixtures — regenerating
+# them on a different machine or with a newer netmhc-bundle will likely
+# shift the numbers within pytest.approx tolerances.  Fixture headers
+# carry machine-specific comment lines (paths, timestamps, hostnames)
+# that don't affect parsing; they're left intact so the captures remain
+# byte-faithful reproductions of what the binaries emitted.
 # ---------------------------------------------------------------------------
 
 _FIXTURE_DIR = (
@@ -860,3 +869,54 @@ class TestRealNetMHCFixtures:
         assert cache.prediction_method_name == "netmhcstabpan"
         out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
         assert len(out) == 1
+
+
+@pytest.mark.skipif(
+    not _FIXTURE_DIR.exists(),
+    reason="NetMHC fixtures not available",
+)
+class TestMultiAlleleFixturesKnownBroken:
+    """Multi-allele NetMHCpan / NetMHCstabpan outputs are committed as
+    fixtures but don't parse through mhctools today — the per-allele
+    \"Distance to training data\" header lines confuse its row parser.
+    Filed upstream as openvax/mhctools#195.  These xfail tests pin the
+    current behavior so when the upstream fix lands, they flip to
+    passing and we get a reviewable diff that promotes them to regular
+    happy-path tests."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "mhctools#195 — multi-allele NetMHCpan stdout crashes on "
+            "per-allele header lines. Xfail flips to pass when upstream "
+            "is fixed; promote to happy-path test at that point."
+        ),
+    )
+    def test_multi_allele_netmhcpan_41_parses(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL.out",
+        )
+        alleles = set(cache.alleles)
+        assert alleles == {
+            "HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02",
+        }
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="mhctools#195 — same issue for NetMHCpan 4.0",
+    )
+    def test_multi_allele_netmhcpan_40_parses(self):
+        cache = CachedPredictor.from_netmhcpan_stdout(
+            _FIXTURE_DIR / "netmhcpan_40_SLLQHLIGL.out",
+        )
+        assert len(cache.alleles) == 3
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="mhctools#195 — same issue for NetMHCstabpan",
+    )
+    def test_multi_allele_netmhcstabpan_parses(self):
+        cache = CachedPredictor.from_netmhcstabpan_stdout(
+            _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL.out",
+        )
+        assert len(cache.alleles) == 3

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -969,46 +969,32 @@ class TestRealNetMHCFixtures:
     not _FIXTURE_DIR.exists(),
     reason="NetMHC fixtures not available",
 )
-class TestMultiAlleleFixturesKnownBroken:
-    """Multi-allele NetMHCpan / NetMHCstabpan outputs are committed as
-    fixtures but don't parse through mhctools today — the per-allele
-    \"Distance to training data\" header lines confuse its row parser.
-    Filed upstream as openvax/mhctools#195.  These xfail tests pin the
-    current behavior so when the upstream fix lands, they flip to
-    passing and we get a reviewable diff that promotes them to regular
-    happy-path tests."""
+class TestMultiAlleleFixtures:
+    """Multi-allele outputs from netmhc-bundle.  Previously xfail'd
+    due to mhctools#195 (per-allele header lines crashing the parser).
+    The switch to parse_netmhcpan_to_preds in from_netmhcpan_stdout
+    resolved the issue — these are now happy-path tests.
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "mhctools#195 — multi-allele NetMHCpan stdout crashes on "
-            "per-allele header lines. Xfail flips to pass when upstream "
-            "is fixed; promote to happy-path test at that point."
-        ),
-    )
+    Each fixture carries SLLQHLIGL at 3 alleles (A*02:01, A*24:02,
+    B*07:02)."""
+
     def test_multi_allele_netmhcpan_41_parses(self):
         cache = CachedPredictor.from_netmhcpan_stdout(
             _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL.out",
         )
-        alleles = set(cache.alleles)
-        assert alleles == {
+        assert set(cache.alleles) == {
             "HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02",
         }
+        out = cache.predict_peptides_dataframe(["SLLQHLIGL"])
+        # 3 alleles × 2 kinds (affinity + presentation) = 6 rows.
+        assert len(out) == 6
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="mhctools#195 — same issue for NetMHCpan 4.0",
-    )
     def test_multi_allele_netmhcpan_40_parses(self):
         cache = CachedPredictor.from_netmhcpan_stdout(
             _FIXTURE_DIR / "netmhcpan_40_SLLQHLIGL.out",
         )
         assert len(cache.alleles) == 3
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="mhctools#195 — same issue for NetMHCstabpan",
-    )
     def test_multi_allele_netmhcstabpan_parses(self):
         cache = CachedPredictor.from_netmhcstabpan_stdout(
             _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL.out",

--- a/tests/test_cli_cached_predictor.py
+++ b/tests/test_cli_cached_predictor.py
@@ -44,13 +44,6 @@ class TestCachedPredictorCliErrors:
         with pytest.raises(ValueError, match="--mhc-predictor"):
             _run(["--peptide-csv", csv])
 
-    def test_cache_file_without_format_raises(self, tmp_path):
-        pytest.importorskip("mhctools")
-        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
-        # Replaced by auto-sniff.  A bare TSV without identifying columns
-        # still raises; see TestCachedPredictorCliAutoSniff::test_tsv_not_autodetected.
-        pytest.skip("superseded by auto-sniff; see TestCachedPredictorCliAutoSniff")
-
     def test_file_and_directory_mutually_exclusive(self, tmp_path):
         csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
         with pytest.raises(ValueError, match="mutually exclusive"):
@@ -187,6 +180,28 @@ class TestCachedPredictorCliTsv:
         assert row["percentile_rank"] == 1.2
         assert row["prediction_method_name"] == "netchop"
         assert row["predictor_version"] == "3.1"
+        # kind defaults to pMHC_affinity so DSL Affinity.* scope works.
+        assert row["kind"] == "pMHC_affinity"
+
+    def test_tsv_explicit_kind(self, tmp_path):
+        """--mhc-cache-tsv-kind stamps a non-default kind when the TSV
+        carries e.g. stability predictions."""
+        tsv_path = tmp_path / "stab.tsv"
+        tsv_path.write_text(
+            "peptide\tallele\tthalf_hours\n"
+            "SLLQHLIGL\tHLA-A*02:01\t4.5\n"
+        )
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        out = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(tsv_path),
+            "--mhc-cache-format", "tsv",
+            "--mhc-cache-predictor-name", "custom-stab",
+            "--mhc-cache-predictor-version", "1.0",
+            "--mhc-cache-tsv-kind", "pMHC_stability",
+            "--mhc-cache-tsv-column", "value=thalf_hours",
+        ])
+        assert out.iloc[0]["kind"] == "pMHC_stability"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_cached_predictor.py
+++ b/tests/test_cli_cached_predictor.py
@@ -1,0 +1,194 @@
+"""CLI-level tests for --mhc-cache-* arguments.
+
+Exercise the end-to-end CLI path through topiary's argument parser and
+predict_epitopes_from_args, confirming that each supported
+--mhc-cache-format wires into the right CachedPredictor loader and
+that the output DataFrame carries the expected prediction values.
+
+Uses the real NetMHC-family stdout fixtures in tests/data/netmhc_fixtures/
+(captured from netmhc-bundle binaries on peptide SLLQHLIGL × a few
+HLA alleles) so the tests verify both the CLI glue and the parsing
+chain through mhctools.
+"""
+import pathlib
+
+import pytest
+
+from topiary.cli.args import arg_parser, predict_epitopes_from_args
+
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / "data" / "netmhc_fixtures"
+_HAS_FIXTURES = _FIXTURE_DIR.exists()
+
+
+def _run(cli_args):
+    """Parse a list of CLI tokens and run the prediction pipeline."""
+    args = arg_parser.parse_args(cli_args)
+    return predict_epitopes_from_args(args)
+
+
+def _write_peptide_csv(path, peptide):
+    """Write a one-peptide CSV at ``path`` and return its string path."""
+    path.write_text(f"peptide\n{peptide}\n")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Error paths: CLI validation
+# ---------------------------------------------------------------------------
+
+
+class TestCachedPredictorCliErrors:
+    def test_no_predictor_no_cache_raises(self, tmp_path):
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        with pytest.raises(ValueError, match="--mhc-predictor"):
+            _run(["--peptide-csv", csv])
+
+    def test_cache_file_without_format_raises(self, tmp_path):
+        pytest.importorskip("mhctools")
+        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+        if not fixture.exists():
+            pytest.skip("fixture missing")
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        with pytest.raises(ValueError, match="--mhc-cache-format"):
+            _run([
+                "--peptide-csv", csv,
+                "--mhc-cache-file", str(fixture),
+            ])
+
+    def test_file_and_directory_mutually_exclusive(self, tmp_path):
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _run([
+                "--peptide-csv", csv,
+                "--mhc-cache-file", "a.out",
+                "--mhc-cache-directory", "b",
+                "--mhc-cache-format", "netmhcpan_stdout",
+            ])
+
+
+# ---------------------------------------------------------------------------
+# Happy-path runs through each NetMHC-family fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_FIXTURES, reason="NetMHC fixtures missing")
+class TestCachedPredictorCliHappyPath:
+    def test_netmhcpan_stdout_wires_cli_to_loader(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcpan_stdout",
+        ])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["peptide"] == "SLLQHLIGL"
+        assert row["allele"] == "HLA-A*02:01"
+        assert row["affinity"] == pytest.approx(8.82, rel=1e-3)
+        assert row["prediction_method_name"] == "netmhcpan"
+        assert row["predictor_version"] == "4.1b"
+
+    def test_netmhc_stdout_version_4(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhc_40_SLLQHLIGL.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhc_stdout",
+            "--mhc-cache-netmhc-version", "4",
+        ])
+        # Multi-allele fixture → one row per (peptide, allele)
+        assert set(df["allele"]) == {
+            "HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02",
+        }
+        assert (df["prediction_method_name"] == "netmhc").all()
+
+    def test_netmhcstabpan_stdout(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL_A0201.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcstabpan_stdout",
+        ])
+        assert len(df) == 1
+        assert df.iloc[0]["prediction_method_name"] == "netmhcstabpan"
+
+    def test_explicit_predictor_version_override(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcpan_stdout",
+            "--mhc-cache-predictor-version", "my-custom-label",
+        ])
+        assert (df["predictor_version"] == "my-custom-label").all()
+
+
+# ---------------------------------------------------------------------------
+# Topiary-output round-trip via the CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCachedPredictorCliTopiaryRoundtrip:
+    def test_from_dataframe_written_by_save(self, tmp_path):
+        """Save a CachedPredictor as TSV then reload via CLI."""
+        import pandas as pd
+        from topiary import CachedPredictor
+
+        df = pd.DataFrame([{
+            "peptide": "SLLQHLIGL",
+            "allele": "HLA-A*02:01",
+            "peptide_length": 9,
+            "affinity": 42.0,
+            "score": 0.8,
+            "percentile_rank": 0.5,
+            "prediction_method_name": "synthetic",
+            "predictor_version": "1.0",
+        }])
+        cache = CachedPredictor.from_dataframe(df)
+        cache_path = tmp_path / "cache.tsv"
+        cache.save(cache_path)
+
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        out = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(cache_path),
+            "--mhc-cache-format", "topiary_output",
+        ])
+        assert len(out) == 1
+        assert out.iloc[0]["affinity"] == 42.0
+        assert out.iloc[0]["predictor_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Generic TSV loader with column mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCachedPredictorCliTsv:
+    def test_tsv_with_column_mapping(self, tmp_path):
+        tsv_path = tmp_path / "third_party.tsv"
+        tsv_path.write_text(
+            "peptide\tallele\tIC50_nM\tRank\n"
+            "SLLQHLIGL\tHLA-A*02:01\t125.0\t1.2\n"
+        )
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        out = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(tsv_path),
+            "--mhc-cache-format", "tsv",
+            "--mhc-cache-predictor-name", "netchop",
+            "--mhc-cache-predictor-version", "3.1",
+            "--mhc-cache-tsv-column", "affinity=IC50_nM",
+            "--mhc-cache-tsv-column", "percentile_rank=Rank",
+        ])
+        assert len(out) == 1
+        row = out.iloc[0]
+        assert row["affinity"] == 125.0
+        assert row["percentile_rank"] == 1.2
+        assert row["prediction_method_name"] == "netchop"
+        assert row["predictor_version"] == "3.1"

--- a/tests/test_cli_cached_predictor.py
+++ b/tests/test_cli_cached_predictor.py
@@ -70,13 +70,16 @@ class TestCachedPredictorCliHappyPath:
             "--mhc-cache-file", str(fixture),
             "--mhc-cache-format", "netmhcpan",
         ])
-        assert len(df) == 1
-        row = df.iloc[0]
-        assert row["peptide"] == "SLLQHLIGL"
-        assert row["allele"] == "HLA-A*02:01"
-        assert row["affinity"] == pytest.approx(8.82, rel=1e-3)
-        assert row["prediction_method_name"] == "netmhcpan"
-        assert row["predictor_version"] == "4.1b"
+        # NetMHCpan 4.1 -BA emits affinity + elution_score per
+        # (peptide, allele) → 2 rows.
+        assert len(df) == 2
+        assert set(df["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
+        by_kind = df.set_index("kind")
+        assert by_kind.loc["pMHC_affinity", "affinity"] == pytest.approx(
+            8.82, rel=1e-3,
+        )
+        assert (df["prediction_method_name"] == "netmhcpan").all()
+        assert (df["predictor_version"] == "4.1b").all()
 
     def test_netmhc_stdout_version_4(self, tmp_path):
         fixture = _FIXTURE_DIR / "netmhc_40_SLLQHLIGL.out"
@@ -131,6 +134,7 @@ class TestCachedPredictorCliTopiaryRoundtrip:
             "peptide": "SLLQHLIGL",
             "allele": "HLA-A*02:01",
             "peptide_length": 9,
+            "kind": "pMHC_affinity",
             "affinity": 42.0,
             "score": 0.8,
             "percentile_rank": 0.5,
@@ -159,10 +163,12 @@ class TestCachedPredictorCliTopiaryRoundtrip:
 
 class TestCachedPredictorCliTsv:
     def test_tsv_with_column_mapping(self, tmp_path):
+        """Generic TSV with a 'kind' column and non-canonical data-
+        column names, mapped via --mhc-cache-tsv-column."""
         tsv_path = tmp_path / "third_party.tsv"
         tsv_path.write_text(
-            "peptide\tallele\tIC50_nM\tRank\n"
-            "SLLQHLIGL\tHLA-A*02:01\t125.0\t1.2\n"
+            "peptide\tallele\tIC50_nM\tRank\tkind\n"
+            "SLLQHLIGL\tHLA-A*02:01\t125.0\t1.2\tpMHC_affinity\n"
         )
         pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
         out = _run([
@@ -178,18 +184,15 @@ class TestCachedPredictorCliTsv:
         row = out.iloc[0]
         assert row["affinity"] == 125.0
         assert row["percentile_rank"] == 1.2
-        assert row["prediction_method_name"] == "netchop"
-        assert row["predictor_version"] == "3.1"
-        # kind defaults to pMHC_affinity so DSL Affinity.* scope works.
         assert row["kind"] == "pMHC_affinity"
 
-    def test_tsv_explicit_kind(self, tmp_path):
-        """--mhc-cache-tsv-kind stamps a non-default kind when the TSV
-        carries e.g. stability predictions."""
+    def test_tsv_stability_kind(self, tmp_path):
+        """TSV with a stability 'kind' value — DSL's Stability scope
+        dispatches on it."""
         tsv_path = tmp_path / "stab.tsv"
         tsv_path.write_text(
-            "peptide\tallele\tthalf_hours\n"
-            "SLLQHLIGL\tHLA-A*02:01\t4.5\n"
+            "peptide\tallele\tthalf_hours\tkind\n"
+            "SLLQHLIGL\tHLA-A*02:01\t4.5\tpMHC_stability\n"
         )
         pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
         out = _run([
@@ -198,10 +201,29 @@ class TestCachedPredictorCliTsv:
             "--mhc-cache-format", "tsv",
             "--mhc-cache-predictor-name", "custom-stab",
             "--mhc-cache-predictor-version", "1.0",
-            "--mhc-cache-tsv-kind", "pMHC_stability",
             "--mhc-cache-tsv-column", "value=thalf_hours",
         ])
         assert out.iloc[0]["kind"] == "pMHC_stability"
+
+    def test_tsv_multi_kind_in_one_file(self, tmp_path):
+        """Multi-kind TSV — both affinity and presentation rows for the
+        same (peptide, allele) coexist via the 4-tuple index key."""
+        tsv_path = tmp_path / "multi.tsv"
+        tsv_path.write_text(
+            "peptide\tallele\tkind\taffinity\tpercentile_rank\tscore\n"
+            "SLLQHLIGL\tHLA-A*02:01\tpMHC_affinity\t42.0\t1.0\t\n"
+            "SLLQHLIGL\tHLA-A*02:01\tpMHC_presentation\t\t0.5\t0.85\n"
+        )
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        out = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(tsv_path),
+            "--mhc-cache-format", "tsv",
+            "--mhc-cache-predictor-name", "multi-kind-tool",
+            "--mhc-cache-predictor-version", "1.0",
+        ])
+        assert len(out) == 2
+        assert set(out["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +242,7 @@ class TestCachedPredictorCliSharding:
                 "peptide": peptide,
                 "allele": "HLA-A*02:01",
                 "peptide_length": 9,
+                "kind": "pMHC_affinity",
                 "affinity": affinity,
                 "score": 0.5,
                 "percentile_rank": 1.0,
@@ -252,26 +275,34 @@ class TestCachedPredictorCliSharding:
 @pytest.mark.skipif(not _HAS_FIXTURES, reason="NetMHC fixtures missing")
 class TestCachedPredictorCliFilterSort:
     def test_filter_by_applies_to_cached_predictions(self, tmp_path):
-        """--filter-by runs on the joined cached-prediction DataFrame."""
+        """--filter-by runs on the joined cached-prediction DataFrame.
+        DSL filters on the `affinity` column work against multi-kind
+        cached output."""
         fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
         pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
-        # Query at A*02:01 where SLLQHLIGL is a strong binder (~8.8 nM).
-        # A permissive filter (affinity <= 500) keeps the row.
+        # Permissive filter keeps rows where affinity passes (the
+        # presentation row has affinity=NaN which is NaN-tolerant in
+        # topiary's filter semantics — see
+        # feedback_apply_filter_non_boolean).
         df = _run([
             "--peptide-csv", pep_csv,
             "--mhc-cache-file", str(fixture),
             "--mhc-cache-format", "netmhcpan",
             "--filter-by", "affinity <= 500",
         ])
-        assert len(df) == 1
-        # Restrictive filter (affinity <= 1) drops it.
+        assert len(df) >= 1
+        # The affinity row (pMHC_affinity with affinity=8.82) survives.
+        affinity_rows = df[df["kind"] == "pMHC_affinity"]
+        assert len(affinity_rows) == 1
+        assert affinity_rows.iloc[0]["affinity"] <= 500
+        # Restrictive filter drops the affinity row too.
         df_empty = _run([
             "--peptide-csv", pep_csv,
             "--mhc-cache-file", str(fixture),
             "--mhc-cache-format", "netmhcpan",
             "--filter-by", "affinity <= 1",
         ])
-        assert len(df_empty) == 0
+        assert not (df_empty["kind"] == "pMHC_affinity").any()
 
     def test_sort_by_applies_to_cached_predictions(self, tmp_path):
         """--sort-by runs on the joined cached-prediction DataFrame."""
@@ -306,8 +337,10 @@ class TestCachedPredictorCliAutoSniff:
             "--peptide-csv", csv,
             "--mhc-cache-file", str(fixture),
         ])
-        assert len(df) == 1
-        assert df.iloc[0]["prediction_method_name"] == "netmhcpan"
+        # NetMHCpan 4.1 -BA emits affinity + elution_score → 2 rows.
+        assert len(df) == 2
+        assert (df["prediction_method_name"] == "netmhcpan").all()
+        assert set(df["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
 
     def test_netmhcstabpan_autodetected(self, tmp_path):
         fixture = _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL_A0201.out"

--- a/tests/test_cli_cached_predictor.py
+++ b/tests/test_cli_cached_predictor.py
@@ -47,14 +47,9 @@ class TestCachedPredictorCliErrors:
     def test_cache_file_without_format_raises(self, tmp_path):
         pytest.importorskip("mhctools")
         fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
-        if not fixture.exists():
-            pytest.skip("fixture missing")
-        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
-        with pytest.raises(ValueError, match="--mhc-cache-format"):
-            _run([
-                "--peptide-csv", csv,
-                "--mhc-cache-file", str(fixture),
-            ])
+        # Replaced by auto-sniff.  A bare TSV without identifying columns
+        # still raises; see TestCachedPredictorCliAutoSniff::test_tsv_not_autodetected.
+        pytest.skip("superseded by auto-sniff; see TestCachedPredictorCliAutoSniff")
 
     def test_file_and_directory_mutually_exclusive(self, tmp_path):
         csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
@@ -63,7 +58,7 @@ class TestCachedPredictorCliErrors:
                 "--peptide-csv", csv,
                 "--mhc-cache-file", "a.out",
                 "--mhc-cache-directory", "b",
-                "--mhc-cache-format", "netmhcpan_stdout",
+                "--mhc-cache-format", "netmhcpan",
             ])
 
 
@@ -80,7 +75,7 @@ class TestCachedPredictorCliHappyPath:
         df = _run([
             "--peptide-csv", csv,
             "--mhc-cache-file", str(fixture),
-            "--mhc-cache-format", "netmhcpan_stdout",
+            "--mhc-cache-format", "netmhcpan",
         ])
         assert len(df) == 1
         row = df.iloc[0]
@@ -96,7 +91,7 @@ class TestCachedPredictorCliHappyPath:
         df = _run([
             "--peptide-csv", csv,
             "--mhc-cache-file", str(fixture),
-            "--mhc-cache-format", "netmhc_stdout",
+            "--mhc-cache-format", "netmhc",
             "--mhc-cache-netmhc-version", "4",
         ])
         # Multi-allele fixture → one row per (peptide, allele)
@@ -111,7 +106,7 @@ class TestCachedPredictorCliHappyPath:
         df = _run([
             "--peptide-csv", csv,
             "--mhc-cache-file", str(fixture),
-            "--mhc-cache-format", "netmhcstabpan_stdout",
+            "--mhc-cache-format", "netmhcstabpan",
         ])
         assert len(df) == 1
         assert df.iloc[0]["prediction_method_name"] == "netmhcstabpan"
@@ -122,7 +117,7 @@ class TestCachedPredictorCliHappyPath:
         df = _run([
             "--peptide-csv", csv,
             "--mhc-cache-file", str(fixture),
-            "--mhc-cache-format", "netmhcpan_stdout",
+            "--mhc-cache-format", "netmhcpan",
             "--mhc-cache-predictor-version", "my-custom-label",
         ])
         assert (df["predictor_version"] == "my-custom-label").all()
@@ -192,3 +187,169 @@ class TestCachedPredictorCliTsv:
         assert row["percentile_rank"] == 1.2
         assert row["prediction_method_name"] == "netchop"
         assert row["predictor_version"] == "3.1"
+
+
+# ---------------------------------------------------------------------------
+# CLI directory sharding + filter/sort interaction
+# ---------------------------------------------------------------------------
+
+
+class TestCachedPredictorCliSharding:
+    def test_mhc_cache_directory_merges_shards(self, tmp_path):
+        """--mhc-cache-directory loads every matching file and concats them."""
+        import pandas as pd
+        from topiary import CachedPredictor
+
+        def _make_shard(peptide, affinity):
+            df = pd.DataFrame([{
+                "peptide": peptide,
+                "allele": "HLA-A*02:01",
+                "peptide_length": 9,
+                "affinity": affinity,
+                "score": 0.5,
+                "percentile_rank": 1.0,
+                "prediction_method_name": "synthetic",
+                "predictor_version": "1.0",
+            }])
+            return CachedPredictor.from_dataframe(df)
+
+        cache_dir = tmp_path / "caches"
+        cache_dir.mkdir()
+        _make_shard("SLLQHLIGL", 42.0).save(cache_dir / "a.tsv")
+        _make_shard("GILGFVFTL", 100.0).save(cache_dir / "b.tsv")
+
+        # Peptides CSV covering BOTH shards
+        pep_csv = tmp_path / "pep.csv"
+        pep_csv.write_text("peptide\nSLLQHLIGL\nGILGFVFTL\n")
+
+        df = _run([
+            "--peptide-csv", str(pep_csv),
+            "--mhc-cache-directory", str(cache_dir),
+            "--mhc-cache-directory-pattern", "*.tsv",
+        ])
+        assert len(df) == 2
+        assert set(df["peptide"]) == {"SLLQHLIGL", "GILGFVFTL"}
+        by_pep = df.set_index("peptide")
+        assert by_pep.loc["SLLQHLIGL", "affinity"] == 42.0
+        assert by_pep.loc["GILGFVFTL", "affinity"] == 100.0
+
+
+@pytest.mark.skipif(not _HAS_FIXTURES, reason="NetMHC fixtures missing")
+class TestCachedPredictorCliFilterSort:
+    def test_filter_by_applies_to_cached_predictions(self, tmp_path):
+        """--filter-by runs on the joined cached-prediction DataFrame."""
+        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        # Query at A*02:01 where SLLQHLIGL is a strong binder (~8.8 nM).
+        # A permissive filter (affinity <= 500) keeps the row.
+        df = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcpan",
+            "--filter-by", "affinity <= 500",
+        ])
+        assert len(df) == 1
+        # Restrictive filter (affinity <= 1) drops it.
+        df_empty = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcpan",
+            "--filter-by", "affinity <= 1",
+        ])
+        assert len(df_empty) == 0
+
+    def test_sort_by_applies_to_cached_predictions(self, tmp_path):
+        """--sort-by runs on the joined cached-prediction DataFrame."""
+        fixture = _FIXTURE_DIR / "netmhc_40_SLLQHLIGL.out"  # multi-allele
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhc",
+            "--mhc-cache-netmhc-version", "4",
+            "--sort-by", "affinity",  # ascending — strongest binder first
+        ])
+        assert len(df) == 3
+        # Strongest binder is A*02:01 (~13 nM); sort pushes it to the top.
+        assert df.iloc[0]["allele"] == "HLA-A*02:01"
+
+
+# ---------------------------------------------------------------------------
+# Auto-sniff: --mhc-cache-format can be omitted for formats with
+# identifying content (NetMHC family, mhcflurry, topiary output).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_FIXTURES, reason="NetMHC fixtures missing")
+class TestCachedPredictorCliAutoSniff:
+    def test_netmhcpan_autodetected(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        # No --mhc-cache-format — sniffed from the "NetMHCpan version 4.1b"
+        # preamble line.
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+        ])
+        assert len(df) == 1
+        assert df.iloc[0]["prediction_method_name"] == "netmhcpan"
+
+    def test_netmhcstabpan_autodetected(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL_A0201.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+        ])
+        assert len(df) == 1
+        assert df.iloc[0]["prediction_method_name"] == "netmhcstabpan"
+
+    def test_netmhc_classic_autodetected(self, tmp_path):
+        fixture = _FIXTURE_DIR / "netmhc_40_SLLQHLIGL.out"
+        csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        df = _run([
+            "--peptide-csv", csv,
+            "--mhc-cache-file", str(fixture),
+        ])
+        # NetMHC classic — multi-allele file → 3 rows
+        assert len(df) == 3
+
+    def test_topiary_output_autodetected(self, tmp_path):
+        import pandas as pd
+        from topiary import CachedPredictor
+
+        df = pd.DataFrame([{
+            "peptide": "SLLQHLIGL",
+            "allele": "HLA-A*02:01",
+            "peptide_length": 9,
+            "affinity": 42.0,
+            "score": 0.5,
+            "percentile_rank": 1.0,
+            "kind": "pMHC_affinity",
+            "prediction_method_name": "synthetic",
+            "predictor_version": "1.0",
+        }])
+        cache = CachedPredictor.from_dataframe(df)
+        cache.save(tmp_path / "cache.tsv")
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        # No --mhc-cache-format — sniffed from the column headers.
+        out = _run([
+            "--peptide-csv", pep_csv,
+            "--mhc-cache-file", str(tmp_path / "cache.tsv"),
+        ])
+        assert len(out) == 1
+        assert out.iloc[0]["affinity"] == 42.0
+
+    def test_tsv_not_autodetected(self, tmp_path):
+        """Generic TSV has no identifying content; must be explicit."""
+        tsv_path = tmp_path / "third_party.tsv"
+        tsv_path.write_text(
+            "peptide\tallele\tIC50_nM\n"
+            "SLLQHLIGL\tHLA-A*02:01\t42.0\n"
+        )
+        pep_csv = _write_peptide_csv(tmp_path / "pep.csv", "SLLQHLIGL")
+        with pytest.raises(ValueError, match="auto-detect"):
+            _run([
+                "--peptide-csv", pep_csv,
+                "--mhc-cache-file", str(tsv_path),
+            ])

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -187,11 +187,14 @@ class CachedPredictor:
         keep = [c for c in _CACHE_COLUMNS if c in df.columns]
         out = df[keep].copy()
         # n_flank / c_flank are part of the composite key — backfill
-        # with None when the source file doesn't provide them so every
-        # row has a well-defined key shape.
+        # with empty string when the source file doesn't provide them
+        # so every row has a well-defined key shape and there's no
+        # NaN-vs-None ambiguity in hashes or groupby passes.
         for flank_col in ("n_flank", "c_flank"):
             if flank_col not in out.columns:
-                out[flank_col] = None
+                out[flank_col] = ""
+            else:
+                out[flank_col] = out[flank_col].map(_flank_key)
         out["peptide"] = out["peptide"].astype(str)
         out["allele"] = out["allele"].astype(str)
         out["peptide_length"] = out["peptide_length"].astype(int)
@@ -915,12 +918,7 @@ class CachedPredictor:
         if callable(on_overlap):
             singletons = df[~dup_mask]
             resolved = []
-            # dropna=False: keep groups where a key column is None/NaN
-            # (flank columns are None for predictors that don't supply
-            # them; default groupby would drop those groups entirely).
-            for _, group in df[dup_mask].groupby(
-                key_cols, sort=False, dropna=False,
-            ):
+            for _, group in df[dup_mask].groupby(key_cols, sort=False):
                 rows = [r.to_dict() for _, r in group.iterrows()]
                 merged = rows[0]
                 for nxt in rows[1:]:
@@ -1009,23 +1007,24 @@ def _read_text(path) -> str:
 
 
 def _flank_key(value):
-    """Normalize a flank column value into something hashable + stable
-    across NaN / None / empty-string representations.
+    """Normalize a flank column value for use as part of the cache key.
 
-    Returns ``None`` for any missing / NaN / empty value, else the
-    uppercased string.  Ensures a row whose ``n_flank`` is NaN and a
-    row whose ``n_flank`` is ``None`` hash to the same key (they
-    represent the same absence-of-flank)."""
+    Empty string ``""`` represents "no flank context" (predictors that
+    don't take flanks, or source files that didn't provide them).
+    ``NaN`` / ``None`` / whitespace-only all coerce to ``""`` so
+    round-trips through TSV / Parquet stay stable.  Otherwise:
+    uppercased stripped string.
+    """
     if value is None:
-        return None
+        return ""
     try:
         if pd.isna(value):
-            return None
+            return ""
     except (TypeError, ValueError):
         pass
     s = str(value).strip()
     if not s or s.lower() == "nan":
-        return None
+        return ""
     return s.upper()
 
 

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -513,6 +513,7 @@ class CachedPredictor:
         sep: str = "\t",
         prediction_method_name: Optional[str] = None,
         predictor_version: Optional[str] = None,
+        kind: str = "pMHC_affinity",
         fallback=None,
         also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
@@ -523,10 +524,20 @@ class CachedPredictor:
         names actually present in the file, e.g.
         ``{"affinity": "ic50", "percentile_rank": "rank"}``.
         Pass ``sep=","`` for CSV files.
+
+        ``kind`` stamps every row unless a ``kind`` column is already
+        present in the file.  Default ``"pMHC_affinity"`` fits most
+        third-party binding-affinity tables; pass ``"pMHC_presentation"``
+        for eluted-ligand outputs, ``"pMHC_stability"`` for stability
+        predictors.  The DSL's ``Affinity.*`` / ``Presentation.*`` /
+        ``Stability.*`` scopes dispatch on this column, so a wrong
+        default silently filters downstream.
         """
         df = pd.read_csv(path, sep=sep)
         if columns:
             df = df.rename(columns={v: k for k, v in columns.items()})
+        if "kind" not in df.columns:
+            df["kind"] = kind
         return cls.from_dataframe(
             df,
             prediction_method_name=prediction_method_name,

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -38,16 +38,29 @@ import pandas as pd
 
 # Columns a cache row must carry so the core invariant and lookup work.
 _REQUIRED_COLUMNS = (
-    "peptide", "allele", "peptide_length",
+    "peptide", "allele", "peptide_length", "kind",
     "prediction_method_name", "predictor_version",
 )
 
 # All columns the cache preserves on load and round-trip.
 _CACHE_COLUMNS = (
-    "peptide", "allele", "peptide_length",
-    "score", "affinity", "percentile_rank", "value", "kind",
+    "peptide", "allele", "peptide_length", "kind",
+    "score", "affinity", "percentile_rank", "value",
     "prediction_method_name", "predictor_version",
+    # Provenance / context — carried through when the source file has
+    # them.  n_flank / c_flank matter for mhcflurry's processing
+    # prediction (flanking residues influence the score);
+    # source_sequence_name + peptide_offset identify which protein +
+    # position a peptide came from; sample_name discriminates multi-
+    # sample inputs.  All optional; absent → None.
+    "source_sequence_name", "peptide_offset",
+    "n_flank", "c_flank", "sample_name",
 )
+
+# Composite key for the cache index — distinguishes rows that share
+# (peptide, allele, length) but differ on kind (mhcflurry affinity +
+# presentation + processing, NetMHCpan -BA's affinity + elution, etc.).
+_KEY_COLS = ("peptide", "allele", "peptide_length", "kind")
 
 
 class CachedPredictor:
@@ -145,11 +158,26 @@ class CachedPredictor:
                     f"the version invariant — supply a value via the "
                     f"loader's predictor_name / predictor_version args."
                 )
+        # Reject null / empty kind the same way — multi-kind cache
+        # keys on (peptide, allele, length, kind); NaN/missing kind
+        # would silently collide across kinds.
+        na_mask = df["kind"].isna() | (
+            df["kind"].astype(str).str.strip().isin(["", "None", "nan", "NaN"])
+        )
+        if na_mask.any():
+            raise ValueError(
+                f"CachedPredictor: column 'kind' must be a non-empty "
+                f"string on every row (got {int(na_mask.sum())} "
+                f"null/empty value(s)).  The cache keys on "
+                f"(peptide, allele, peptide_length, kind); missing "
+                f"kind would collide across kinds."
+            )
         keep = [c for c in _CACHE_COLUMNS if c in df.columns]
         out = df[keep].copy()
         out["peptide"] = out["peptide"].astype(str)
         out["allele"] = out["allele"].astype(str)
         out["peptide_length"] = out["peptide_length"].astype(int)
+        out["kind"] = out["kind"].astype(str)
         # Version strings may look numeric ("1.0") and get coerced by
         # pandas on TSV/CSV reload — force to str so the invariant
         # compares the same shape on both sides of a round-trip.
@@ -181,9 +209,17 @@ class CachedPredictor:
 
     @staticmethod
     def _build_index(df: pd.DataFrame) -> dict:
+        """Build ``(peptide, allele, peptide_length, kind) → row_dict``
+        index.  The four-way key is what lets a single cache hold
+        affinity + presentation + processing rows for the same
+        ``(peptide, allele)`` — a three-tuple key would collide."""
         return {
-            (str(r["peptide"]), str(r["allele"]), int(r["peptide_length"])):
-                r.to_dict()
+            (
+                str(r["peptide"]),
+                str(r["allele"]),
+                int(r["peptide_length"]),
+                str(r["kind"]),
+            ): r.to_dict()
             for _, r in df.iterrows()
         }
 
@@ -209,11 +245,15 @@ class CachedPredictor:
     def predict_peptides_dataframe(
         self, peptides: Iterable[str],
     ) -> pd.DataFrame:
-        """Return one row per ``(peptide, allele)`` for each input peptide
-        crossed with every allele in the cache (or in the fallback, if set).
+        """Return one row per ``(peptide, allele, kind)`` — every kind
+        the cache carries for a given ``(peptide, allele)`` produces
+        its own row.  mhcflurry's class1_presentation pipeline stores
+        three kinds per key (affinity + presentation + processing);
+        NetMHCpan ``-BA`` stores two (affinity + elution score).  This
+        matches the shape ``mhctools.predict_proteins_dataframe`` emits.
 
-        Misses are resolved through ``self.fallback`` (which merges into
-        the cache) if set; else raise ``KeyError``.
+        Misses are resolved through ``self.fallback`` (which merges
+        into the cache) if set; else raise ``KeyError``.
         """
         peptides = [str(p) for p in peptides]
         query_alleles = self._cache_alleles()
@@ -223,31 +263,52 @@ class CachedPredictor:
                 | set(getattr(self.fallback, "alleles", []))
             )
 
-        # Identify peptides with at least one missing (peptide, allele).
+        # The cache's kind set — typically one or two entries per
+        # predictor.  Multi-kind predictors produce the full set.
+        cache_kinds = self._cache_kinds()
+
+        # Identify peptides with at least one missing (peptide, allele)
+        # across any known kind.  Resolving at peptide granularity keeps
+        # the fallback call simple (it returns all kinds for each peptide
+        # anyway) and matches the prior behavior's semantics.
         missed_peptides = set()
         for peptide in peptides:
             length = len(peptide)
             for allele in query_alleles:
-                if (peptide, allele, length) not in self._index:
+                # At least one kind must be present for this (pep, allele).
+                if not any(
+                    (peptide, allele, length, k) in self._index
+                    for k in cache_kinds
+                ):
                     missed_peptides.add(peptide)
                     break
 
         # Resolve misses through fallback (populates self._index in place).
         if missed_peptides:
             self._fallback_resolve(sorted(missed_peptides))
+            # Refresh kinds — fallback may have added new kinds.
+            cache_kinds = self._cache_kinds()
 
-        # Assemble output from the (updated) cache.
+        # Assemble output — one row per (peptide, allele, kind) that
+        # exists in the cache.
         rows = []
         for peptide in peptides:
             length = len(peptide)
             for allele in query_alleles:
-                row = self._index.get((peptide, allele, length))
-                if row is not None:
-                    rows.append(row)
+                for kind in cache_kinds:
+                    row = self._index.get((peptide, allele, length, kind))
+                    if row is not None:
+                        rows.append(row)
 
         if not rows:
             return pd.DataFrame(columns=list(_CACHE_COLUMNS))
         return pd.DataFrame(rows).reindex(columns=list(_CACHE_COLUMNS))
+
+    def _cache_kinds(self):
+        """Distinct kinds present in the cache."""
+        if len(self._df) == 0:
+            return []
+        return sorted(set(self._df["kind"].unique().tolist()))
 
     # mhctools compat: some code paths probe for ``predict_dataframe``.
     predict_dataframe = predict_peptides_dataframe
@@ -342,6 +403,7 @@ class CachedPredictor:
                 str(row["peptide"]),
                 str(row["allele"]),
                 int(row["peptide_length"]),
+                str(row["kind"]),
             )
             return key not in self._index
 
@@ -349,7 +411,10 @@ class CachedPredictor:
         novel_rows = new_rows[novel_mask]
         for _, r in novel_rows.iterrows():
             key = (
-                str(r["peptide"]), str(r["allele"]), int(r["peptide_length"]),
+                str(r["peptide"]),
+                str(r["allele"]),
+                int(r["peptide_length"]),
+                str(r["kind"]),
             )
             self._index[key] = r.to_dict()
 
@@ -513,7 +578,6 @@ class CachedPredictor:
         sep: str = "\t",
         prediction_method_name: Optional[str] = None,
         predictor_version: Optional[str] = None,
-        kind: str = "pMHC_affinity",
         fallback=None,
         also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
@@ -522,22 +586,22 @@ class CachedPredictor:
 
         ``columns`` maps canonical cache column names to the column
         names actually present in the file, e.g.
-        ``{"affinity": "ic50", "percentile_rank": "rank"}``.
+        ``{"affinity": "ic50", "percentile_rank": "rank", "kind": "score_kind"}``.
         Pass ``sep=","`` for CSV files.
 
-        ``kind`` stamps every row unless a ``kind`` column is already
-        present in the file.  Default ``"pMHC_affinity"`` fits most
-        third-party binding-affinity tables; pass ``"pMHC_presentation"``
-        for eluted-ligand outputs, ``"pMHC_stability"`` for stability
-        predictors.  The DSL's ``Affinity.*`` / ``Presentation.*`` /
-        ``Stability.*`` scopes dispatch on this column, so a wrong
-        default silently filters downstream.
+        The file **must** have a ``kind`` column per row (either
+        natively or via the ``columns=`` mapping) — one of
+        ``"pMHC_affinity"``, ``"pMHC_presentation"``,
+        ``"pMHC_stability"``, ``"antigen_processing"``.  The DSL's
+        ``Affinity.*`` / ``Presentation.*`` / ``Stability.*`` scopes
+        dispatch on it.  A single-kind table is easy: add a ``kind``
+        column with the same value on every row.  Multi-kind tables
+        (e.g. affinity + presentation in the same file) work out of
+        the box.
         """
         df = pd.read_csv(path, sep=sep)
         if columns:
             df = df.rename(columns={v: k for k, v in columns.items()})
-        if "kind" not in df.columns:
-            df["kind"] = kind
         return cls.from_dataframe(
             df,
             prediction_method_name=prediction_method_name,
@@ -576,28 +640,13 @@ class CachedPredictor:
         when you need a custom label.
         """
         df = pd.read_csv(path)
-        col_map = {}
-        if "mhcflurry_affinity" in df.columns:
-            col_map["mhcflurry_affinity"] = "affinity"
-        if "mhcflurry_affinity_percentile" in df.columns:
-            col_map["mhcflurry_affinity_percentile"] = "percentile_rank"
-        if "mhcflurry_presentation_score" in df.columns:
-            col_map["mhcflurry_presentation_score"] = "score"
-        df = df.rename(columns=col_map)
-        # TODO(multi-kind): mhcflurry's full class1_presentation pipeline
-        # emits affinity + presentation + processing per (peptide,
-        # allele) row.  CachedPredictor today keys on (peptide, allele,
-        # peptide_length) — storing multiple kinds for the same key
-        # would collapse to the last one written.  For now, pick the
-        # richer of the two signals present ("pMHC_presentation" when
-        # the presentation column exists, else "pMHC_affinity").
-        # Multi-kind caches tracked as a follow-up issue.
-        if "kind" not in df.columns:
-            df["kind"] = (
-                "pMHC_presentation"
-                if "score" in df.columns
-                else "pMHC_affinity"
-            )
+        # mhcflurry's wide-format output carries up to three kinds of
+        # prediction per (peptide, allele) row: binding affinity,
+        # presentation, antigen processing.  Explode into one row per
+        # (peptide, allele, kind), skipping kinds whose columns aren't
+        # populated.  The cache keys on the 4-tuple so all kinds
+        # coexist cleanly.
+        df = _explode_mhcflurry_kinds(df)
         if predictor_version is None:
             predictor_version = mhcflurry_composite_version()
         return cls.from_dataframe(
@@ -619,31 +668,33 @@ class CachedPredictor:
         cls,
         path,
         *,
-        mode: str = "binding_affinity",
         predictor_version: Optional[str] = None,
         fallback=None,
         also_accept_versions: Optional[Iterable[str]] = None,
     ) -> "CachedPredictor":
         """Load a NetMHCpan stdout capture (2.8 / 3 / 4 / 4.1).
 
-        Uses ``mhctools.parsing.parse_netmhcpan_stdout`` which auto-
-        detects the version.  ``mode`` picks between
-        ``"binding_affinity"`` (default) and ``"elution_score"`` for
-        NetMHCpan 4+; ignored on earlier versions.  When
-        ``predictor_version`` is omitted, the version string is
+        Uses ``mhctools.parsing.parse_netmhcpan_to_preds`` which auto-
+        detects the version and returns **every kind** present in the
+        output — a ``-BA`` run carries both binding-affinity and
+        elution-score rows per (peptide, allele), and both land in the
+        cache as separate ``pMHC_affinity`` + ``pMHC_presentation``
+        rows.
+
+        When ``predictor_version`` is omitted, the version string is
         parsed from the stdout preamble (e.g. ``"4.1b"``).
         """
-        from mhctools.parsing import parse_netmhcpan_stdout
+        from mhctools.parsing import parse_netmhcpan_to_preds
         text = _read_text(path)
-        preds = parse_netmhcpan_stdout(text, mode=mode)
         if predictor_version is None:
             predictor_version = _version_from_header(text) or "unknown"
-        kind = (
-            "pMHC_presentation" if mode == "elution_score"
-            else "pMHC_affinity"
+        preds = parse_netmhcpan_to_preds(
+            text,
+            predictor_name="netmhcpan",
+            predictor_version=predictor_version,
         )
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds, kind=kind),
+            _predictions_to_dataframe(preds),
             prediction_method_name="netmhcpan",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -806,7 +857,7 @@ class CachedPredictor:
         combined = pd.concat(
             [c._df for c in caches], ignore_index=True,
         )
-        key_cols = ["peptide", "allele", "peptide_length"]
+        key_cols = list(_KEY_COLS)
 
         dup_mask = combined.duplicated(subset=key_cols, keep=False)
         if dup_mask.any():
@@ -829,7 +880,7 @@ class CachedPredictor:
                 f" (and {len(dupes) - 5} more)"
             raise ValueError(
                 f"CachedPredictor.concat: {len(dupes)} overlapping "
-                f"(peptide, allele, peptide_length) key(s) across "
+                f"(peptide, allele, peptide_length, kind) key(s) across "
                 f"shards.  Sample: {sample}{extra}.  Pass "
                 f"on_overlap='last' / 'first' / callable to resolve."
             )
@@ -934,11 +985,9 @@ def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:
     mhctools attribute name) → ``peptide_length``.
 
     ``kind`` is required and stamped on every row — DSL expressions
-    like ``Affinity.value <= 500`` filter on the ``kind`` column to
-    disambiguate affinity / presentation / stability / processing
-    rows, and mhctools' ``BindingPrediction`` objects don't carry
-    ``kind`` as an attribute.  The caller (one of the ``from_*``
-    classmethods) knows the right value based on tool + mode.
+    like ``Affinity.value <= 500`` filter on the ``kind`` column, and
+    mhctools' ``BindingPrediction`` objects don't carry ``kind`` as
+    an attribute.  The caller knows the right value based on the tool.
     """
     rows = [
         {
@@ -950,9 +999,37 @@ def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:
             "affinity": p.affinity,
             "percentile_rank": p.percentile_rank,
             "value": getattr(p, "value", None),
-            # prediction_method_name is set per-loader by from_dataframe's
-            # backfill from the classmethod's caller.  Left unset here so
-            # the classmethod's explicit value wins.
+            "source_sequence_name": getattr(p, "source_sequence_name", None),
+            "peptide_offset": getattr(p, "offset", None),
+        }
+        for p in preds
+    ]
+    return pd.DataFrame(rows)
+
+
+def _predictions_to_dataframe(preds) -> pd.DataFrame:
+    """Convert an mhctools ``list[Prediction]`` (multi-kind) into a
+    DataFrame shaped for :class:`CachedPredictor`.
+
+    Unlike ``BindingPrediction``, ``Prediction`` exposes ``.kind``
+    directly, so callers don't supply it — a NetMHCpan ``-BA`` run
+    naturally produces affinity + presentation rows interleaved.
+    ``n_flank`` / ``c_flank`` are carried through when present.
+    """
+    rows = [
+        {
+            "peptide": p.peptide,
+            "allele": p.allele,
+            "peptide_length": len(p.peptide),
+            "kind": str(p.kind),
+            "score": p.score,
+            "affinity": getattr(p, "value", None) if p.kind == "pMHC_affinity" else None,
+            "percentile_rank": p.percentile_rank,
+            "value": p.value,
+            "source_sequence_name": getattr(p, "source_sequence_name", None),
+            "peptide_offset": getattr(p, "offset", None),
+            "n_flank": getattr(p, "n_flank", None),
+            "c_flank": getattr(p, "c_flank", None),
         }
         for p in preds
     ]
@@ -978,6 +1055,93 @@ def _version_from_header(text: str) -> Optional[str]:
     before it can stretch to several KB when verbose flags are set."""
     m = _NETMHC_VERSION_RE.search(text[:10000])
     return m.group(1) if m else None
+
+
+def _explode_mhcflurry_kinds(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert wide-format mhcflurry output into one row per
+    ``(peptide, allele, kind)``.
+
+    mhcflurry's class1_presentation pipeline emits up to three kinds
+    in a single CSV row:
+
+    - ``pMHC_affinity``: ``mhcflurry_affinity`` (nM) +
+      ``mhcflurry_affinity_percentile``
+    - ``pMHC_presentation``: ``mhcflurry_presentation_score`` +
+      ``mhcflurry_presentation_percentile``
+    - ``antigen_processing``: ``mhcflurry_processing_score``
+
+    Rows whose columns for a given kind are all NaN are skipped — so
+    an affinity-only CSV (no presentation columns) produces only the
+    ``pMHC_affinity`` rows, and vice versa.
+    """
+    # (kind, affinity_col, rank_col, score_col) — None = N/A for that kind.
+    kind_specs = [
+        ("pMHC_affinity",
+         "mhcflurry_affinity",
+         "mhcflurry_affinity_percentile",
+         None),
+        ("pMHC_presentation",
+         None,
+         "mhcflurry_presentation_percentile",
+         "mhcflurry_presentation_score"),
+        ("antigen_processing",
+         None,
+         None,
+         "mhcflurry_processing_score"),
+    ]
+    # Provenance / context columns that round-trip with every kind.
+    # mhcflurry's predict output emits n_flank / c_flank when the
+    # processing model is active; source_sequence_name + offset when
+    # called via predict-scan on full proteins; sample_name for
+    # multi-sample CSVs.  'offset' is renamed to 'peptide_offset' to
+    # match topiary's canonical column naming.
+    base_col_aliases = {
+        "peptide": "peptide",
+        "allele": "allele",
+        "peptide_length": "peptide_length",
+        "source_sequence_name": "source_sequence_name",
+        "offset": "peptide_offset",
+        "peptide_offset": "peptide_offset",
+        "n_flank": "n_flank",
+        "c_flank": "c_flank",
+        "sample_name": "sample_name",
+    }
+
+    rows = []
+    for _, r in df.iterrows():
+        base = {
+            target: r[source]
+            for source, target in base_col_aliases.items()
+            if source in df.columns
+        }
+        for kind, aff_col, rank_col, score_col in kind_specs:
+            cols = [c for c in (aff_col, rank_col, score_col)
+                    if c and c in df.columns]
+            if not cols or all(pd.isna(r[c]) for c in cols):
+                continue
+            row = dict(base)
+            row["kind"] = kind
+            row["affinity"] = (
+                r[aff_col] if aff_col and aff_col in df.columns else None
+            )
+            row["percentile_rank"] = (
+                r[rank_col] if rank_col and rank_col in df.columns else None
+            )
+            row["score"] = (
+                r[score_col]
+                if score_col and score_col in df.columns else None
+            )
+            # 'value' is the kind's primary metric: nM for affinity,
+            # score for presentation/processing.
+            row["value"] = (
+                row["affinity"] if kind == "pMHC_affinity"
+                else row["score"]
+            )
+            rows.append(row)
+
+    if not rows:
+        return df.head(0)
+    return pd.DataFrame(rows)
 
 
 def mhcflurry_composite_version() -> str:

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -57,10 +57,22 @@ _CACHE_COLUMNS = (
     "n_flank", "c_flank", "sample_name",
 )
 
-# Composite key for the cache index — distinguishes rows that share
-# (peptide, allele, length) but differ on kind (mhcflurry affinity +
-# presentation + processing, NetMHCpan -BA's affinity + elution, etc.).
-_KEY_COLS = ("peptide", "allele", "peptide_length", "kind")
+# Composite key for the cache index.
+#
+# - (peptide, allele, peptide_length): basic identity.
+# - kind: distinguishes affinity / presentation / processing / stability
+#   — needed because mhcflurry's class1_presentation pipeline and
+#   NetMHCpan's -BA flag emit multiple kinds per (peptide, allele).
+# - n_flank, c_flank: some predictors (mhcflurry's antigen_processing,
+#   mhcflurry's pMHC_presentation) take flanking residues as input, so
+#   the same peptide at two different protein contexts produces
+#   different scores.  Absent flanks (None) coexist cleanly with
+#   populated flanks — predictors that don't use flanks just produce
+#   a single (None, None) entry per (peptide, allele, kind).
+_KEY_COLS = (
+    "peptide", "allele", "peptide_length", "kind",
+    "n_flank", "c_flank",
+)
 
 
 class CachedPredictor:
@@ -174,6 +186,12 @@ class CachedPredictor:
             )
         keep = [c for c in _CACHE_COLUMNS if c in df.columns]
         out = df[keep].copy()
+        # n_flank / c_flank are part of the composite key — backfill
+        # with None when the source file doesn't provide them so every
+        # row has a well-defined key shape.
+        for flank_col in ("n_flank", "c_flank"):
+            if flank_col not in out.columns:
+                out[flank_col] = None
         out["peptide"] = out["peptide"].astype(str)
         out["allele"] = out["allele"].astype(str)
         out["peptide_length"] = out["peptide_length"].astype(int)
@@ -209,16 +227,20 @@ class CachedPredictor:
 
     @staticmethod
     def _build_index(df: pd.DataFrame) -> dict:
-        """Build ``(peptide, allele, peptide_length, kind) → row_dict``
-        index.  The four-way key is what lets a single cache hold
-        affinity + presentation + processing rows for the same
-        ``(peptide, allele)`` — a three-tuple key would collide."""
+        """Build ``(peptide, allele, peptide_length, kind, n_flank,
+        c_flank) → row_dict`` index.  The full key lets a single cache
+        hold multiple kinds per (peptide, allele) — and, within a kind
+        that depends on flanking context (mhcflurry processing and
+        presentation), distinguish the same peptide at different
+        source-protein positions."""
         return {
             (
                 str(r["peptide"]),
                 str(r["allele"]),
                 int(r["peptide_length"]),
                 str(r["kind"]),
+                _flank_key(r.get("n_flank")),
+                _flank_key(r.get("c_flank")),
             ): r.to_dict()
             for _, r in df.iterrows()
         }
@@ -275,34 +297,39 @@ class CachedPredictor:
         for peptide in peptides:
             length = len(peptide)
             for allele in query_alleles:
-                # At least one kind must be present for this (pep, allele).
-                if not any(
-                    (peptide, allele, length, k) in self._index
-                    for k in cache_kinds
-                ):
+                # At least one cached row must exist at (pep, allele,
+                # length) across any kind / flank combo.
+                if not self._lookup_by_prefix(peptide, allele, length):
                     missed_peptides.add(peptide)
                     break
 
         # Resolve misses through fallback (populates self._index in place).
         if missed_peptides:
             self._fallback_resolve(sorted(missed_peptides))
-            # Refresh kinds — fallback may have added new kinds.
-            cache_kinds = self._cache_kinds()
 
-        # Assemble output — one row per (peptide, allele, kind) that
-        # exists in the cache.
+        # Assemble output — every cache row matching (peptide, allele)
+        # across every kind + flank combo.  Single-kind / single-flank
+        # caches return one row per (peptide, allele); multi-kind
+        # (mhcflurry -BA, class1_presentation) or multi-flank (same
+        # peptide across protein contexts) return multiple rows.
         rows = []
         for peptide in peptides:
             length = len(peptide)
             for allele in query_alleles:
-                for kind in cache_kinds:
-                    row = self._index.get((peptide, allele, length, kind))
-                    if row is not None:
-                        rows.append(row)
+                rows.extend(self._lookup_by_prefix(peptide, allele, length))
 
         if not rows:
             return pd.DataFrame(columns=list(_CACHE_COLUMNS))
         return pd.DataFrame(rows).reindex(columns=list(_CACHE_COLUMNS))
+
+    def _lookup_by_prefix(self, peptide, allele, length):
+        """Return every cached row matching ``(peptide, allele,
+        peptide_length)`` — all kinds and flank contexts."""
+        prefix = (str(peptide), str(allele), int(length))
+        return [
+            row for key, row in self._index.items()
+            if key[:3] == prefix
+        ]
 
     def _cache_kinds(self):
         """Distinct kinds present in the cache."""
@@ -398,25 +425,22 @@ class CachedPredictor:
         # P present for allele A, missing for allele B) would see its
         # (P, A) row silently overwritten by the fallback's output
         # when (P, B) triggers a fallback call.  Preserve user intent.
-        def _is_new(row):
-            key = (
+        def _row_key(row):
+            return (
                 str(row["peptide"]),
                 str(row["allele"]),
                 int(row["peptide_length"]),
                 str(row["kind"]),
+                _flank_key(row.get("n_flank")),
+                _flank_key(row.get("c_flank")),
             )
-            return key not in self._index
 
-        novel_mask = new_rows.apply(_is_new, axis=1)
+        novel_mask = new_rows.apply(
+            lambda r: _row_key(r) not in self._index, axis=1,
+        )
         novel_rows = new_rows[novel_mask]
         for _, r in novel_rows.iterrows():
-            key = (
-                str(r["peptide"]),
-                str(r["allele"]),
-                int(r["peptide_length"]),
-                str(r["kind"]),
-            )
-            self._index[key] = r.to_dict()
+            self._index[_row_key(r)] = r.to_dict()
 
         if len(novel_rows) == 0:
             return
@@ -891,7 +915,12 @@ class CachedPredictor:
         if callable(on_overlap):
             singletons = df[~dup_mask]
             resolved = []
-            for _, group in df[dup_mask].groupby(key_cols, sort=False):
+            # dropna=False: keep groups where a key column is None/NaN
+            # (flank columns are None for predictors that don't supply
+            # them; default groupby would drop those groups entirely).
+            for _, group in df[dup_mask].groupby(
+                key_cols, sort=False, dropna=False,
+            ):
                 rows = [r.to_dict() for _, r in group.iterrows()]
                 merged = rows[0]
                 for nxt in rows[1:]:
@@ -977,6 +1006,27 @@ class CachedPredictor:
 def _read_text(path) -> str:
     with open(path, "r") as f:
         return f.read()
+
+
+def _flank_key(value):
+    """Normalize a flank column value into something hashable + stable
+    across NaN / None / empty-string representations.
+
+    Returns ``None`` for any missing / NaN / empty value, else the
+    uppercased string.  Ensures a row whose ``n_flank`` is NaN and a
+    row whose ``n_flank`` is ``None`` hash to the same key (they
+    represent the same absence-of-flank)."""
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    s = str(value).strip()
+    if not s or s.lower() == "nan":
+        return None
+    return s.upper()
 
 
 def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -930,8 +930,12 @@ _NETMHC_VERSION_RE = re.compile(
 
 def _version_from_header(text: str) -> Optional[str]:
     """Parse a NetMHC-family version string (e.g. ``"4.1b"``) from
-    the stdout preamble.  Returns ``None`` if no version line found."""
-    m = _NETMHC_VERSION_RE.search(text[:2000])
+    the stdout preamble.  Returns ``None`` if no version line found.
+
+    Searches the first 10kB of the text; NetMHC tools put the version
+    line within the first ~100 lines but the argument-dump preamble
+    before it can stretch to several KB when verbose flags are set."""
+    m = _NETMHC_VERSION_RE.search(text[:10000])
     return m.group(1) if m else None
 
 

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -573,6 +573,15 @@ class CachedPredictor:
         if "mhcflurry_presentation_score" in df.columns:
             col_map["mhcflurry_presentation_score"] = "score"
         df = df.rename(columns=col_map)
+        # Prefer presentation as the kind when mhcflurry's presentation
+        # column is present (the full pipeline), else fall back to
+        # affinity-only output.
+        if "kind" not in df.columns:
+            df["kind"] = (
+                "pMHC_presentation"
+                if "score" in df.columns
+                else "pMHC_affinity"
+            )
         if predictor_version is None:
             predictor_version = mhcflurry_composite_version()
         return cls.from_dataframe(
@@ -613,8 +622,12 @@ class CachedPredictor:
         preds = parse_netmhcpan_stdout(text, mode=mode)
         if predictor_version is None:
             predictor_version = _version_from_header(text) or "unknown"
+        kind = (
+            "pMHC_presentation" if mode == "elution_score"
+            else "pMHC_affinity"
+        )
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds),
+            _bindings_to_dataframe(preds, kind=kind),
             prediction_method_name="netmhcpan",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -651,7 +664,7 @@ class CachedPredictor:
         if predictor_version is None:
             predictor_version = _version_from_header(text) or version
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds),
+            _bindings_to_dataframe(preds, kind="pMHC_affinity"),
             prediction_method_name="netmhc",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -675,7 +688,7 @@ class CachedPredictor:
         if predictor_version is None:
             predictor_version = _version_from_header(text) or "unknown"
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds),
+            _bindings_to_dataframe(preds, kind="pMHC_affinity"),
             prediction_method_name="netmhccons",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -720,8 +733,12 @@ class CachedPredictor:
             preds = parser(text, mode=mode)
         if predictor_version is None:
             predictor_version = _version_from_header(text) or version
+        kind = (
+            "pMHC_presentation" if mode == "elution_score"
+            else "pMHC_affinity"
+        )
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds),
+            _bindings_to_dataframe(preds, kind=kind),
             prediction_method_name="netmhciipan",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -877,7 +894,7 @@ class CachedPredictor:
         if predictor_version is None:
             predictor_version = _version_from_header(text) or "unknown"
         return cls.from_dataframe(
-            _bindings_to_dataframe(preds),
+            _bindings_to_dataframe(preds, kind="pMHC_stability"),
             prediction_method_name="netmhcstabpan",
             predictor_version=predictor_version,
             fallback=fallback,
@@ -895,16 +912,24 @@ def _read_text(path) -> str:
         return f.read()
 
 
-def _bindings_to_dataframe(preds) -> pd.DataFrame:
+def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:
     """Convert an mhctools ``list[BindingPrediction]`` into a DataFrame
     shaped for :class:`CachedPredictor`.  Uses ``length`` (the
     mhctools attribute name) → ``peptide_length``.
+
+    ``kind`` is required and stamped on every row — DSL expressions
+    like ``Affinity.value <= 500`` filter on the ``kind`` column to
+    disambiguate affinity / presentation / stability / processing
+    rows, and mhctools' ``BindingPrediction`` objects don't carry
+    ``kind`` as an attribute.  The caller (one of the ``from_*``
+    classmethods) knows the right value based on tool + mode.
     """
     rows = [
         {
             "peptide": p.peptide,
             "allele": p.allele,
             "peptide_length": p.length,
+            "kind": kind,
             "score": p.score,
             "affinity": p.affinity,
             "percentile_rank": p.percentile_rank,

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -584,9 +584,14 @@ class CachedPredictor:
         if "mhcflurry_presentation_score" in df.columns:
             col_map["mhcflurry_presentation_score"] = "score"
         df = df.rename(columns=col_map)
-        # Prefer presentation as the kind when mhcflurry's presentation
-        # column is present (the full pipeline), else fall back to
-        # affinity-only output.
+        # TODO(multi-kind): mhcflurry's full class1_presentation pipeline
+        # emits affinity + presentation + processing per (peptide,
+        # allele) row.  CachedPredictor today keys on (peptide, allele,
+        # peptide_length) — storing multiple kinds for the same key
+        # would collapse to the last one written.  For now, pick the
+        # richer of the two signals present ("pMHC_presentation" when
+        # the presentation column exists, else "pMHC_affinity").
+        # Multi-kind caches tracked as a follow-up issue.
         if "kind" not in df.columns:
             df["kind"] = (
                 "pMHC_presentation"

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -20,6 +20,11 @@ import pandas as pd
 from mhctools.cli import add_mhc_args, predictors_from_args
 from varcode.cli import add_variant_args, variant_collection_from_args
 
+from .cached_predictor import (
+    add_cached_predictor_args,
+    cached_predictor_from_args,
+    cached_predictor_in_use,
+)
 from .filtering import add_filter_args
 from .rna import (
     add_expression_args,
@@ -206,6 +211,17 @@ def create_arg_parser(
         add_rna_args(arg_parser)
     if mhc:
         add_mhc_args(arg_parser)
+        add_cached_predictor_args(arg_parser)
+        # mhctools' add_mhc_args registers --mhc-predictor / --mhc-alleles
+        # as required.  Relax them so users can run exclusively from a
+        # --mhc-cache-file / --mhc-cache-directory; predict_epitopes_from_args
+        # validates that at least one MHC source is supplied.
+        for action in arg_parser._actions:
+            if action.option_strings and any(
+                opt in ("--mhc-predictor", "--mhc-alleles")
+                for opt in action.option_strings
+            ):
+                action.required = False
     if variants:
         add_variant_args(arg_parser)
     if protein_changes:
@@ -505,12 +521,21 @@ def predict_epitopes_from_args(args):
     args : argparse.Namespace
         Parsed commandline arguments for Topiary
     """
-    model_instances = predictors_from_args(args)
+    if cached_predictor_in_use(args):
+        models = cached_predictor_from_args(args)
+    else:
+        if not getattr(args, "mhc_predictor", None):
+            raise ValueError(
+                "Must supply either --mhc-predictor (live predictor) or "
+                "--mhc-cache-file / --mhc-cache-directory (cached "
+                "predictions).  Both are missing."
+            )
+        models = predictors_from_args(args)
 
     filter_by, sort_by, sort_direction = _build_filter_and_sort(args)
 
     predictor = TopiaryPredictor(
-        models=model_instances,
+        models=models,
         padding_around_mutation=args.padding_around_mutation,
         filter_by=filter_by,
         sort_by=sort_by,

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -216,6 +216,12 @@ def create_arg_parser(
         # as required.  Relax them so users can run exclusively from a
         # --mhc-cache-file / --mhc-cache-directory; predict_epitopes_from_args
         # validates that at least one MHC source is supplied.
+        #
+        # Accessing _actions here is intentional — it's argparse's de-facto
+        # public API for mutating registered arguments post-registration.
+        # If mhctools ever changes its add_mhc_args action layout this loop
+        # will still work (it only looks at option_strings), and worst-case
+        # would fall back to mhctools' original required=True behavior.
         for action in arg_parser._actions:
             if action.option_strings and any(
                 opt in ("--mhc-predictor", "--mhc-alleles")

--- a/topiary/cli/cached_predictor.py
+++ b/topiary/cli/cached_predictor.py
@@ -121,11 +121,26 @@ def add_cached_predictor_args(arg_parser):
         help="Column separator for 'tsv' format.  Default is tab.",
     )
     group.add_argument(
+        "--mhc-cache-tsv-kind",
+        default="pMHC_affinity",
+        choices=(
+            "pMHC_affinity", "pMHC_presentation",
+            "pMHC_stability", "antigen_processing",
+        ),
+        help=(
+            "Kind stamp for 'tsv' format rows (only used when the "
+            "file itself has no 'kind' column).  The DSL's "
+            "Affinity / Presentation / Stability / Processing scopes "
+            "dispatch on this; a wrong value silently filters "
+            "downstream.  Default: pMHC_affinity."
+        ),
+    )
+    group.add_argument(
         "--mhc-cache-netmhcpan-mode",
         default="binding_affinity",
         choices=("binding_affinity", "elution_score"),
         help=(
-            "Mode for 'netmhcpan_stdout' format on NetMHCpan 4+ output.  "
+            "Mode for 'netmhcpan' format on NetMHCpan 4+ output.  "
             "Default: binding_affinity."
         ),
     )
@@ -134,7 +149,7 @@ def add_cached_predictor_args(arg_parser):
         default="4",
         choices=("3", "4", "4.1"),
         help=(
-            "NetMHC classic version for 'netmhc_stdout' format.  "
+            "NetMHC classic version for 'netmhc' format.  "
             "Default: 4."
         ),
     )
@@ -143,7 +158,7 @@ def add_cached_predictor_args(arg_parser):
         default="4.3",
         choices=("legacy", "4", "4.3"),
         help=(
-            "NetMHCIIpan version for 'netmhciipan_stdout' format.  "
+            "NetMHCIIpan version for 'netmhciipan' format.  "
             "Default: 4.3."
         ),
     )
@@ -152,7 +167,7 @@ def add_cached_predictor_args(arg_parser):
         default="elution_score",
         choices=("binding_affinity", "elution_score"),
         help=(
-            "Mode for 'netmhciipan_stdout' format on NetMHCIIpan 4+ "
+            "Mode for 'netmhciipan' format on NetMHCIIpan 4+ "
             "output.  Default: elution_score."
         ),
     )
@@ -213,6 +228,7 @@ def cached_predictor_from_args(args) -> CachedPredictor:
             sep=args.mhc_cache_tsv_sep,
             prediction_method_name=args.mhc_cache_predictor_name,
             predictor_version=args.mhc_cache_predictor_version,
+            kind=args.mhc_cache_tsv_kind,
         )
 
     if fmt == "netmhcpan":

--- a/topiary/cli/cached_predictor.py
+++ b/topiary/cli/cached_predictor.py
@@ -120,30 +120,12 @@ def add_cached_predictor_args(arg_parser):
         default="\t",
         help="Column separator for 'tsv' format.  Default is tab.",
     )
-    group.add_argument(
-        "--mhc-cache-tsv-kind",
-        default="pMHC_affinity",
-        choices=(
-            "pMHC_affinity", "pMHC_presentation",
-            "pMHC_stability", "antigen_processing",
-        ),
-        help=(
-            "Kind stamp for 'tsv' format rows (only used when the "
-            "file itself has no 'kind' column).  The DSL's "
-            "Affinity / Presentation / Stability / Processing scopes "
-            "dispatch on this; a wrong value silently filters "
-            "downstream.  Default: pMHC_affinity."
-        ),
-    )
-    group.add_argument(
-        "--mhc-cache-netmhcpan-mode",
-        default="binding_affinity",
-        choices=("binding_affinity", "elution_score"),
-        help=(
-            "Mode for 'netmhcpan' format on NetMHCpan 4+ output.  "
-            "Default: binding_affinity."
-        ),
-    )
+    # Generic TSV files must carry a 'kind' column per row (one of
+    # pMHC_affinity / pMHC_presentation / pMHC_stability /
+    # antigen_processing).  The loader reads it directly; no CLI
+    # knob needed.  The DSL's Affinity.* / Presentation.* / etc.
+    # scopes dispatch on kind, so getting it right in the source TSV
+    # is load-bearing.
     group.add_argument(
         "--mhc-cache-netmhc-version",
         default="4",
@@ -228,13 +210,11 @@ def cached_predictor_from_args(args) -> CachedPredictor:
             sep=args.mhc_cache_tsv_sep,
             prediction_method_name=args.mhc_cache_predictor_name,
             predictor_version=args.mhc_cache_predictor_version,
-            kind=args.mhc_cache_tsv_kind,
         )
 
     if fmt == "netmhcpan":
         return CachedPredictor.from_netmhcpan_stdout(
             cache_file,
-            mode=args.mhc_cache_netmhcpan_mode,
             predictor_version=args.mhc_cache_predictor_version,
         )
 

--- a/topiary/cli/cached_predictor.py
+++ b/topiary/cli/cached_predictor.py
@@ -1,0 +1,257 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Commandline arguments for :class:`~topiary.CachedPredictor`.
+
+Adds a group of ``--mhc-cache-*`` flags so users can run topiary from
+pre-computed prediction files without invoking a live MHC predictor:
+
+    topiary --mhc-cache-file predictions.csv --mhc-cache-format mhcflurry \\
+        --peptide-csv input.csv --output-csv results.csv
+
+Supported formats mirror :class:`CachedPredictor`'s ``from_*`` loaders.
+"""
+
+from ..cached import CachedPredictor
+
+
+_CACHE_FORMATS = (
+    "topiary_output",
+    "mhcflurry",
+    "tsv",
+    "netmhcpan_stdout",
+    "netmhc_stdout",
+    "netmhcpan_cons_stdout",
+    "netmhciipan_stdout",
+    "netmhcstabpan_stdout",
+)
+
+
+def add_cached_predictor_args(arg_parser):
+    group = arg_parser.add_argument_group(
+        title="Cached Predictions",
+        description=(
+            "Run topiary from a pre-computed prediction file instead of "
+            "invoking a live MHC predictor.  Mutually exclusive with "
+            "--mhc-predictor (the cache supplies predictions)."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-file",
+        default=None,
+        help=(
+            "Path to a pre-computed prediction file.  Requires "
+            "--mhc-cache-format.  Alternative to --mhc-cache-directory."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-directory",
+        default=None,
+        help=(
+            "Load every matching file in a directory as shards and merge "
+            "them.  Use --mhc-cache-directory-pattern to restrict the "
+            "glob (defaults to '*').  Uses the topiary_output format for "
+            "every matched file — all shards must share the same "
+            "(predictor_name, predictor_version)."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-directory-pattern",
+        default="*",
+        help="Glob pattern for --mhc-cache-directory.  Default: *.",
+    )
+    group.add_argument(
+        "--mhc-cache-format",
+        choices=_CACHE_FORMATS,
+        default=None,
+        help=(
+            "Format of --mhc-cache-file.  Required when --mhc-cache-file "
+            "is set."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-predictor-name",
+        default=None,
+        help=(
+            "Override the prediction_method_name column value.  Required "
+            "for 'tsv' format when the file doesn't carry this column."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-predictor-version",
+        default=None,
+        help=(
+            "Override the predictor_version column value.  Required for "
+            "'tsv' format when the file doesn't carry this column; "
+            "optional for the NetMHC-family formats (auto-parsed from "
+            "the stdout preamble when omitted) and for 'mhcflurry' "
+            "(auto-composed from the local install via "
+            "topiary.mhcflurry_composite_version() when omitted)."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-tsv-column",
+        action="append",
+        default=[],
+        metavar="CANONICAL=FILE_COLUMN",
+        help=(
+            "Column-name mapping for 'tsv' format.  Repeatable.  Example: "
+            "--mhc-cache-tsv-column affinity=IC50 "
+            "--mhc-cache-tsv-column percentile_rank=Rank"
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-tsv-sep",
+        default="\t",
+        help="Column separator for 'tsv' format.  Default is tab.",
+    )
+    group.add_argument(
+        "--mhc-cache-netmhcpan-mode",
+        default="binding_affinity",
+        choices=("binding_affinity", "elution_score"),
+        help=(
+            "Mode for 'netmhcpan_stdout' format on NetMHCpan 4+ output.  "
+            "Default: binding_affinity."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-netmhc-version",
+        default="4",
+        choices=("3", "4", "4.1"),
+        help=(
+            "NetMHC classic version for 'netmhc_stdout' format.  "
+            "Default: 4."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-netmhciipan-version",
+        default="4.3",
+        choices=("legacy", "4", "4.3"),
+        help=(
+            "NetMHCIIpan version for 'netmhciipan_stdout' format.  "
+            "Default: 4.3."
+        ),
+    )
+    group.add_argument(
+        "--mhc-cache-netmhciipan-mode",
+        default="elution_score",
+        choices=("binding_affinity", "elution_score"),
+        help=(
+            "Mode for 'netmhciipan_stdout' format on NetMHCIIpan 4+ "
+            "output.  Default: elution_score."
+        ),
+    )
+
+
+def cached_predictor_in_use(args) -> bool:
+    """True when the caller has asked for cached predictions (file or dir)."""
+    return bool(
+        getattr(args, "mhc_cache_file", None)
+        or getattr(args, "mhc_cache_directory", None)
+    )
+
+
+def cached_predictor_from_args(args) -> CachedPredictor:
+    """Construct a CachedPredictor from the parsed CLI args.
+
+    Assumes :func:`cached_predictor_in_use` returned True.  Raises
+    ``ValueError`` with an actionable message on any missing required
+    flag for the chosen format.
+    """
+    cache_dir = getattr(args, "mhc_cache_directory", None)
+    cache_file = getattr(args, "mhc_cache_file", None)
+
+    if cache_file and cache_dir:
+        raise ValueError(
+            "--mhc-cache-file and --mhc-cache-directory are mutually "
+            "exclusive.  Pick one."
+        )
+
+    if cache_dir is not None:
+        pattern = getattr(args, "mhc_cache_directory_pattern", None) or "*"
+        return CachedPredictor.from_directory(cache_dir, pattern=pattern)
+
+    fmt = getattr(args, "mhc_cache_format", None)
+    if not fmt:
+        raise ValueError(
+            "--mhc-cache-file requires --mhc-cache-format to be set "
+            f"(choose one of {list(_CACHE_FORMATS)})."
+        )
+
+    if fmt == "topiary_output":
+        return CachedPredictor.from_topiary_output(cache_file)
+
+    if fmt == "mhcflurry":
+        return CachedPredictor.from_mhcflurry(
+            cache_file,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "tsv":
+        columns = _parse_tsv_columns(args.mhc_cache_tsv_column)
+        return CachedPredictor.from_tsv(
+            cache_file,
+            columns=columns,
+            sep=args.mhc_cache_tsv_sep,
+            prediction_method_name=args.mhc_cache_predictor_name,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "netmhcpan_stdout":
+        return CachedPredictor.from_netmhcpan_stdout(
+            cache_file,
+            mode=args.mhc_cache_netmhcpan_mode,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "netmhc_stdout":
+        return CachedPredictor.from_netmhc_stdout(
+            cache_file,
+            version=args.mhc_cache_netmhc_version,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "netmhcpan_cons_stdout":
+        return CachedPredictor.from_netmhcpan_cons_stdout(
+            cache_file,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "netmhciipan_stdout":
+        return CachedPredictor.from_netmhciipan_stdout(
+            cache_file,
+            version=args.mhc_cache_netmhciipan_version,
+            mode=args.mhc_cache_netmhciipan_mode,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    if fmt == "netmhcstabpan_stdout":
+        return CachedPredictor.from_netmhcstabpan_stdout(
+            cache_file,
+            predictor_version=args.mhc_cache_predictor_version,
+        )
+
+    raise ValueError(f"Unknown --mhc-cache-format: {fmt!r}")
+
+
+def _parse_tsv_columns(column_args):
+    """Parse list of ``canonical=file_col`` strings into a mapping dict."""
+    out = {}
+    for entry in column_args:
+        if "=" not in entry:
+            raise ValueError(
+                f"--mhc-cache-tsv-column expects KEY=VALUE; got {entry!r}."
+            )
+        k, v = entry.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out

--- a/topiary/cli/cached_predictor.py
+++ b/topiary/cli/cached_predictor.py
@@ -29,11 +29,11 @@ _CACHE_FORMATS = (
     "topiary_output",
     "mhcflurry",
     "tsv",
-    "netmhcpan_stdout",
-    "netmhc_stdout",
-    "netmhcpan_cons_stdout",
-    "netmhciipan_stdout",
-    "netmhcstabpan_stdout",
+    "netmhcpan",
+    "netmhc",
+    "netmhccons",
+    "netmhciipan",
+    "netmhcstabpan",
 )
 
 
@@ -75,8 +75,13 @@ def add_cached_predictor_args(arg_parser):
         choices=_CACHE_FORMATS,
         default=None,
         help=(
-            "Format of --mhc-cache-file.  Required when --mhc-cache-file "
-            "is set."
+            "Format of --mhc-cache-file.  Optional: topiary sniffs the "
+            "format from the file's content when omitted — NetMHC-family "
+            "stdout captures carry a 'version X.Y' preamble, mhcflurry "
+            "CSVs have 'mhcflurry_*' columns, topiary's own output has "
+            "'prediction_method_name' + 'predictor_version'.  Only the "
+            "'tsv' format requires an explicit --mhc-cache-format "
+            "(generic tables can't be auto-detected)."
         ),
     )
     group.add_argument(
@@ -183,10 +188,13 @@ def cached_predictor_from_args(args) -> CachedPredictor:
 
     fmt = getattr(args, "mhc_cache_format", None)
     if not fmt:
-        raise ValueError(
-            "--mhc-cache-file requires --mhc-cache-format to be set "
-            f"(choose one of {list(_CACHE_FORMATS)})."
-        )
+        fmt = _sniff_format(cache_file)
+        if fmt is None:
+            raise ValueError(
+                f"Could not auto-detect --mhc-cache-format for "
+                f"{cache_file!r}.  Pass --mhc-cache-format explicitly "
+                f"(one of {list(_CACHE_FORMATS)})."
+            )
 
     if fmt == "topiary_output":
         return CachedPredictor.from_topiary_output(cache_file)
@@ -207,27 +215,27 @@ def cached_predictor_from_args(args) -> CachedPredictor:
             predictor_version=args.mhc_cache_predictor_version,
         )
 
-    if fmt == "netmhcpan_stdout":
+    if fmt == "netmhcpan":
         return CachedPredictor.from_netmhcpan_stdout(
             cache_file,
             mode=args.mhc_cache_netmhcpan_mode,
             predictor_version=args.mhc_cache_predictor_version,
         )
 
-    if fmt == "netmhc_stdout":
+    if fmt == "netmhc":
         return CachedPredictor.from_netmhc_stdout(
             cache_file,
             version=args.mhc_cache_netmhc_version,
             predictor_version=args.mhc_cache_predictor_version,
         )
 
-    if fmt == "netmhcpan_cons_stdout":
+    if fmt == "netmhccons":
         return CachedPredictor.from_netmhcpan_cons_stdout(
             cache_file,
             predictor_version=args.mhc_cache_predictor_version,
         )
 
-    if fmt == "netmhciipan_stdout":
+    if fmt == "netmhciipan":
         return CachedPredictor.from_netmhciipan_stdout(
             cache_file,
             version=args.mhc_cache_netmhciipan_version,
@@ -235,7 +243,7 @@ def cached_predictor_from_args(args) -> CachedPredictor:
             predictor_version=args.mhc_cache_predictor_version,
         )
 
-    if fmt == "netmhcstabpan_stdout":
+    if fmt == "netmhcstabpan":
         return CachedPredictor.from_netmhcstabpan_stdout(
             cache_file,
             predictor_version=args.mhc_cache_predictor_version,
@@ -255,3 +263,58 @@ def _parse_tsv_columns(column_args):
         k, v = entry.split("=", 1)
         out[k.strip()] = v.strip()
     return out
+
+
+def _sniff_format(path):
+    """Guess the cache format from file content.
+
+    Returns one of the strings in ``_CACHE_FORMATS`` or ``None`` when
+    detection is ambiguous (e.g. a generic TSV without identifying
+    columns).  ``"tsv"`` is never returned — generic TSVs need an
+    explicit ``--mhc-cache-format tsv``.
+
+    Detection order:
+    1. Parquet magic bytes → ``topiary_output``.
+    2. NetMHC-family ``...version ...`` preamble lines → respective
+       tool name.
+    3. ``mhcflurry_*`` columns in the first text line → ``mhcflurry``.
+    4. ``prediction_method_name`` + ``predictor_version`` columns in
+       the first text line → ``topiary_output``.
+    """
+    try:
+        with open(path, "rb") as f:
+            magic = f.read(4)
+    except OSError:
+        return None
+    if magic == b"PAR1":
+        return "topiary_output"
+
+    try:
+        with open(path, "r", errors="replace") as f:
+            head = f.read(10000)
+    except OSError:
+        return None
+
+    # NetMHC-family preamble detection.  Order matters: more specific
+    # tool names come first so e.g. "NetMHCstabpan" doesn't get
+    # mis-tagged as "NetMHC".
+    import re
+    for needle, fmt in (
+        (r"\bNetMHCstabpan\b", "netmhcstabpan"),
+        (r"\bNetMHCIIpan\b", "netmhciipan"),
+        (r"\bNetMHCcons\b", "netmhccons"),
+        (r"\bNetMHCpan\b", "netmhcpan"),
+        (r"\bNetMHC\b", "netmhc"),
+    ):
+        if re.search(needle, head):
+            return fmt
+
+    first_line = head.split("\n", 1)[0]
+    if "mhcflurry_affinity" in first_line or "mhcflurry_presentation" in first_line:
+        return "mhcflurry"
+    if (
+        "prediction_method_name" in first_line
+        and "predictor_version" in first_line
+    ):
+        return "topiary_output"
+    return None


### PR DESCRIPTION
## Summary

Three related changes on the cached-predictions story (orthogonal to PR #135 which is still in review on the SelfProteome side):

1. **CLI support** for `CachedPredictor`.  New `--mhc-cache-*` argument group lets users run topiary entirely from pre-computed prediction files without invoking a live MHC predictor.
2. **Real NetMHC-family fixtures** captured from the `netmhc-bundle` binaries for peptide `SLLQHLIGL` at `HLA-A*02:01 / A*24:02 / B*07:02` (substituted for `B*07:01` which NetMHCpan doesn't recognize).  15 new tests exercise the full parsing + CLI chain against real data.
3. **README section reorder** — "MHC prediction models" moved near the top; "Cached predictions" moved to the end.

## CLI shape

```bash
topiary --peptide-csv peptides.csv \
    --mhc-cache-file netmhcpan_run.out \
    --mhc-cache-format netmhcpan_stdout \
    --output-csv results.csv
```

Supported formats (via `--mhc-cache-format`): `topiary_output`, `mhcflurry`, `tsv`, `netmhcpan_stdout`, `netmhc_stdout`, `netmhcpan_cons_stdout`, `netmhciipan_stdout`, `netmhcstabpan_stdout`.  Plus `--mhc-cache-directory` with `--mhc-cache-directory-pattern` for sharded caches.

`--mhc-predictor` / `--mhc-alleles` become optional when a cache is supplying predictions.  Validation covers missing format, mutually-exclusive file vs directory, and no-source-at-all cases.

Full flag reference is documented in `docs/cached.md`.

## Fixtures

`tests/data/netmhc_fixtures/`:

- `netmhcpan_41_SLLQHLIGL_{A0201,A2402,B0702}.out` — NetMHCpan 4.1b stdout, single-allele per file.
- `netmhcpan_40_SLLQHLIGL_*.out` — NetMHCpan 4.0 stdout.
- `netmhc_40_SLLQHLIGL.out` — NetMHC classic 4.0 (multi-allele works).
- `netmhcstabpan_SLLQHLIGL_*.out` — NetMHCstabpan single-allele.
- Multi-allele NetMHCpan and stabpan files are also committed but don't parse today due to mhctools' per-allele-header-line bug, filed as openvax/mhctools#195.

NetMHCcons skipped — the binary calls `python2` which isn't on PATH here.

## Minor fix

`topiary/cached.py`: expanded the version-header regex search window from 2000 to 10000 chars.  NetMHCpan preambles with full argument dumps push the `# NetMHCpan version X.Yb` line past 2000 chars (real captures show it at char ~2700), which was making `predictor_version` default to `"unknown"` instead of parsing from the header.

## Test plan

- [x] 6 new `TestRealNetMHCFixtures` tests in `tests/test_cached_predictor.py` assert actual numeric predictions (e.g. SLLQHLIGL × A*02:01 = 8.82 nM, 0.105%rank) through each `from_*_stdout` loader.
- [x] 9 new tests in \`tests/test_cli_cached_predictor.py` exercise the CLI end-to-end — error paths, happy paths for netmhcpan/netmhc/netmhcstabpan/topiary-output/tsv formats, explicit version override, TSV column mapping.
- [x] `./test.sh` — 1126 passed, 3 skipped.
- [x] `./lint.sh` — clean.
- [x] `mkdocs build --strict` — clean.
- [ ] CI green.

## Related

- mhctools#195 — multi-allele NetMHCpan parser bug (root cause analyzed, fix proposed upstream).
- #128 — parent issue for the CachedPredictor work; this PR is the CLI layer and verification scaffolding.