### PR TITLE
EvalContext default_methods for multi-predictor frames (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.10.0
+
+**EvalContext `default_methods` for multi-predictor frames (#140):**
+
+- `EvalContext(df, default_methods={...})` — resolve unqualified
+  `Affinity` / `Presentation` / etc. references when a DataFrame has
+  multiple `prediction_method_name` values for the same kind. Without
+  it, the ambiguity check still raises (behavior unchanged).
+- Keys accept canonical kind names (`"pMHC_affinity"`), DSL short names
+  (`"affinity"`, `"ba"`, `"el"`, ...), or mhctools `Kind` constants.
+- `apply_filter(df, node, default_methods=...)` and
+  `apply_sort(df, nodes, default_methods=...)` forward the kwarg.
+- Error message on ambiguous unqualified access now points users at
+  `default_methods` as the opt-in escape hatch.
+
+Context: multi-predictor pipelines (e.g. LENS emitting MHCflurry
++ netMHCpan + netMHCstabpan) previously had to either qualify every
+DSL expression with `['modelname']` or pre-subset the DataFrame to one
+method per kind. `default_methods` is the declarative alternative.
+
 ## 5.9.0
 
 **SelfProteome part B (#138):**

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -793,18 +793,105 @@ def test_default_methods_resolves_ambiguity():
     assert Affinity.value.eval(ctx).iloc[0] == 120.0
 
 
-def test_default_methods_accepts_short_name_and_kind_enum():
-    """Short names and Kind constants are canonicalized to kind values."""
+@pytest.mark.parametrize("key", [
+    "pMHC_affinity",     # canonical kind string
+    "pmhc_affinity",     # lowercase canonical
+    "affinity",          # DSL short name
+    "ba",                # synonym (binding affinity)
+    "aff",               # synonym
+    "ic50",              # synonym (IC50)
+    Kind.pMHC_affinity,  # mhctools Kind enum value
+])
+def test_default_methods_affinity_synonyms(key):
+    """Every accepted spelling of 'pMHC_affinity' resolves to the same kind."""
     df = _multi_model_df()
-    assert Affinity.value.eval(
-        EvalContext(df, default_methods={"affinity": "mhcflurry"})
-    ).iloc[0] == 350.0
-    assert Affinity.value.eval(
-        EvalContext(df, default_methods={"ba": "netmhcpan"})
-    ).iloc[0] == 120.0
-    assert Affinity.value.eval(
-        EvalContext(df, default_methods={Kind.pMHC_affinity: "mhcflurry"})
-    ).iloc[0] == 350.0
+    ctx = EvalContext(df, default_methods={key: "mhcflurry"})
+    assert Affinity.value.eval(ctx).iloc[0] == 350.0
+
+
+@pytest.mark.parametrize("key,method,expected", [
+    ("pMHC_presentation", "mhcflurry", 0.9),
+    ("presentation",      "mhcflurry", 0.9),
+    ("el",                "mhcflurry", 0.9),
+])
+def test_default_methods_presentation_synonyms(key, method, expected):
+    """Presentation synonyms (pMHC_presentation, presentation, el)."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.9, value=None, percentile_rank=0.3,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.7, value=None, percentile_rank=1.0,
+             prediction_method_name="netmhcpan"),
+    ])
+    ctx = EvalContext(df, default_methods={key: method})
+    assert Presentation.score.eval(ctx).iloc[0] == expected
+
+
+@pytest.mark.parametrize("key", ["pMHC_stability", "stability"])
+def test_default_methods_stability_synonyms(key):
+    """Stability synonyms (pMHC_stability, stability)."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_stability",
+             score=0.8, value=5.0, percentile_rank=1.0,
+             prediction_method_name="netmhcstabpan"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_stability",
+             score=0.6, value=3.0, percentile_rank=2.0,
+             prediction_method_name="otherpredictor"),
+    ])
+    ctx = EvalContext(df, default_methods={key: "netmhcstabpan"})
+    assert Stability.score.eval(ctx).iloc[0] == 0.8
+
+
+@pytest.mark.parametrize("key", ["antigen_processing", "processing"])
+def test_default_methods_processing_synonyms(key):
+    """Processing synonyms (antigen_processing, processing)."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="antigen_processing",
+             score=0.75, value=None, percentile_rank=None,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="antigen_processing",
+             score=0.45, value=None, percentile_rank=None,
+             prediction_method_name="netchop"),
+    ])
+    from topiary.ranking import Processing
+    ctx = EvalContext(df, default_methods={key: "mhcflurry"})
+    assert Processing.score.eval(ctx).iloc[0] == 0.75
+
+
+def test_default_methods_accepts_multiple_synonyms_in_one_dict():
+    """Mixed synonyms across kinds in a single default_methods dict."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.9, value=None, percentile_rank=0.3,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=10,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.7, value=None, percentile_rank=1.0,
+             prediction_method_name="netmhcpan"),
+    ])
+    # Mixing canonical and short names in one dict.
+    ctx = EvalContext(df, default_methods={
+        "ba": "netmhcpan",           # synonym for pMHC_affinity
+        "presentation": "mhcflurry",  # short name for pMHC_presentation
+    })
+    assert Affinity.value.eval(ctx).iloc[0] == 120.0
+    assert Presentation.score.eval(ctx).iloc[0] == 0.9
 
 
 def test_default_methods_unknown_method_raises():

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -15,6 +15,7 @@ from topiary.ranking import (
     Comparison,
     Const,
     Count,
+    EvalContext,
     Field,
     KindAccessor,
     Len,
@@ -775,6 +776,161 @@ def test_unqualified_single_model_ok():
     df = _multi_model_df()
     # Presentation only comes from mhcflurry — no ambiguity
     assert Presentation.score.evaluate(df) == 0.9
+
+
+# ---------------------------------------------------------------------------
+# EvalContext(default_methods=...)  —  issue #140
+# ---------------------------------------------------------------------------
+
+
+def test_default_methods_resolves_ambiguity():
+    """Unqualified affinity picks the defaulted method instead of raising."""
+    df = _multi_model_df()
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "mhcflurry"})
+    assert Affinity.value.eval(ctx).iloc[0] == 350.0
+
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "netmhcpan"})
+    assert Affinity.value.eval(ctx).iloc[0] == 120.0
+
+
+def test_default_methods_accepts_short_name_and_kind_enum():
+    """Short names and Kind constants are canonicalized to kind values."""
+    df = _multi_model_df()
+    assert Affinity.value.eval(
+        EvalContext(df, default_methods={"affinity": "mhcflurry"})
+    ).iloc[0] == 350.0
+    assert Affinity.value.eval(
+        EvalContext(df, default_methods={"ba": "netmhcpan"})
+    ).iloc[0] == 120.0
+    assert Affinity.value.eval(
+        EvalContext(df, default_methods={Kind.pMHC_affinity: "mhcflurry"})
+    ).iloc[0] == 350.0
+
+
+def test_default_methods_unknown_method_raises():
+    """Defaulting to a method that isn't in the frame surfaces a helpful error."""
+    df = _multi_model_df()
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "nosuchmodel"})
+    with pytest.raises(ValueError, match="nosuchmodel"):
+        Affinity.value.eval(ctx)
+
+
+def test_default_methods_unknown_kind_raises():
+    """Non-kind keys are rejected at EvalContext construction."""
+    with pytest.raises(ValueError, match="not a known kind"):
+        EvalContext(pd.DataFrame(), default_methods={"banana": "mhcflurry"})
+
+
+def test_default_methods_non_string_value_raises():
+    with pytest.raises(TypeError, match="method name string"):
+        EvalContext(pd.DataFrame(), default_methods={"pMHC_affinity": 42})
+
+
+def test_default_methods_only_applies_to_listed_kinds():
+    """Default for one kind doesn't silence ambiguity on a different kind."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.9, value=None, percentile_rank=0.3,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.7, value=None, percentile_rank=1.0,
+             prediction_method_name="netmhcpan"),
+    ])
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "mhcflurry"})
+    # affinity resolves cleanly
+    assert Affinity.value.eval(ctx).iloc[0] == 350.0
+    # presentation is still ambiguous
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        Presentation.score.eval(ctx)
+
+
+def test_default_methods_no_effect_on_single_model_frame():
+    """Default is only consulted on the multi-method ambiguity branch."""
+    # Only presentation (single-model) — default for affinity is a no-op.
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKL", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_presentation",
+             score=0.9, value=None, percentile_rank=0.3,
+             prediction_method_name="mhcflurry"),
+    ])
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "netmhcpan"})
+    assert Presentation.score.eval(ctx).iloc[0] == 0.9
+
+
+def test_default_methods_explicit_bracket_overrides():
+    """Field(method=...) path ignores default_methods — still qualifies itself."""
+    df = _multi_model_df()
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "mhcflurry"})
+    # Explicit ['netmhcpan'] must win over the default.
+    assert Affinity["netmhcpan"].value.eval(ctx).iloc[0] == 120.0
+
+
+def test_default_methods_unset_still_raises_ambiguity():
+    """Not passing default_methods preserves the current strict error."""
+    df = _multi_model_df()
+    ctx = EvalContext(df)  # no default_methods
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        Affinity.value.eval(ctx)
+
+
+def test_ambiguity_error_mentions_default_methods():
+    """Error message hints at the default_methods escape hatch."""
+    df = _multi_model_df()
+    with pytest.raises(ValueError, match="default_methods"):
+        Affinity.value.evaluate(df)
+
+
+def test_apply_filter_accepts_default_methods():
+    """apply_filter forwards default_methods to EvalContext."""
+    df = _multi_model_df()
+    # With mhcflurry default: value is 350 — fails <= 200 filter → no rows.
+    result = apply_filter(df, Affinity.value <= 200,
+                          default_methods={"pMHC_affinity": "mhcflurry"})
+    assert len(result) == 0
+    # With netmhcpan default: value is 120 — passes <= 200 filter → all rows.
+    result = apply_filter(df, Affinity.value <= 200,
+                          default_methods={"pMHC_affinity": "netmhcpan"})
+    assert len(result) == 3
+
+
+def test_apply_sort_accepts_default_methods():
+    """apply_sort forwards default_methods to EvalContext."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+        dict(source_sequence_name="s", peptide="BBBB", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.4, value=80.0, percentile_rank=0.2,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="BBBB", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.9, value=500.0, percentile_rank=3.0,
+             prediction_method_name="netmhcpan"),
+    ])
+    result = apply_sort(df, [Affinity.value],
+                        default_methods={"pMHC_affinity": "mhcflurry"})
+    # mhcflurry values: AAAA=350, BBBB=80 — ascending (affinity) → BBBB first
+    assert result.iloc[0]["peptide"] == "BBBB"
+    result = apply_sort(df, [Affinity.value],
+                        default_methods={"pMHC_affinity": "netmhcpan"})
+    # netmhcpan values: AAAA=120, BBBB=500 → AAAA first
+    assert result.iloc[0]["peptide"] == "AAAA"
 
 
 def test_bracket_norm_shorthand():

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -908,6 +908,49 @@ def test_default_methods_unknown_kind_raises():
         EvalContext(pd.DataFrame(), default_methods={"banana": "mhcflurry"})
 
 
+def test_default_methods_error_surfaces_short_aliases():
+    """Error message lists short aliases alongside canonical kind names."""
+    try:
+        EvalContext(pd.DataFrame(), default_methods={"banana": "mhcflurry"})
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        msg = str(exc)
+        # Canonical kind names
+        assert "pMHC_affinity" in msg
+        assert "pMHC_presentation" in msg
+        # Short aliases / synonyms
+        assert "affinity" in msg
+        assert "ba" in msg
+        assert "el" in msg
+        assert "processing" in msg
+        # Lower-case duplicates of canonicals shouldn't clutter the list.
+        assert "pmhc_affinity" not in msg
+
+
+def test_default_methods_substring_match_literal_not_regex():
+    """Method substring match is regex=False — dots are literal characters."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+    ])
+    # 'net.*pan' as a regex would match both netmhcpan and (hypothetical)
+    # netmhcstabpan. As a literal substring, it matches neither — should
+    # raise method-not-found, not silently pick one.
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "net.*pan"})
+    with pytest.raises(ValueError, match=r"net\.\*pan"):
+        Affinity.value.eval(ctx)
+
+    # Same check on the explicit-method Field path.
+    with pytest.raises(ValueError, match=r"net\.\*pan"):
+        Affinity["net.*pan"].value.evaluate(df)
+
+
 def test_default_methods_non_string_value_raises():
     with pytest.raises(TypeError, match="method name string"):
         EvalContext(pd.DataFrame(), default_methods={"pMHC_affinity": 42})

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -50,7 +50,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.9.1"
+__version__ = "5.10.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -99,11 +99,15 @@ def _resolve_sort_direction(node, sort_direction):
     return sort_direction
 
 
-def apply_filter(df, node):
+def apply_filter(df, node, default_methods=None):
     """Apply a boolean-valued DSL node to *df*.
 
     Keeps all rows for peptide-allele groups whose evaluated value is
     truthy.  ``None`` for *node* is a no-op.
+
+    *default_methods* is forwarded to :class:`EvalContext` — see its
+    docstring for the per-kind default ``prediction_method_name`` kwarg
+    used to resolve unqualified Field references on multi-method inputs.
     """
     if node is None:
         return df
@@ -111,7 +115,7 @@ def apply_filter(df, node):
         return df.reset_index(drop=True)
 
     _validate_columns(df, node)
-    ctx = EvalContext(df)
+    ctx = EvalContext(df, default_methods=default_methods)
     # Reindex defensively so a misbehaving node (index mismatch) surfaces
     # as NaN → False rather than silently picking up rows from a
     # different MultiIndex alignment.
@@ -125,7 +129,7 @@ def apply_filter(df, node):
     return df[keep].reset_index(drop=True)
 
 
-def apply_sort(df, sort_nodes, sort_direction="auto"):
+def apply_sort(df, sort_nodes, sort_direction="auto", default_methods=None):
     """Sort groups by one or more DSL nodes (lexicographic fallthrough).
 
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
@@ -133,6 +137,9 @@ def apply_sort(df, sort_nodes, sort_direction="auto"):
     desc) when *sort_direction* is ``"auto"``; otherwise the string
     value is used for all nodes.  NaN values do not force an ordering —
     they fall through to the next tiebreaker.
+
+    *default_methods* is forwarded to :class:`EvalContext` — see its
+    docstring.
     """
     if not sort_nodes:
         return df
@@ -142,7 +149,7 @@ def apply_sort(df, sort_nodes, sort_direction="auto"):
     for node in sort_nodes:
         _validate_columns(df, node)
 
-    ctx = EvalContext(df)
+    ctx = EvalContext(df, default_methods=default_methods)
     n_groups = len(ctx.group_index)
     n_keys = len(sort_nodes)
     values_matrix = np.empty((n_groups, n_keys), dtype=float)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -146,10 +146,19 @@ def _normalize_default_methods(mapping):
             )
         kind = aliases.get(_kind_name(key).lower())
         if kind is None:
-            valid = sorted({_kind_value(k) for k in aliases.values()})
+            # Surface the canonical kind values and every DSL short
+            # alias so a user who typed 'banana' sees that 'ba' /
+            # 'affinity' / 'pMHC_affinity' all map to the same kind.
+            # The alias dict is lower-cased for case-insensitive
+            # lookup; skip lower-case duplicates of canonicals to
+            # keep the list readable.
+            canonical = {_kind_value(k) for k in aliases.values()}
+            canonical_lower = {c.lower() for c in canonical}
+            shorts = {a for a in aliases.keys() if a not in canonical_lower}
+            accepted = sorted(shorts | canonical)
             raise ValueError(
                 f"default_methods key {key!r} is not a known kind. "
-                f"Expected one of: {valid}"
+                f"Accepted spellings: {accepted}"
             )
         out[_kind_value(kind)] = method
     return out
@@ -571,7 +580,7 @@ class Field(DSLNode):
             if col in sub.columns:
                 method_lower = self.method.lower()
                 method_mask = sub[col].str.lower().str.contains(
-                    method_lower, na=False
+                    method_lower, na=False, regex=False
                 )
                 matched = sub[method_mask]
                 if matched.empty:
@@ -610,7 +619,7 @@ class Field(DSLNode):
                     col = "prediction_method_name"
                     default_lower = default.lower()
                     method_mask = sub[col].str.lower().str.contains(
-                        default_lower, na=False
+                        default_lower, na=False, regex=False
                     )
                     matched = sub[method_mask]
                     if matched.empty:

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -128,6 +128,32 @@ def _pick_group_keys(df):
     return list(_GROUP_KEYS)
 
 
+def _normalize_default_methods(mapping):
+    """Canonicalize ``default_methods`` keys to DataFrame ``kind`` values.
+
+    Accepts canonical names (``"pMHC_affinity"``), DSL short names
+    (``"affinity"``, ``"ba"``, ``"el"``, ...), and mhctools ``Kind``
+    constants.  Values are method strings passed through unchanged.
+    """
+    aliases = _build_kind_aliases()
+    out = {}
+    for key, method in mapping.items():
+        if not isinstance(method, str):
+            raise TypeError(
+                f"default_methods[{key!r}] must be a method name string, "
+                f"got {type(method).__name__}"
+            )
+        kind = aliases.get(_kind_name(key).lower())
+        if kind is None:
+            valid = sorted({_kind_value(k) for k in aliases.values()})
+            raise ValueError(
+                f"default_methods key {key!r} is not a known kind. "
+                f"Expected one of: {valid}"
+            )
+        out[_kind_value(kind)] = method
+    return out
+
+
 class EvalContext:
     """Context for vectorized DSL evaluation.
 
@@ -135,13 +161,44 @@ class EvalContext:
     MultiIndex.  Every :class:`DSLNode` ``.eval(ctx)`` returns a
     ``pd.Series`` indexed by this MultiIndex (one value per peptide
     -allele group).
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Prediction rows, long-form.
+    group_keys : list of str, optional
+        Override the auto-detected peptide-allele group keys.
+    default_methods : dict, optional
+        Per-kind default ``prediction_method_name`` for resolving
+        unqualified Field references when multiple methods produce
+        the same kind.  Keys may be canonical kind names
+        (``"pMHC_affinity"``), short names (``"affinity"``, ``"ba"``,
+        ``"el"``, ...), or mhctools ``Kind`` constants.  Without
+        this kwarg, ambiguous references raise ``ValueError`` — the
+        safety behavior is preserved by default.
+
+        Example::
+
+            ctx = EvalContext(
+                df,
+                default_methods={
+                    "pMHC_affinity": "mhcflurry",
+                    "pMHC_stability": "netmhcstabpan",
+                },
+            )
     """
 
-    __slots__ = ("df", "group_keys", "_group_index", "_group_tuples_cache")
+    __slots__ = (
+        "df", "group_keys", "default_methods",
+        "_group_index", "_group_tuples_cache",
+    )
 
-    def __init__(self, df, group_keys=None):
+    def __init__(self, df, group_keys=None, default_methods=None):
         self.df = df
         self.group_keys = list(group_keys) if group_keys else _pick_group_keys(df)
+        self.default_methods = (
+            _normalize_default_methods(default_methods) if default_methods else {}
+        )
         self._group_index = None
         self._group_tuples_cache = None
 
@@ -547,15 +604,32 @@ class Field(DSLNode):
                 ctx.group_keys, sort=False
             )["prediction_method_name"].nunique()
             if (methods_per_group > 1).any():
-                method_list = ", ".join(
-                    sorted(sub["prediction_method_name"].dropna().unique())
-                )
-                raise ValueError(
-                    f"Ambiguous: multiple models produce "
-                    f"{_kind_name(self.kind)} ({method_list}). "
-                    f"Use {_kind_short_name(self.kind)}['modelname'] "
-                    f"to disambiguate."
-                )
+                default = ctx.default_methods.get(_kind_value(self.kind))
+                if default is not None:
+                    col = "prediction_method_name"
+                    default_lower = default.lower()
+                    method_mask = sub[col].str.lower().str.contains(
+                        default_lower, na=False
+                    )
+                    matched = sub[method_mask]
+                    if matched.empty:
+                        available = sorted(sub[col].dropna().unique())
+                        raise _method_not_found_error(
+                            _kind_name(self.kind), default, available
+                        )
+                    sub = matched
+                else:
+                    method_list = ", ".join(
+                        sorted(sub["prediction_method_name"].dropna().unique())
+                    )
+                    raise ValueError(
+                        f"Ambiguous: multiple models produce "
+                        f"{_kind_name(self.kind)} ({method_list}). "
+                        f"Use {_kind_short_name(self.kind)}['modelname'] "
+                        f"to disambiguate, or pass "
+                        f"default_methods={{{_kind_value(self.kind)!r}: "
+                        f"'modelname'}} to EvalContext."
+                    )
 
         col_name = self.scope + self.field
         if col_name not in sub.columns:

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -103,6 +103,7 @@ def _build_kind_aliases(kind_source=Kind):
     aliases["ba"] = kind_source.pMHC_affinity
     aliases["aff"] = kind_source.pMHC_affinity
     aliases["ic50"] = kind_source.pMHC_affinity
+    aliases["processing"] = kind_source.antigen_processing
     return aliases
 
 


### PR DESCRIPTION
## Summary

Closes #140. Adds `default_methods` kwarg to `EvalContext` so unqualified `Affinity` / `Presentation` / etc. references can resolve cleanly on DataFrames with multiple `prediction_method_name` values per kind — the case that motivates the issue (LENS pipeline emits MHCflurry + netMHCpan + netMHCstabpan; vaxrank just shipped `subset_topiary_df_for_eval` as a downstream workaround).

```python
ctx = EvalContext(
    df,
    default_methods={"pMHC_affinity": "mhcflurry", "pMHC_stability": "netmhcstabpan"},
)
Affinity.value.eval(ctx)     # no ambiguity error
```

Additive — `EvalContext(df)` without the kwarg keeps the current strict ambiguity check.

## Changes

- `EvalContext(df, default_methods=...)` — stores a normalized `{kind_value: method_name}` dict.
- `Field.eval` consults it in the existing ambiguity branch before raising. Explicit `Affinity['netmhcpan']` qualification still wins over defaults.
- `apply_filter(df, node, default_methods=...)` and `apply_sort(df, nodes, default_methods=...)` forward the kwarg.
- Ambiguity `ValueError` message now points users at `default_methods` as the escape hatch.
- Keys accept canonical kind names (`"pMHC_affinity"`), DSL short names (`"affinity"`, `"ba"`, `"el"`, ...), or mhctools `Kind` constants.
- Unknown kind keys / non-string method values raise at `EvalContext` construction with an actionable message.

## Test plan

- [x] `EvalContext(df, default_methods={"pMHC_affinity": "mhcflurry"})` → `Affinity.value` resolves to mhcflurry's row
- [x] Same with `"netmhcpan"` → resolves to netmhcpan's row
- [x] Short name (`"affinity"`, `"ba"`) + `Kind.pMHC_affinity` all normalize correctly
- [x] Unknown method in default → `method_not_found` error with available list
- [x] Unknown kind key → `ValueError("not a known kind")`
- [x] Non-string method value → `TypeError`
- [x] Default for affinity doesn't silence presentation ambiguity on a multi-method presentation kind
- [x] Single-model frame ignores `default_methods` (no-op)
- [x] Explicit `Affinity['netmhcpan']` bracket still wins over default
- [x] `EvalContext(df)` without kwarg still raises `Ambiguous: multiple models`
- [x] Ambiguity error message mentions `default_methods`
- [x] `apply_filter(default_methods=...)` and `apply_sort(default_methods=...)` end-to-end
- [x] Full suite: `pytest tests/` → 1192 passed, 3 skipped