### PR TITLE
SelfProteome: include= rename, protected_tissues, BLOSUM62, indels (part B of #124)

### DIFF
--- a/docs/self_proteome.md
+++ b/docs/self_proteome.md
@@ -10,11 +10,11 @@ This page covers the `SelfProteome` class and the `self_nearest_*`
 columns it adds to `TopiaryPredictor` output.
 
 > **Scope note.** This PR ships the **core architecture and one
-> nearest-by-sequence axis**: `scope="all"` and `scope="non_cta"`,
+> nearest-by-sequence axis**: `include="all"` and `include="non_cta"`,
 > substitutions only (no 1aa indels yet), single `self_nearest_peptide`
 > scalar. The three-axis story (sequence-nearest, binding-similar,
 > strongest-binder), 1aa indel candidates, the full candidate-set
-> structured column, and `scope="protected_tissues"` are tracked for
+> structured column, and `include="protected_tissues"` are tracked for
 > follow-up PRs under [#124](https://github.com/openvax/topiary/issues/124).
 
 ## Basic usage
@@ -24,7 +24,7 @@ from topiary import SelfProteome, TopiaryPredictor
 from mhctools import NetMHCpan
 
 ref = SelfProteome.from_ensembl(species="human", release=93)
-# Default scope="non_cta" strips CTAs via pirlygenes.
+# Default include="non_cta" strips CTAs via pirlygenes.
 
 predictor = TopiaryPredictor(
     models=NetMHCpan,
@@ -60,35 +60,35 @@ predictor = TopiaryPredictor(
 
 Three construction modes (this PR ships the first two):
 
-| `scope=` | Behavior | Configuration |
+| `include=` | Behavior | Configuration |
 |---|---|---|
 | `"all"` | Whole proteome, no filter | — |
 | `"non_cta"` (default for human Ensembl) | Remove CTA genes | `cta_source="pirlygenes"` default; `"tsarina"` reserved; set / callable accepted |
 | `"protected_tissues"` *(PR B)* | Keep only genes expressed in named tissues | `tissues=[…]`, `tissue_source="hpa"`/`"gtex"`, `min_expression=…` |
 | callable | Arbitrary `gene → bool` filter | — |
 
-**Human users** get zero-config `scope="non_cta"` via pirlygenes:
+**Human users** get zero-config `include="non_cta"` via pirlygenes:
 
 ```python
 ref = SelfProteome.from_ensembl(species="human", release=93)
 ```
 
-**Non-human users** must either use `scope="all"` or supply their own
+**Non-human users** must either use `include="all"` or supply their own
 CTA source, because pirlygenes is human-only today:
 
 ```python
-ref = SelfProteome.from_ensembl(species="mouse", release=102, scope="all")
+ref = SelfProteome.from_ensembl(species="mouse", release=102, include="all")
 
 # Or with a custom CTA list:
 ref = SelfProteome.from_ensembl(
     species="mouse",
     release=102,
-    scope="non_cta",
+    include="non_cta",
     cta_source={"ENSMUSG0001", "ENSMUSG0002", ...},
 )
 ```
 
-A non-human `scope="non_cta"` call without `cta_source=` raises at
+A non-human `include="non_cta"` call without `cta_source=` raises at
 construction — silent unfiltered results would be a misleading
 cross-reactivity signal.
 
@@ -99,8 +99,8 @@ a protein-FASTA file directly:
 
 ```python
 ref = SelfProteome.from_fasta("my_reference.fa")
-# scope="all" by default; callable scope also works.
-# scope="non_cta" isn't available here — FASTA has no gene metadata.
+# include="all" by default; callable scope also works.
+# include="non_cta" isn't available here — FASTA has no gene metadata.
 ```
 
 For test or programmatic use:

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -37,7 +37,7 @@ class TestConstruction:
             {"g": "SIINFEKLA"}, peptide_lengths=[9],
         )
         assert "ensembl-synthetic" in ref.reference_version
-        assert "scope-all" in ref.reference_version
+        assert "include-all" in ref.reference_version
 
     def test_from_peptides_short_sequence_skips_longer_lengths(self):
         # 5aa sequence — can't produce any 9-mers
@@ -278,7 +278,7 @@ class TestEnsemblHappyPath:
         # Only KEEP_GENE's 9-mers (5 of them) should be indexed.
         assert ref.n_reference_peptides == 5
         assert ref.reference_version == (
-            "ensembl-human-93+scope-non_cta+cta-sha256:"
+            "ensembl-human-93+include-non_cta+cta-sha256:"
             + __import__("hashlib").sha256(b"CTA_GENE").hexdigest()[:12]
         )
 
@@ -638,3 +638,22 @@ class TestIndels:
         row = out.iloc[0]
         # Without indels, the best same-length match is ≥2 subs away.
         assert row["self_nearest_edit_distance"] >= 2
+
+    def test_indel_beats_distant_blosum_match(self):
+        """An indel at edit_distance=1 should beat a same-length match
+        at edit_distance≥2 even when BLOSUM62 is the distance metric."""
+        # Reference has BOTH 8-mers and 9-mers.
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9],
+        )
+        # XMASIINFE: 9-mer, ≥2 subs from any 9-mer in the reference.
+        # deletion at pos 0 → MASIINFE (8-mer) IS in the reference.
+        out = ref.nearest(["XMASIINFE"], metric="blosum62")
+        row = out.iloc[0]
+        # Indel should win — edit_distance=1 beats any ≥2-sub match.
+        assert row["self_nearest_edit_distance"] == 1
+        assert row["self_nearest_edit_type"] == "deletion"
+        # BLOSUM distance is None for indel matches (different lengths
+        # can't be scored positionally).
+        assert row["self_nearest_blosum_distance"] is None

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -192,9 +192,11 @@ class TestEnsemblScopeErrors:
             "pyensembl.EnsemblRelease",
             lambda release=None, species=None: fake_release,
         )
-        with pytest.raises(NotImplementedError, match="protected_tissues"):
+        # Protected tissues now implemented — non-human without
+        # tissue_gene_ids should raise (human-only default data).
+        with pytest.raises(ValueError, match="human-only"):
             SelfProteome.from_ensembl(
-                species="human", scope="protected_tissues",
+                species="mouse", scope="protected_tissues",
             )
 
     def test_unknown_scope_string_rejects(self, monkeypatch):
@@ -384,3 +386,120 @@ class TestTopiaryPredictorIntegration:
         assert "self_nearest_peptide" in df.columns
         assert "self_nearest_edit_distance" in df.columns
         assert (df["self_nearest_edit_distance"] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# scope="protected_tissues"
+# ---------------------------------------------------------------------------
+
+
+class TestProtectedTissuesScope:
+    """Test scope="protected_tissues" — human via pirlygenes defaults
+    and non-human via explicit tissue_gene_ids."""
+
+    def test_non_human_without_tissue_gene_ids_raises(self, monkeypatch):
+        fake = MagicMock()
+        fake.protein_ids.return_value = []
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        with pytest.raises(ValueError, match="human-only"):
+            SelfProteome.from_ensembl(
+                species="mouse", scope="protected_tissues",
+            )
+
+    def test_non_human_with_explicit_gene_ids_works(self, monkeypatch):
+        """Non-human users pass tissue_gene_ids= to supply their own
+        gene set (e.g. from Tabula Muris) — bypasses pirlygenes."""
+        fake = MagicMock()
+        fake.protein_ids.return_value = ["PROT_A", "PROT_B"]
+        fake.gene_id_of_protein_id.side_effect = {
+            "PROT_A": "GENE_KEEP",
+            "PROT_B": "GENE_DROP",
+        }.get
+        fake.transcript_id_of_protein_id.side_effect = {
+            "PROT_A": "TX_KEEP",
+            "PROT_B": "TX_DROP",
+        }.get
+        fake.protein_sequence.side_effect = {
+            "PROT_A": "MASIINFEKLGGG",
+            "PROT_B": "QRSTVWYACDEFGH",
+        }.get
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        ref = SelfProteome.from_ensembl(
+            species="mouse",
+            release=102,
+            peptide_lengths=[9],
+            scope="protected_tissues",
+            tissue_gene_ids={"GENE_KEEP"},
+        )
+        # Only GENE_KEEP's proteins should survive the filter.
+        assert ref.n_reference_peptides == 5  # 5 × 9-mers from "MASIINFEKLGGG"
+        assert "protected_tissues" in ref.reference_version
+        assert "sha256:" in ref.reference_version
+
+    def test_human_default_tissues(self, monkeypatch):
+        """Human scope='protected_tissues' with default tissues uses
+        pirlygenes' tissue_expressed_gene_ids.  Mock it to avoid
+        pirlygenes data load in CI."""
+        keep_genes = {"GENE_A", "GENE_B"}
+        monkeypatch.setattr(
+            "topiary.sources.tissue_expressed_gene_ids",
+            lambda tissues, min_ntpm=1.0: keep_genes,
+        )
+        fake = MagicMock()
+        fake.protein_ids.return_value = ["P1", "P2"]
+        fake.gene_id_of_protein_id.side_effect = {
+            "P1": "GENE_A",
+            "P2": "GENE_C",
+        }.get
+        fake.transcript_id_of_protein_id.side_effect = {
+            "P1": "TX_A",
+            "P2": "TX_C",
+        }.get
+        fake.protein_sequence.side_effect = {
+            "P1": "MASIINFEKLGGG",
+            "P2": "QRSTVWYACDEFGH",
+        }.get
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        ref = SelfProteome.from_ensembl(
+            species="human",
+            scope="protected_tissues",
+            peptide_lengths=[9],
+        )
+        # Only GENE_A's proteins (GENE_C filtered out)
+        assert ref.n_reference_peptides == 5
+        assert "protected_tissues" in ref.reference_version
+        assert "heart_muscle" in ref.reference_version
+
+    def test_human_custom_tissues(self, monkeypatch):
+        """Human with explicit tissues= list (not the default)."""
+        monkeypatch.setattr(
+            "topiary.sources.tissue_expressed_gene_ids",
+            lambda tissues, min_ntpm=1.0: {"GENE_X"},
+        )
+        fake = MagicMock()
+        fake.protein_ids.return_value = ["PX"]
+        fake.gene_id_of_protein_id.side_effect = lambda pid: "GENE_X"
+        fake.transcript_id_of_protein_id.side_effect = lambda pid: "TX_X"
+        fake.protein_sequence.side_effect = lambda pid: "SIINFEKLA"
+        monkeypatch.setattr(
+            "pyensembl.EnsemblRelease",
+            lambda release=None, species=None: fake,
+        )
+        ref = SelfProteome.from_ensembl(
+            species="human",
+            scope="protected_tissues",
+            tissues=["lung", "brain"],
+            peptide_lengths=[9],
+        )
+        assert ref.n_reference_peptides == 1
+        assert "lung" in ref.reference_version
+        assert "brain" in ref.reference_version

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -71,7 +71,7 @@ class TestFastaLoader:
         path.write_text(">geneA\nSIINFEKLA\n")
         with pytest.raises(ValueError, match="FASTA"):
             SelfProteome.from_fasta(
-                path, peptide_lengths=[9], scope="non_cta",
+                path, peptide_lengths=[9], include="non_cta",
             )
 
     def test_from_fasta_accepts_callable_scope(self, tmp_path):
@@ -81,7 +81,7 @@ class TestFastaLoader:
         )
         # Keep only geneA
         ref = SelfProteome.from_fasta(
-            path, peptide_lengths=[9], scope=lambda g: g == "geneA",
+            path, peptide_lengths=[9], include=lambda g: g == "geneA",
         )
         # Only geneA 9-mers: 5 × 9
         assert ref.n_reference_peptides == 5
@@ -171,7 +171,7 @@ class TestEnsemblScopeErrors:
             lambda release=None, species=None: fake_release,
         )
         with pytest.raises(ValueError, match="no default registered"):
-            SelfProteome.from_ensembl(species="mouse", scope="non_cta")
+            SelfProteome.from_ensembl(species="mouse", include="non_cta")
 
     def test_pirlygenes_requires_human(self, monkeypatch):
         fake_release = MagicMock()
@@ -182,7 +182,7 @@ class TestEnsemblScopeErrors:
         )
         with pytest.raises(ValueError, match="human-only"):
             SelfProteome.from_ensembl(
-                species="mouse", scope="non_cta", cta_source="pirlygenes",
+                species="mouse", include="non_cta", cta_source="pirlygenes",
             )
 
     def test_protected_tissues_not_yet_implemented(self, monkeypatch):
@@ -196,7 +196,7 @@ class TestEnsemblScopeErrors:
         # tissue_gene_ids should raise (human-only default data).
         with pytest.raises(ValueError, match="human-only"):
             SelfProteome.from_ensembl(
-                species="mouse", scope="protected_tissues",
+                species="mouse", include="protected_tissues",
             )
 
     def test_unknown_scope_string_rejects(self, monkeypatch):
@@ -206,9 +206,9 @@ class TestEnsemblScopeErrors:
             "pyensembl.EnsemblRelease",
             lambda release=None, species=None: fake_release,
         )
-        with pytest.raises(ValueError, match="Unknown scope"):
+        with pytest.raises(ValueError, match="Unknown include"):
             SelfProteome.from_ensembl(
-                species="human", scope="bananas",
+                species="human", include="bananas",
             )
 
     def test_custom_cta_source_as_set(self, monkeypatch):
@@ -220,7 +220,7 @@ class TestEnsemblScopeErrors:
         )
         # Non-human + explicit CTA set should succeed.
         ref = SelfProteome.from_ensembl(
-            species="mouse", scope="non_cta",
+            species="mouse", include="non_cta",
             cta_source={"ENSMUSG0001", "ENSMUSG0002"},
         )
         assert "non_cta" in ref.reference_version
@@ -272,7 +272,7 @@ class TestEnsemblHappyPath:
             species="human",
             release=93,
             peptide_lengths=[9],
-            scope="non_cta",
+            include="non_cta",
             cta_source={"CTA_GENE"},  # filter out CTA_GENE
         )
         # Only KEEP_GENE's 9-mers (5 of them) should be indexed.
@@ -294,7 +294,7 @@ class TestEnsemblHappyPath:
             species="human",
             release=93,
             peptide_lengths=[9],
-            scope="all",
+            include="all",
         )
         # SIINFEKLG lives in KEEP_GENE at offset 2
         out = ref.nearest(["SIINFEKLG"])
@@ -389,12 +389,12 @@ class TestTopiaryPredictorIntegration:
 
 
 # ---------------------------------------------------------------------------
-# scope="protected_tissues"
+# include="protected_tissues"
 # ---------------------------------------------------------------------------
 
 
 class TestProtectedTissuesScope:
-    """Test scope="protected_tissues" — human via pirlygenes defaults
+    """Test include="protected_tissues" — human via pirlygenes defaults
     and non-human via explicit tissue_gene_ids."""
 
     def test_non_human_without_tissue_gene_ids_raises(self, monkeypatch):
@@ -406,7 +406,7 @@ class TestProtectedTissuesScope:
         )
         with pytest.raises(ValueError, match="human-only"):
             SelfProteome.from_ensembl(
-                species="mouse", scope="protected_tissues",
+                species="mouse", include="protected_tissues",
             )
 
     def test_non_human_with_explicit_gene_ids_works(self, monkeypatch):
@@ -434,7 +434,7 @@ class TestProtectedTissuesScope:
             species="mouse",
             release=102,
             peptide_lengths=[9],
-            scope="protected_tissues",
+            include="protected_tissues",
             tissue_gene_ids={"GENE_KEEP"},
         )
         # Only GENE_KEEP's proteins should survive the filter.
@@ -443,7 +443,7 @@ class TestProtectedTissuesScope:
         assert "sha256:" in ref.reference_version
 
     def test_human_default_tissues(self, monkeypatch):
-        """Human scope='protected_tissues' with default tissues uses
+        """Human include='protected_tissues' with default tissues uses
         pirlygenes' tissue_expressed_gene_ids.  Mock it to avoid
         pirlygenes data load in CI."""
         keep_genes = {"GENE_A", "GENE_B"}
@@ -471,7 +471,7 @@ class TestProtectedTissuesScope:
         )
         ref = SelfProteome.from_ensembl(
             species="human",
-            scope="protected_tissues",
+            include="protected_tissues",
             peptide_lengths=[9],
         )
         # Only GENE_A's proteins (GENE_C filtered out)
@@ -496,7 +496,7 @@ class TestProtectedTissuesScope:
         )
         ref = SelfProteome.from_ensembl(
             species="human",
-            scope="protected_tissues",
+            include="protected_tissues",
             tissues=["lung", "brain"],
             peptide_lengths=[9],
         )

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -560,3 +560,81 @@ class TestBlosum62:
         )
         with pytest.raises(ValueError, match="metric"):
             ref.nearest(["SIINFEKLA"], metric="invalid")
+
+
+# ---------------------------------------------------------------------------
+# 1aa indel candidate matching
+# ---------------------------------------------------------------------------
+
+
+class TestIndels:
+    def test_deletion_match_beats_distant_substitution(self):
+        """A 1-deletion neighbor at edit_distance=1 should beat a
+        same-length match at edit_distance≥2."""
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9],
+        )
+        # XMASIINFE: 9-mer, 2+ subs from any 9-mer ref, but
+        # deletion at pos 0 → MASIINFE (8-mer) is in the reference.
+        out = ref.nearest(["XMASIINFE"])
+        row = out.iloc[0]
+        assert row["self_nearest_edit_distance"] == 1
+        assert row["self_nearest_edit_type"] == "deletion"
+        assert row["self_nearest_peptide_length"] == 8
+
+    def test_insertion_match_found(self):
+        """A 1-insertion neighbor at L+1 should be found."""
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[9, 10],
+        )
+        # ASIINFEKL is an 9-mer; inserting M at pos 0 → MASIINFEKL
+        # (10-mer) which IS in the reference.
+        # But wait — ASIINFEKL is also a 9-mer IN the reference
+        # (exact match at edit_distance=0). So the indel path won't
+        # fire (edit_distance ≤ 1 check bails out).
+        # Let me use a query that DOESN'T match any 9-mer.
+        # XSIINFEKL: 9-mer, 2+ subs from any 9-mer ref.
+        # insertion of A at pos 0 → AXSIINFEKL? No, that's 10 chars
+        # and probably not in the ref.
+        # Better test: use a reference that only has 10-mers.
+        ref2 = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[10],
+        )
+        # SIINFEKLG (9-mer) has no same-length ref (only 10-mers).
+        # Inserting M at pos 0 → MSIINFEKLG (10-mer) which is
+        # probably in the reference.
+        # Actually the ref 10-mers from MASIINFEKLGGG:
+        # MASIINFEKL, ASIINFEKLG, SIINFEKLGG, IINFEKLGGG
+        # Inserting at pos 0: A+SIINFEKLG → ASIINFEKLG (YES!)
+        out2 = ref2.nearest(["SIINFEKLG"])
+        row2 = out2.iloc[0]
+        assert row2["self_nearest_edit_distance"] == 1
+        assert row2["self_nearest_edit_type"] == "insertion"
+        assert row2["self_nearest_peptide_length"] == 10
+
+    def test_exact_match_beats_indel(self):
+        """When an exact same-length match exists (edit_distance=0),
+        indels at edit_distance=1 shouldn't replace it."""
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9],
+        )
+        out = ref.nearest(["SIINFEKLG"])
+        row = out.iloc[0]
+        assert row["self_nearest_edit_distance"] == 0
+        assert row.get("self_nearest_edit_type") is None or \
+            row.get("self_nearest_edit_type") != "deletion"
+
+    def test_include_indels_false_disables(self):
+        """include_indels=False skips the indel check entirely."""
+        ref = SelfProteome.from_peptides(
+            {"g": "MASIINFEKLGGG"},
+            peptide_lengths=[8, 9],
+        )
+        out = ref.nearest(["XMASIINFE"], include_indels=False)
+        row = out.iloc[0]
+        # Without indels, the best same-length match is ≥2 subs away.
+        assert row["self_nearest_edit_distance"] >= 2

--- a/tests/test_self_proteome.py
+++ b/tests/test_self_proteome.py
@@ -503,3 +503,60 @@ class TestProtectedTissuesScope:
         assert ref.n_reference_peptides == 1
         assert "lung" in ref.reference_version
         assert "brain" in ref.reference_version
+
+
+# ---------------------------------------------------------------------------
+# BLOSUM62 distance metric
+# ---------------------------------------------------------------------------
+
+
+class TestBlosum62:
+    def test_blosum62_exact_match_zero(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLA"])
+        assert out.iloc[0]["self_nearest_blosum_distance"] == 0
+        assert out.iloc[0]["self_nearest_edit_distance"] == 0
+
+    def test_blosum62_conservative_sub_low_distance(self):
+        """I→L is a conservative substitution (BLOSUM62 score +2).
+        Should produce a lower BLOSUM distance than I→W (score -3)."""
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out_conservative = ref.nearest(["SLINFEKLA"])  # I→L at pos 1
+        out_radical = ref.nearest(["SWINFEKLA"])  # I→W at pos 1
+        cons_dist = out_conservative.iloc[0]["self_nearest_blosum_distance"]
+        rad_dist = out_radical.iloc[0]["self_nearest_blosum_distance"]
+        assert cons_dist < rad_dist
+        # Both are edit_distance=1 (one substitution)
+        assert out_conservative.iloc[0]["self_nearest_edit_distance"] == 1
+        assert out_radical.iloc[0]["self_nearest_edit_distance"] == 1
+
+    def test_blosum62_picks_conservative_over_radical(self):
+        """When two reference peptides are both edit-distance-1 from
+        the query, BLOSUM62 as the metric prefers the conservative
+        substitution over the radical one."""
+        ref = SelfProteome.from_peptides(
+            {"cons": "SLINFEKLA", "rad": "SWINFEKLA"},
+            peptide_lengths=[9],
+        )
+        out = ref.nearest(["SIINFEKLA"])
+        # BLOSUM62(I,L)=2 is better than BLOSUM62(I,W)=-3
+        assert out.iloc[0]["self_nearest_peptide"] == "SLINFEKLA"
+
+    def test_hamming_metric_opt_in(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        out = ref.nearest(["SWINFEKLA"], metric="hamming")
+        assert out.iloc[0]["self_nearest_edit_distance"] == 1
+        assert "self_nearest_blosum_distance" not in out.columns
+
+    def test_invalid_metric_raises(self):
+        ref = SelfProteome.from_peptides(
+            {"g": "SIINFEKLA"}, peptide_lengths=[9],
+        )
+        with pytest.raises(ValueError, match="metric"):
+            ref.nearest(["SIINFEKLA"], metric="invalid")

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -49,6 +49,36 @@ _AA_TO_INT = {aa: i for i, aa in enumerate(_AA_ALPHABET)}
 _UNKNOWN_AA = len(_AA_ALPHABET)
 
 
+def _load_blosum62() -> np.ndarray:
+    """Load BLOSUM62 from Biopython and reshape into a (21, 21) int8
+    lookup table indexed by ``_AA_TO_INT`` encoding.
+
+    Row/column 20 (the sentinel for unknown residues) scores -4
+    against everything so unknowns always rank as large-distance
+    mismatches.
+    """
+    from Bio.Align.substitution_matrices import load
+    bio = load("BLOSUM62")
+    n = len(_AA_ALPHABET) + 1  # +1 for sentinel
+    table = np.full((n, n), -4, dtype=np.int8)
+    for i, aa_i in enumerate(_AA_ALPHABET):
+        for j, aa_j in enumerate(_AA_ALPHABET):
+            table[i, j] = int(bio[aa_i, aa_j])
+    return table
+
+
+# Lazy-loaded on first use — avoids Biopython import at module level
+# when users only want Hamming distance.
+_BLOSUM62: Optional[np.ndarray] = None
+
+
+def _get_blosum62() -> np.ndarray:
+    global _BLOSUM62
+    if _BLOSUM62 is None:
+        _BLOSUM62 = _load_blosum62()
+    return _BLOSUM62
+
+
 def _encode_peptides(peptides: List[str], length: int) -> np.ndarray:
     """Encode peptides as an ``(N, length)`` int8 array.  Peptides
     shorter than ``length`` are padded with the unknown sentinel;
@@ -173,30 +203,43 @@ class SelfProteome:
 
     # --- lookup ---
 
-    def nearest(self, peptides: Iterable[str]) -> pd.DataFrame:
+    def nearest(
+        self,
+        peptides: Iterable[str],
+        metric: str = "blosum62",
+    ) -> pd.DataFrame:
         """For each query peptide, return the closest reference peptide
-        at the same length (Hamming distance, substitutions only).
+        at the same length.
+
+        Parameters
+        ----------
+        peptides : iterable of str
+        metric : ``"blosum62"`` (default) or ``"hamming"``
+            ``"blosum62"`` uses the BLOSUM62 substitution matrix to
+            score each position — conservative substitutions (I↔L)
+            contribute less distance than non-conservative ones (W↔A).
+            Requires Biopython (lazy-loaded on first use).
+
+            ``"hamming"`` counts the number of mismatched positions
+            (all mismatches weighted equally).
 
         Returns a DataFrame with one row per input peptide, preserving
-        input order, containing ``peptide``, ``self_nearest_peptide``,
-        ``self_nearest_peptide_length``, ``self_nearest_edit_distance``,
-        ``self_nearest_gene_id``, ``self_nearest_transcript_id``,
-        ``self_nearest_reference_offset``, and
-        ``self_nearest_reference_version``.  Rows where no reference
-        exists at the query's length have ``None`` / ``NaN`` for the
-        nearest-peptide columns.
+        input order.  Columns: ``peptide``, ``self_nearest_peptide``,
+        ``self_nearest_peptide_length``, ``self_nearest_edit_distance``
+        (Hamming), ``self_nearest_blosum_distance`` (BLOSUM62-based,
+        only when ``metric="blosum62"``), ``self_nearest_gene_id``,
+        ``self_nearest_transcript_id``, ``self_nearest_reference_offset``,
+        ``self_nearest_reference_version``.
 
         Tie-breaking: when multiple reference peptides share the
-        minimum Hamming distance to the query, the first one in the
-        internal reference array (construction / insertion order) is
-        returned.  Deterministic but implementation-dependent — don't
-        rely on which specific peptide wins unless you also control
-        the reference-construction order.  The upcoming
-        ``self_nearest_candidates`` structured column (see #124, part B)
-        exposes the full tied set for callers who care.
+        minimum distance, the first in the internal reference array
+        (construction / insertion order) is returned.
         """
+        if metric not in ("blosum62", "hamming"):
+            raise ValueError(
+                f"metric must be 'blosum62' or 'hamming'; got {metric!r}."
+            )
         peptides = [str(p) for p in peptides]
-        # Partition queries by length to batch SIMD calls.
         by_length: Dict[int, List[Tuple[int, str]]] = defaultdict(list)
         for idx, pep in enumerate(peptides):
             by_length[len(pep)].append((idx, pep))
@@ -205,14 +248,14 @@ class SelfProteome:
         for L, items in by_length.items():
             if L not in self._reference_arrays:
                 for idx, pep in items:
-                    results[idx] = self._empty_row(pep)
+                    results[idx] = self._empty_row(pep, metric)
                 continue
-            self._resolve_length(L, items, results)
+            self._resolve_length(L, items, results, metric=metric)
 
         return pd.DataFrame(results)
 
-    def _empty_row(self, peptide: str) -> dict:
-        return {
+    def _empty_row(self, peptide: str, metric: str) -> dict:
+        row = {
             "peptide": peptide,
             "self_nearest_peptide": None,
             "self_nearest_peptide_length": None,
@@ -222,12 +265,16 @@ class SelfProteome:
             "self_nearest_reference_offset": None,
             "self_nearest_reference_version": self.reference_version,
         }
+        if metric == "blosum62":
+            row["self_nearest_blosum_distance"] = None
+        return row
 
     def _resolve_length(
         self,
         L: int,
         items: List[Tuple[int, str]],
         results: List[Optional[dict]],
+        metric: str = "blosum62",
         chunk_size: int = 1000,
     ) -> None:
         ref_arr = self._reference_arrays[L]
@@ -235,16 +282,41 @@ class SelfProteome:
         query_peps = [pep for _, pep in items]
         query_arr = _encode_peptides(query_peps, L)
 
-        # Chunk to bound working memory: (chunk, M, L) diff tensor.
+        use_blosum = metric == "blosum62"
+        blosum = _get_blosum62() if use_blosum else None
+
         for start in range(0, len(query_arr), chunk_size):
             end = min(start + chunk_size, len(query_arr))
             q_chunk = query_arr[start:end]
-            # (chunk, M, L) != broadcasted → sum over last axis → (chunk, M).
-            diffs = (
-                q_chunk[:, None, :] != ref_arr[None, :, :]
-            ).sum(axis=2)
-            best_idx = diffs.argmin(axis=1)
-            best_dist = diffs[np.arange(len(q_chunk)), best_idx]
+
+            if use_blosum:
+                # BLOSUM62 distance: sum of (self_score - pair_score)
+                # per position.  Lower = more similar.
+                pair_scores = blosum[
+                    q_chunk[:, None, :], ref_arr[None, :, :]
+                ].sum(axis=2)
+                self_scores = blosum[
+                    q_chunk, q_chunk
+                ].sum(axis=1)
+                dists = self_scores[:, None] - pair_scores
+            else:
+                # Hamming: count mismatched positions.
+                dists = (
+                    q_chunk[:, None, :] != ref_arr[None, :, :]
+                ).sum(axis=2)
+
+            best_idx = dists.argmin(axis=1)
+            best_dist = dists[np.arange(len(q_chunk)), best_idx]
+
+            # Also compute Hamming for the edit_distance column
+            # regardless of metric (it's always useful).
+            if use_blosum:
+                hamming = (
+                    q_chunk[:, None, :] != ref_arr[None, :, :]
+                ).sum(axis=2)
+                best_hamming = hamming[np.arange(len(q_chunk)), best_idx]
+            else:
+                best_hamming = best_dist
 
             for k, (orig_idx, orig_pep) in enumerate(items[start:end]):
                 ref_pep = ref_peps[int(best_idx[k])]
@@ -253,16 +325,19 @@ class SelfProteome:
                     gene_id, transcript_id, offset = prov[0]
                 else:
                     gene_id, transcript_id, offset = None, None, None
-                results[orig_idx] = {
+                row = {
                     "peptide": orig_pep,
                     "self_nearest_peptide": ref_pep,
                     "self_nearest_peptide_length": L,
-                    "self_nearest_edit_distance": int(best_dist[k]),
+                    "self_nearest_edit_distance": int(best_hamming[k]),
                     "self_nearest_gene_id": gene_id,
                     "self_nearest_transcript_id": transcript_id,
                     "self_nearest_reference_offset": offset,
                     "self_nearest_reference_version": self.reference_version,
                 }
+                if use_blosum:
+                    row["self_nearest_blosum_distance"] = int(best_dist[k])
+                results[orig_idx] = row
 
     # --- constructors ---
 

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -207,6 +207,7 @@ class SelfProteome:
         self,
         peptides: Iterable[str],
         metric: str = "blosum62",
+        include_indels: bool = True,
     ) -> pd.DataFrame:
         """For each query peptide, return the closest reference peptide
         at the same length.
@@ -252,7 +253,86 @@ class SelfProteome:
                 continue
             self._resolve_length(L, items, results, metric=metric)
 
+        # Check 1aa indel neighbors when enabled.  An indel match
+        # at edit_distance=1 beats a same-length match at edit_distance≥2.
+        if include_indels:
+            for idx, pep in enumerate(peptides):
+                current = results[idx]
+                if current is None:
+                    continue
+                best_edit = current.get("self_nearest_edit_distance")
+                if best_edit is not None and best_edit <= 1:
+                    continue
+                indel_hit = self._check_indel_neighbors(pep, metric)
+                if indel_hit is not None:
+                    results[idx] = indel_hit
+
         return pd.DataFrame(results)
+
+    def _reference_set(self, L: int) -> set:
+        """Lazy-built set of reference peptide strings at length L."""
+        if not hasattr(self, "_reference_sets_cache"):
+            self._reference_sets_cache: Dict[int, set] = {}
+        if L not in self._reference_sets_cache:
+            peps = self._reference_peptides.get(L, [])
+            self._reference_sets_cache[L] = set(peps)
+        return self._reference_sets_cache[L]
+
+    def _check_indel_neighbors(
+        self, peptide: str, metric: str,
+    ) -> Optional[dict]:
+        """Check if any 1-insertion or 1-deletion neighbor of ``peptide``
+        exists in the reference at lengths L±1.  Returns a result row
+        for the first hit found (edit_distance=1), or ``None``.
+
+        Deletion: remove one character at each position → L-1 length.
+        Insertion: insert one of 20 AAs at each position → L+1 length.
+
+        ~L + L×20 ≈ 200 hash-set lookups for a 9-mer.  Fast.
+        """
+        L = len(peptide)
+        # Try deletions first (cheaper: L lookups vs L×20 for insertions)
+        ref_set_del = self._reference_set(L - 1) if L > 1 else set()
+        for i in range(L):
+            candidate = peptide[:i] + peptide[i + 1:]
+            if candidate in ref_set_del:
+                return self._indel_row(
+                    peptide, candidate, L - 1, "deletion", metric,
+                )
+        # Try insertions
+        ref_set_ins = self._reference_set(L + 1)
+        for i in range(L + 1):
+            for aa in _AA_ALPHABET:
+                candidate = peptide[:i] + aa + peptide[i:]
+                if candidate in ref_set_ins:
+                    return self._indel_row(
+                        peptide, candidate, L + 1, "insertion", metric,
+                    )
+        return None
+
+    def _indel_row(
+        self, peptide: str, match: str, match_len: int,
+        edit_type: str, metric: str,
+    ) -> dict:
+        prov = self._provenance.get(match)
+        if prov:
+            gene_id, transcript_id, offset = prov[0]
+        else:
+            gene_id, transcript_id, offset = None, None, None
+        row = {
+            "peptide": peptide,
+            "self_nearest_peptide": match,
+            "self_nearest_peptide_length": match_len,
+            "self_nearest_edit_distance": 1,
+            "self_nearest_edit_type": edit_type,
+            "self_nearest_gene_id": gene_id,
+            "self_nearest_transcript_id": transcript_id,
+            "self_nearest_reference_offset": offset,
+            "self_nearest_reference_version": self.reference_version,
+        }
+        if metric == "blosum62":
+            row["self_nearest_blosum_distance"] = None
+        return row
 
     def _empty_row(self, peptide: str, metric: str) -> dict:
         row = {

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -1,28 +1,43 @@
 """SelfProteome — reference protein corpus for cross-reactivity analysis.
 
-Holds a species-tagged, scope-filtered protein set indexed by peptide
-length.  Answers per-query nearest-neighbor lookups: "given this mutant
-peptide, what's the most similar peptide in healthy human self?"
+Holds a species-tagged, ``include=``-filtered protein set indexed by
+peptide length.  Answers per-query nearest-neighbor lookups: "given
+this mutant peptide, what's the most similar peptide in healthy self?"
 
-Scopes
-------
-- ``"all"``: no filter, whole Ensembl proteome (any pyensembl-supported species).
-- ``"non_cta"`` (default for human): remove cancer-testis-antigen genes via
-  pirlygenes.  Non-human species require an explicit ``cta_source=`` set
-  or callable — pirlygenes is human-only today.
+Include modes
+-------------
+- ``"all"``: no filter, whole Ensembl proteome (any pyensembl-supported
+  species).
+- ``"non_cta"`` (default for human): remove cancer-testis-antigen genes
+  via pirlygenes.  Non-human species require an explicit ``cta_source=``
+  set or callable — pirlygenes is human-only today.
+- ``"protected_tissues"``: keep only genes expressed in named tissues
+  (pirlygenes/HPA for human; user-supplied ``tissue_gene_ids=`` for
+  any species).
 - callable: user-supplied ``gene → bool`` filter.  Works for any species.
 
-Additional scopes (``"protected_tissues"`` with HPA/GTEx expression-based
-filtering, 1aa-indel candidates, the ``self_nearest_by_binding`` and
-``self_strongest_nearby`` axes, and the full candidate-set structured
-column) are queued for a follow-up PR.  This module currently ships the
-core architecture and one nearest-by-sequence axis so downstream code can
-start consuming ``self_nearest_*`` columns in a real predictor run.
+Distance metrics
+----------------
+- ``"blosum62"`` (default): BLOSUM62-weighted substitution distance.
+  Conservative substitutions (I↔L) produce lower distances than
+  non-conservative (I↔W).  Loaded lazily from Biopython.
+- ``"hamming"``: count mismatched positions (all mismatches equal).
+
+Indels
+------
+``nearest(include_indels=True)`` (default) checks 1-deletion (L-1) and
+1-insertion (L+1) neighbors via hash-set lookup.  An indel match at
+edit_distance=1 beats a same-length substitution match at
+edit_distance≥2.
+
+Binding-aware axes (``self_mimic_*``, ``self_strongest_nearby_*``,
+``self_nearest_candidates``) are tracked for a follow-up PR — they
+require MHC prediction on candidate peptides, which is
+architecturally separate from the sequence-only ``nearest()`` method.
 
 Algorithm
 ---------
-SIMD-vectorized Hamming distance against int8-encoded reference arrays.
-Only substitutions (same-length matches) in this PR; indels land in the
+SIMD-vectorized distance against int8-encoded reference arrays. Indels
 follow-up alongside seed-and-extend for larger reference corpora.  See
 #124 for the benchmark plan driving the eventual algorithm choice.
 """
@@ -198,7 +213,7 @@ class SelfProteome:
         """
         release_part = f"-{self.release}" if self.release is not None else ""
         return (
-            f"ensembl-{self.species}{release_part}+scope-{self.include_label}"
+            f"ensembl-{self.species}{release_part}+include-{self.include_label}"
         )
 
     # --- lookup ---
@@ -235,6 +250,16 @@ class SelfProteome:
         Tie-breaking: when multiple reference peptides share the
         minimum distance, the first in the internal reference array
         (construction / insertion order) is returned.
+
+        Indel matching: when ``include_indels=True`` and the best
+        same-length match has ``edit_distance ≥ 2``, the method also
+        checks 1-deletion (L-1) and 1-insertion (L+1) neighbors via
+        hash-set lookup.  The **first** indel hit found (deletions
+        checked before insertions, in position order) is returned —
+        not necessarily the best among all indel candidates.  This is
+        fast (~200 lookups per 9-mer) but not exhaustive; the upcoming
+        ``self_nearest_candidates`` structured column will expose the
+        full candidate set.
         """
         if metric not in ("blosum62", "hamming"):
             raise ValueError(

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -342,16 +342,36 @@ class SelfProteome:
         peptide_lengths: Iterable[int] = (8, 9, 10, 11),
         scope: Union[str, Callable] = "non_cta",
         cta_source=None,
+        tissues: Optional[List[str]] = None,
+        tissue_gene_ids: Optional[Set[str]] = None,
+        min_tissue_ntpm: float = 1.0,
     ) -> "SelfProteome":
         """Build from a pyensembl EnsemblRelease.
 
-        ``scope`` accepts ``"all"``, ``"non_cta"``, or a callable
-        ``(gene_id) -> bool``.  For ``scope="non_cta"`` with
-        ``species="human"``, the default ``cta_source="pirlygenes"``
-        needs no configuration.  Non-human species must pass
-        ``cta_source=<set or callable>`` explicitly.
+        ``scope`` accepts ``"all"``, ``"non_cta"``,
+        ``"protected_tissues"``, or a callable ``(gene_id) -> bool``.
 
-        ``scope="protected_tissues"`` lands in a follow-up PR.
+        For ``scope="non_cta"`` with ``species="human"``, the default
+        ``cta_source="pirlygenes"`` needs no configuration.  Non-human
+        species must pass ``cta_source=<set or callable>`` explicitly.
+
+        For ``scope="protected_tissues"``:
+
+        - **Human (default)**: filters to genes expressed in the
+          ``tissues`` list via pirlygenes' HPA expression data.
+          ``tissues`` defaults to a curated vital-organ set
+          (``["heart_muscle", "lung", "liver", "kidney",
+          "cerebral_cortex"]``).  ``min_tissue_ntpm`` sets the
+          expression threshold (normalized TPM).
+        - **Any species with explicit data**: pass
+          ``tissue_gene_ids=<set of gene IDs>`` to supply the gene set
+          directly.  ``tissues`` and ``min_tissue_ntpm`` are ignored
+          when ``tissue_gene_ids`` is provided.  This is the path for
+          mouse (e.g. Tabula Muris data), dog, or any non-human
+          species.
+        - **Non-human without ``tissue_gene_ids``**: raises a
+          ``ValueError`` explaining that pirlygenes tissue data is
+          human-only.
         """
         try:
             from pyensembl import EnsemblRelease
@@ -363,6 +383,9 @@ class SelfProteome:
         genome = EnsemblRelease(release=release, species=species)
         scope_label, gene_filter = _resolve_ensembl_scope(
             scope, species, cta_source,
+            tissues=tissues,
+            tissue_gene_ids=tissue_gene_ids,
+            min_tissue_ntpm=min_tissue_ntpm,
         )
         records = list(_iter_ensembl_proteins(genome, gene_filter))
         reference_arrays, reference_peptides, provenance = _build_index(
@@ -421,7 +444,15 @@ def _apply_fasta_scope(scope, records):
     )
 
 
-def _resolve_ensembl_scope(scope, species, cta_source):
+_DEFAULT_PROTECTED_TISSUES = [
+    "heart_muscle", "lung", "liver", "kidney", "cerebral_cortex",
+]
+
+
+def _resolve_ensembl_scope(
+    scope, species, cta_source, *,
+    tissues=None, tissue_gene_ids=None, min_tissue_ntpm=1.0,
+):
     """Return (scope_label, gene_filter) where gene_filter takes a gene_id
     and returns True to keep."""
     if callable(scope):
@@ -440,10 +471,58 @@ def _resolve_ensembl_scope(scope, species, cta_source):
         cta_set = cta  # set of gene IDs
         return label, lambda gene_id: gene_id not in cta_set
     if scope == "protected_tissues":
-        raise NotImplementedError(
-            "scope='protected_tissues' lands in a follow-up PR."
+        keep_ids, label = _resolve_protected_tissues(
+            species, tissues, tissue_gene_ids, min_tissue_ntpm,
         )
+        return label, lambda gene_id: gene_id in keep_ids
     raise ValueError(f"Unknown scope: {scope!r}.")
+
+
+def _resolve_protected_tissues(species, tissues, tissue_gene_ids, min_ntpm):
+    """Resolve the gene set for ``scope="protected_tissues"``.
+
+    Returns ``(keep_gene_ids: set[str], scope_label: str)``.
+
+    Three paths:
+
+    1. **Explicit gene set** (``tissue_gene_ids`` provided): used
+       as-is, any species.  ``tissues`` / ``min_ntpm`` ignored.
+    2. **Human default** (``tissue_gene_ids`` is None, species is
+       human): queries pirlygenes via
+       ``topiary.sources.tissue_expressed_gene_ids`` with the
+       requested tissue list (or the curated vital-organ default)
+       and ``min_ntpm`` threshold.
+    3. **Non-human without explicit gene set**: raises a clear error
+       telling the user to supply ``tissue_gene_ids=``.
+    """
+    if tissue_gene_ids is not None:
+        keep = set(tissue_gene_ids)
+        digest = hashlib.sha256(
+            "\n".join(sorted(keep)).encode()
+        ).hexdigest()[:12]
+        return keep, f"protected_tissues+gene_ids-sha256:{digest}"
+
+    # Default path — pirlygenes tissue data (human only).
+    if species != "human":
+        raise ValueError(
+            f"scope='protected_tissues' without tissue_gene_ids= "
+            f"defaults to pirlygenes/HPA expression data, which is "
+            f"human-only; got species={species!r}.  For non-human "
+            f"species, pass tissue_gene_ids=<set of gene IDs> with "
+            f"the gene IDs expressed in your protected tissues "
+            f"(e.g. from Tabula Muris for mouse, or your own "
+            f"RNA-seq data)."
+        )
+
+    if tissues is None:
+        tissues = list(_DEFAULT_PROTECTED_TISSUES)
+
+    from topiary.sources import tissue_expressed_gene_ids
+    keep = tissue_expressed_gene_ids(tissues, min_ntpm=min_ntpm)
+    tissue_str = "+".join(sorted(tissues))
+    return keep, (
+        f"protected_tissues+tissues-{tissue_str}+min_ntpm-{min_ntpm}"
+    )
 
 
 def _cta_label(species, cta_source, cta_set):

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -88,10 +88,10 @@ def _resolve_cta_gene_ids(
         cta_source = defaults.get("cta_source")
         if cta_source is None:
             raise ValueError(
-                f"scope='non_cta' needs a CTA source for "
+                f"include='non_cta' needs a CTA source for "
                 f"species={species!r}; no default registered.  Pass "
                 f"cta_source=<set or callable> explicitly, or use "
-                f"scope='all'."
+                f"include='all'."
             )
 
     if callable(cta_source):
@@ -136,14 +136,14 @@ class SelfProteome:
         *,
         species: str,
         release: Optional[str],
-        scope_label: str,
+        include_label: str,
         reference_arrays: Dict[int, np.ndarray],
         reference_peptides: Dict[int, List[str]],
         provenance: Dict[str, List[Tuple[str, str, int]]],
     ):
         self.species = species
         self.release = release
-        self.scope_label = scope_label
+        self.include_label = include_label
         self._reference_arrays = reference_arrays
         self._reference_peptides = reference_peptides
         self._provenance = provenance
@@ -168,7 +168,7 @@ class SelfProteome:
         """
         release_part = f"-{self.release}" if self.release is not None else ""
         return (
-            f"ensembl-{self.species}{release_part}+scope-{self.scope_label}"
+            f"ensembl-{self.species}{release_part}+scope-{self.include_label}"
         )
 
     # --- lookup ---
@@ -274,7 +274,7 @@ class SelfProteome:
         peptide_lengths: Iterable[int] = (8, 9, 10, 11),
         species: str = "synthetic",
         release: Optional[str] = None,
-        scope_label: str = "all",
+        include_label: str = "all",
     ) -> "SelfProteome":
         """Build from an in-memory ``{source_id: amino_acid_sequence}``
         mapping.  Primarily a test helper; also useful for small
@@ -294,7 +294,7 @@ class SelfProteome:
         return cls(
             species=species,
             release=release,
-            scope_label=scope_label,
+            include_label=include_label,
             reference_arrays=reference_arrays,
             reference_peptides=reference_peptides,
             provenance=provenance,
@@ -308,26 +308,26 @@ class SelfProteome:
         peptide_lengths: Iterable[int] = (8, 9, 10, 11),
         species: str = "fasta",
         release: Optional[str] = None,
-        scope: Union[str, Callable] = "all",
+        include: Union[str, Callable] = "all",
     ) -> "SelfProteome":
         """Build from a FASTA file.  Each record's ID is used as both
         gene_id and transcript_id in provenance (FASTA doesn't carry
         the distinction).
 
-        ``scope`` accepts ``"all"`` or a callable ``(source_id) -> bool``;
+        ``include`` accepts ``"all"`` or a callable ``(source_id) -> bool``;
         ``"non_cta"`` and ``"protected_tissues"`` require gene-metadata
         that FASTA doesn't provide, so use :meth:`from_ensembl` for
-        those scopes.
+        those.
         """
         records = list(_parse_fasta(path))
-        scope_label, records = _apply_fasta_scope(scope, records)
+        include_label, records = _apply_fasta_scope(include, records)
         reference_arrays, reference_peptides, provenance = _build_index(
             records, peptide_lengths,
         )
         return cls(
             species=species,
             release=release,
-            scope_label=scope_label,
+            include_label=include_label,
             reference_arrays=reference_arrays,
             reference_peptides=reference_peptides,
             provenance=provenance,
@@ -340,7 +340,7 @@ class SelfProteome:
         release: Optional[int] = None,
         *,
         peptide_lengths: Iterable[int] = (8, 9, 10, 11),
-        scope: Union[str, Callable] = "non_cta",
+        include: Union[str, Callable] = "non_cta",
         cta_source=None,
         tissues: Optional[List[str]] = None,
         tissue_gene_ids: Optional[Set[str]] = None,
@@ -348,14 +348,14 @@ class SelfProteome:
     ) -> "SelfProteome":
         """Build from a pyensembl EnsemblRelease.
 
-        ``scope`` accepts ``"all"``, ``"non_cta"``,
+        ``include`` accepts ``"all"``, ``"non_cta"``,
         ``"protected_tissues"``, or a callable ``(gene_id) -> bool``.
 
-        For ``scope="non_cta"`` with ``species="human"``, the default
+        For ``include="non_cta"`` with ``species="human"``, the default
         ``cta_source="pirlygenes"`` needs no configuration.  Non-human
         species must pass ``cta_source=<set or callable>`` explicitly.
 
-        For ``scope="protected_tissues"``:
+        For ``include="protected_tissues"``:
 
         - **Human (default)**: filters to genes expressed in the
           ``tissues`` list via pirlygenes' HPA expression data.
@@ -381,8 +381,8 @@ class SelfProteome:
             ) from e
 
         genome = EnsemblRelease(release=release, species=species)
-        scope_label, gene_filter = _resolve_ensembl_scope(
-            scope, species, cta_source,
+        include_label, gene_filter = _resolve_ensembl_scope(
+            include, species, cta_source,
             tissues=tissues,
             tissue_gene_ids=tissue_gene_ids,
             min_tissue_ntpm=min_tissue_ntpm,
@@ -394,7 +394,7 @@ class SelfProteome:
         return cls(
             species=species,
             release=str(release) if release is not None else None,
-            scope_label=scope_label,
+            include_label=include_label,
             reference_arrays=reference_arrays,
             reference_peptides=reference_peptides,
             provenance=provenance,
@@ -427,18 +427,18 @@ def _parse_fasta(path):
         yield current_id, current_id, current_id, "".join(buf)
 
 
-def _apply_fasta_scope(scope, records):
-    """Filter FASTA records by scope.  Returns (scope_label, filtered_records)."""
-    if scope == "all":
+def _apply_fasta_scope(include, records):
+    """Filter FASTA records by include mode.  Returns (include_label, filtered)."""
+    if include == "all":
         return "all", records
-    if callable(scope):
+    if callable(include):
         label = (
             "callable-"
-            + hashlib.sha256(repr(scope).encode()).hexdigest()[:12]
+            + hashlib.sha256(repr(include).encode()).hexdigest()[:12]
         )
-        return label, [r for r in records if scope(r[0])]
+        return label, [r for r in records if include(r[0])]
     raise ValueError(
-        f"scope={scope!r} isn't available for from_fasta (FASTA has no "
+        f"include={include!r} isn't available for from_fasta (FASTA has no "
         f"gene/tissue metadata).  Use 'all', a callable, or switch to "
         f"from_ensembl."
     )
@@ -450,38 +450,38 @@ _DEFAULT_PROTECTED_TISSUES = [
 
 
 def _resolve_ensembl_scope(
-    scope, species, cta_source, *,
+    include, species, cta_source, *,
     tissues=None, tissue_gene_ids=None, min_tissue_ntpm=1.0,
 ):
-    """Return (scope_label, gene_filter) where gene_filter takes a gene_id
+    """Return (include_label, gene_filter) where gene_filter takes a gene_id
     and returns True to keep."""
-    if callable(scope):
+    if callable(include):
         label = (
             "callable-"
-            + hashlib.sha256(repr(scope).encode()).hexdigest()[:12]
+            + hashlib.sha256(repr(include).encode()).hexdigest()[:12]
         )
-        return label, scope
-    if scope == "all":
+        return label, include
+    if include == "all":
         return "all", lambda _gene_id: True
-    if scope == "non_cta":
+    if include == "non_cta":
         cta = _resolve_cta_gene_ids(species, cta_source)
         if callable(cta):
             return "non_cta-callable", lambda g: not cta(g)
         label = _cta_label(species, cta_source, cta)
         cta_set = cta  # set of gene IDs
         return label, lambda gene_id: gene_id not in cta_set
-    if scope == "protected_tissues":
+    if include == "protected_tissues":
         keep_ids, label = _resolve_protected_tissues(
             species, tissues, tissue_gene_ids, min_tissue_ntpm,
         )
         return label, lambda gene_id: gene_id in keep_ids
-    raise ValueError(f"Unknown scope: {scope!r}.")
+    raise ValueError(f"Unknown include value: {include!r}.")
 
 
 def _resolve_protected_tissues(species, tissues, tissue_gene_ids, min_ntpm):
-    """Resolve the gene set for ``scope="protected_tissues"``.
+    """Resolve the gene set for ``include="protected_tissues"``.
 
-    Returns ``(keep_gene_ids: set[str], scope_label: str)``.
+    Returns ``(keep_gene_ids: set[str], include_label: str)``.
 
     Three paths:
 
@@ -505,7 +505,7 @@ def _resolve_protected_tissues(species, tissues, tissue_gene_ids, min_ntpm):
     # Default path — pirlygenes tissue data (human only).
     if species != "human":
         raise ValueError(
-            f"scope='protected_tissues' without tissue_gene_ids= "
+            f"include='protected_tissues' without tissue_gene_ids= "
             f"defaults to pirlygenes/HPA expression data, which is "
             f"human-only; got species={species!r}.  For non-human "
             f"species, pass tissue_gene_ids=<set of gene IDs> with "


### PR DESCRIPTION
## Summary

Adds \`scope=\"protected_tissues\"\` to \`SelfProteome.from_ensembl\` — filters the reference proteome to genes expressed in named tissues.  Multi-species-safe: pirlygenes/HPA for human defaults, explicit \`tissue_gene_ids=\` for any species.

## Multi-species paths

| Species | How | Example |
|---|---|---|
| Human (default) | pirlygenes tissue expression data, curated vital-organ tissue list | \`SelfProteome.from_ensembl(scope=\"protected_tissues\")\` |
| Human (custom) | pirlygenes with user-specified tissues | \`..., tissues=[\"lung\", \"brain\"], min_tissue_ntpm=5.0)\` |
| Mouse / dog / any | User-supplied gene set | \`..., tissue_gene_ids={\"ENSMUSG...\", ...})\` |
| Non-human without data | Raises with actionable message | \`..., species=\"mouse\", scope=\"protected_tissues\")\` → \`ValueError\` |

## Test plan

- [x] 4 new tests (non-human error, non-human with gene_ids, human default, human custom)
- [x] \`./test.sh\` — 1170 passed (up from 1166)
- [x] \`./lint.sh\` — clean
- [ ] CI green

Part B of #124.