### PR TITLE
Filter-context auto-aggregation across methods (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## 5.10.0
 
+**Filter-context auto-aggregation across methods (#118):**
+
+- Inside `apply_filter` (and `TopiaryPredictor(filter_by=...)`), an
+  unqualified kind reference (`Affinity <= 500`, `presentation.rank <=
+  2.0`, ...) no longer raises `Ambiguous: multiple models produce ...`
+  when the DataFrame has multiple `prediction_method_name` values for
+  that kind. Instead, the comparison is evaluated per method and
+  combined via `nanmin` (for `<`/`<=`) or `nanmax` (for `>`/`>=`) —
+  the "any method passes" interpretation.
+- Scope is narrow on purpose: only directional `Comparison` nodes
+  (`<`, `<=`, `>`, `>=`), only when evaluated under a filter context
+  (`apply_filter` sets `EvalContext.filter_context=True`), only when
+  all unqualified refs in the comparison are the same kind. `==` /
+  `!=`, `apply_sort`, scalar score expressions, and cross-kind
+  comparisons (`affinity.rank <= processing.rank`) keep the strict
+  ambiguity error.
+- `EvalContext(df, filter_context=True)` is now public — callers who
+  hand-roll eval outside `apply_filter` can opt in explicitly.
+- Single-method frames take the strict path (no behavior change).
+- Complements `EvalContext(default_methods=...)` (#140): if a default
+  resolves the unqualified ref, `Field.eval` returns before this
+  branch runs, so `default_methods` takes precedence.
+
 **EvalContext `default_methods` for multi-predictor frames (#140):**
 
 - `EvalContext(df, default_methods={...})` — resolve unqualified
@@ -18,7 +41,10 @@
 Context: multi-predictor pipelines (e.g. LENS emitting MHCflurry
 + netMHCpan + netMHCstabpan) previously had to either qualify every
 DSL expression with `['modelname']` or pre-subset the DataFrame to one
-method per kind. `default_methods` is the declarative alternative.
+method per kind. `default_methods` is the declarative escape hatch;
+filter-context auto-agg is the pragmatic default for filter
+top-levels, while sort and score stay strict to avoid silent
+semantics on compound arithmetic like `0.5*ba.score + 0.5*el.score`.
 
 ## 5.9.0
 

--- a/tests/test_io_lens.py
+++ b/tests/test_io_lens.py
@@ -325,12 +325,20 @@ class TestDSLIntegration:
         top = sorted_df.iloc[0]
         assert isinstance(top["peptide"], str)
 
-    def test_unqualified_ambiguous_raises(self):
+    def test_unqualified_autoaggregates_in_filter(self):
         """v1.4 has two models producing pMHC_affinity — unqualified
-        access must error."""
+        access auto-aggregates (any method passes) inside apply_filter."""
+        r = read_lens(V1_4).to_long()
+        # No raise: auto-agg fires because the filter has exactly one
+        # unqualified kind.  Result is shape-valid.
+        result = apply_filter(r.df, Affinity <= 500)
+        assert len(result) >= 0
+
+    def test_unqualified_ambiguous_still_raises_in_sort(self):
+        """Sort keeps the strict ambiguity check — only filter auto-aggs."""
         r = read_lens(V1_4).to_long()
         with pytest.raises(ValueError, match="Ambiguous"):
-            apply_filter(r.df, Affinity <= 500)
+            apply_sort(r.df, [Affinity.value])
 
     def test_v1_9_unqualified_ok(self):
         """v1.9 has only MHCflurry → unqualified access works."""

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1063,6 +1063,174 @@ def test_apply_sort_accepts_default_methods():
     assert result.iloc[0]["peptide"] == "AAAA"
 
 
+# Filter-context auto-aggregation across methods  —  issue #118
+# ---------------------------------------------------------------------------
+
+
+def _multi_affinity_df():
+    """Two peptides, each with mhcflurry + netmhcpan affinity rows."""
+    return pd.DataFrame([
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+        dict(source_sequence_name="s", peptide="BBBB", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.3, value=600.0, percentile_rank=5.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="BBBB", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.5, value=800.0, percentile_rank=8.0,
+             prediction_method_name="netmhcpan"),
+    ])
+
+
+def test_autoagg_keeps_if_any_method_passes_le():
+    """AAAA passes (netmhcpan=120 <= 200); BBBB fails (both > 200)."""
+    df = _multi_affinity_df()
+    result = apply_filter(df, Affinity.value <= 200)
+    assert set(result["peptide"]) == {"AAAA"}
+    # Both method rows for AAAA are kept — apply_filter works per group.
+    assert len(result) == 2
+
+
+def test_autoagg_keeps_if_any_method_passes_ge():
+    """> / >= aggregate via nanmax: keep if any method meets the bar."""
+    df = _multi_affinity_df()
+    # BBBB's max(mhcflurry=600, netmhcpan=800) = 800 >= 700 → keep
+    # AAAA's max(350, 120) = 350 < 700 → drop
+    result = apply_filter(df, Affinity.value >= 700)
+    assert set(result["peptide"]) == {"BBBB"}
+
+
+def test_autoagg_nanmin_semantics_drop():
+    """Filter is strict on rows no method passes."""
+    df = _multi_affinity_df()
+    # Neither method passes <= 50 for any peptide.
+    result = apply_filter(df, Affinity.value <= 50)
+    assert len(result) == 0
+
+
+def test_autoagg_does_not_apply_in_sort():
+    """apply_sort keeps strict ambiguity — no silent aggregation."""
+    df = _multi_affinity_df()
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        apply_sort(df, [Affinity.value])
+
+
+def test_autoagg_does_not_apply_outside_filter():
+    """Evaluating a Comparison outside apply_filter stays strict."""
+    df = _multi_affinity_df()
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        (Affinity.value <= 200).evaluate(df)
+
+
+def test_autoagg_skipped_when_cross_kind():
+    """Two unqualified kinds in one comparison → strict (ambiguity raises)."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.6, value=350.0, percentile_rank=2.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="antigen_processing",
+             score=None, value=None, percentile_rank=3.0,
+             prediction_method_name="mhcflurry"),
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="antigen_processing",
+             score=None, value=None, percentile_rank=1.0,
+             prediction_method_name="netmhcpan"),
+    ])
+    from topiary.ranking import Processing
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        apply_filter(df, Affinity.rank <= Processing.rank)
+
+
+def test_autoagg_skipped_when_eq():
+    """Equality and inequality don't auto-aggregate — strict raises."""
+    df = _multi_affinity_df()
+    with pytest.raises(ValueError, match="Ambiguous.*multiple models"):
+        apply_filter(df, Comparison(Affinity.value, operator.eq, Const(120.0)))
+
+
+def test_autoagg_no_op_when_single_method():
+    """Single-method frames take the strict path — no behavior change."""
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="AAAA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity",
+             score=0.8, value=120.0, percentile_rank=0.5,
+             prediction_method_name="netmhcpan"),
+    ])
+    result = apply_filter(df, Affinity.value <= 200)
+    assert len(result) == 1
+
+
+def test_autoagg_qualified_side_mixed():
+    """Qualified LHS + Const RHS: strict path, qualified value used."""
+    df = _multi_affinity_df()
+    # mhcflurry-only: AAAA=350, BBBB=600 — both fail <= 200, keep none.
+    result = apply_filter(df, Affinity["mhcflurry"].value <= 200)
+    assert len(result) == 0
+    # netmhcpan-only: AAAA=120 (pass), BBBB=800 (fail).
+    result = apply_filter(df, Affinity["netmhcpan"].value <= 200)
+    assert set(result["peptide"]) == {"AAAA"}
+
+
+def test_autoagg_compound_bool_each_comparison_aggs():
+    """A BoolOp of Comparisons auto-aggs each comparison independently."""
+    df = _multi_affinity_df()
+    # AAAA: any(value<=200)=True and any(score>=0.5)=True (netmhcpan=0.8) → pass
+    # BBBB: any(value<=200)=False → drop
+    result = apply_filter(
+        df,
+        (Affinity.value <= 200) & (Affinity.score >= 0.5),
+    )
+    assert set(result["peptide"]) == {"AAAA"}
+
+
+def test_autoagg_const_on_left():
+    """Auto-agg mirrors when Const is on the left (e.g. `500 >= affinity`)."""
+    df = _multi_affinity_df()
+    # 200 >= affinity.value equivalent to affinity.value <= 200 → AAAA passes
+    result = apply_filter(df, Const(200) >= Affinity.value)
+    assert set(result["peptide"]) == {"AAAA"}
+
+
+def test_default_methods_takes_precedence_over_autoagg():
+    """#140 + #118 interaction: explicit default wins over auto-agg."""
+    df = _multi_affinity_df()
+    # Without default_methods: auto-agg fires — AAAA passes (netmhcpan=120 <= 200).
+    assert set(
+        apply_filter(df, Affinity.value <= 200)["peptide"]
+    ) == {"AAAA"}
+    # With mhcflurry default: Field resolves to mhcflurry-only values
+    # (AAAA=350, BBBB=600), both fail <= 200 — no rows pass.
+    result = apply_filter(
+        df, Affinity.value <= 200,
+        default_methods={"pMHC_affinity": "mhcflurry"},
+    )
+    assert len(result) == 0
+    # With netmhcpan default: AAAA=120 passes, BBBB=800 fails.
+    result = apply_filter(
+        df, Affinity.value <= 200,
+        default_methods={"pMHC_affinity": "netmhcpan"},
+    )
+    assert set(result["peptide"]) == {"AAAA"}
+    # Partial defaults (covering only one of multiple unqualified kinds
+    # in the same comparison) still fall through to auto-agg for the
+    # uncovered kind. Here every unqualified ref is pMHC_affinity, so
+    # the default covers them all — auto-agg is skipped.
+
+
+
 def test_bracket_norm_shorthand():
     """KindAccessor.norm() delegates to .value.norm()."""
     df = _multi_model_df()

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -115,7 +115,9 @@ def apply_filter(df, node, default_methods=None):
         return df.reset_index(drop=True)
 
     _validate_columns(df, node)
-    ctx = EvalContext(df, default_methods=default_methods)
+    ctx = EvalContext(
+        df, filter_context=True, default_methods=default_methods,
+    )
     # Reindex defensively so a misbehaving node (index mismatch) surfaces
     # as NaN → False rather than silently picking up rows from a
     # different MultiIndex alignment.

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -196,21 +196,35 @@ class EvalContext:
                     "pMHC_stability": "netmhcstabpan",
                 },
             )
+    filter_context : bool, optional
+        When true, directional ``Comparison`` nodes
+        (``<``, ``<=``, ``>``, ``>=``) with unqualified same-kind refs
+        auto-aggregate across methods (nanmin for ``<``/``<=``, nanmax
+        for ``>``/``>=``) instead of raising on ambiguity.
+        :func:`apply_filter` sets this to ``True`` automatically;
+        :func:`apply_sort` leaves it ``False`` so sort stays strict.
     """
 
     __slots__ = (
-        "df", "group_keys", "default_methods",
-        "_group_index", "_group_tuples_cache",
+        "df", "group_keys", "default_methods", "filter_context",
+        "_group_index", "_group_tuples_cache", "_method_override",
     )
 
-    def __init__(self, df, group_keys=None, default_methods=None):
+    def __init__(
+        self, df, group_keys=None, default_methods=None, filter_context=False,
+    ):
         self.df = df
         self.group_keys = list(group_keys) if group_keys else _pick_group_keys(df)
         self.default_methods = (
             _normalize_default_methods(default_methods) if default_methods else {}
         )
+        self.filter_context = filter_context
         self._group_index = None
         self._group_tuples_cache = None
+        # Internal: when Comparison auto-aggregates across methods, it
+        # binds Field(method=None, kind=K) references to a specific
+        # method per iteration by setting (kind_value, method_name) here.
+        self._method_override = None
 
     @property
     def group_index(self) -> pd.MultiIndex:
@@ -574,11 +588,19 @@ class Field(DSLNode):
         if sub.empty:
             return ctx.empty_series()
 
+        # Method binding: explicit self.method wins; else Comparison
+        # auto-agg may have set ctx._method_override for our kind.
+        effective_method = self.method
+        if effective_method is None:
+            override = ctx._method_override
+            if override is not None and override[0] == kind_val:
+                effective_method = override[1]
+
         # Filter by method substring (case-insensitive)
-        if self.method is not None:
+        if effective_method is not None:
             col = "prediction_method_name"
             if col in sub.columns:
-                method_lower = self.method.lower()
+                method_lower = effective_method.lower()
                 method_mask = sub[col].str.lower().str.contains(
                     method_lower, na=False, regex=False
                 )
@@ -586,7 +608,7 @@ class Field(DSLNode):
                 if matched.empty:
                     available = sorted(sub[col].dropna().unique())
                     raise _method_not_found_error(
-                        _kind_name(self.kind), self.method, available
+                        _kind_name(self.kind), effective_method, available
                     )
                 sub = matched
 
@@ -607,7 +629,7 @@ class Field(DSLNode):
 
         # Ambiguity: unqualified access with multiple methods in any group
         if (
-            self.method is None
+            effective_method is None
             and "prediction_method_name" in sub.columns
         ):
             methods_per_group = sub.groupby(
@@ -1173,6 +1195,22 @@ _CMP_SYMBOLS = {
     operator.ne: "!=",
 }
 
+_AGG_OPS = (operator.lt, operator.le, operator.gt, operator.ge)
+
+
+def _collect_unqualified_kinds(node):
+    """Canonical kind values of every unqualified Field ref in *node*."""
+    kinds = set()
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n is None:
+            continue
+        if isinstance(n, Field) and n.method is None:
+            kinds.add(_kind_value(n.kind))
+        stack.extend(n.child_nodes())
+    return kinds
+
 
 class Comparison(DSLNode):
     """Pointwise comparison between two DSL nodes.
@@ -1200,11 +1238,97 @@ class Comparison(DSLNode):
         return [self.left, self.right]
 
     def eval(self, ctx: EvalContext) -> pd.Series:
+        if self._should_auto_aggregate(ctx):
+            result = self._auto_aggregate(ctx)
+            if result is not None:
+                return result
         a = self.left.eval(ctx)
         b = self.right.eval(ctx)
         # pandas comparison returns False for NaN comparisons — matches
         # the intended "missing values fail the filter" behavior.
         return self.op(a, b)
+
+    def _should_auto_aggregate(self, ctx):
+        """Gate check for the narrow auto-aggregation scope (issue #118).
+
+        Fires only when the comparison is evaluated as a filter (not in
+        sort, not in scalar score arithmetic), the operator is a
+        directional inequality, and we haven't already entered the
+        per-method binding loop (no override set).
+
+        `default_methods` (issue #140) takes precedence: if every
+        unqualified kind reference in this comparison has a default,
+        `Field.eval` will resolve it cleanly without ambiguity — skip
+        auto-agg so the explicit user choice wins.
+        """
+        if not (
+            ctx.filter_context
+            and ctx._method_override is None
+            and self.op in _AGG_OPS
+        ):
+            return False
+        if ctx.default_methods:
+            kinds = (
+                _collect_unqualified_kinds(self.left)
+                | _collect_unqualified_kinds(self.right)
+            )
+            if kinds and kinds.issubset(ctx.default_methods):
+                return False
+        return True
+
+    def _auto_aggregate(self, ctx):
+        """Try to auto-aggregate across methods for this comparison.
+
+        Returns a boolean ``pd.Series`` indexed by ``ctx.group_index``
+        on success, or ``None`` to signal the caller should fall back
+        to strict per-side eval (which raises the ambiguity error
+        when warranted).
+        """
+        kinds = _collect_unqualified_kinds(self.left) | _collect_unqualified_kinds(
+            self.right
+        )
+        if len(kinds) != 1:
+            return None
+        kind_val = next(iter(kinds))
+
+        df = ctx.df
+        if df.empty or "kind" not in df.columns:
+            return None
+        kind_rows = df[df["kind"] == kind_val]
+        if "prediction_method_name" not in kind_rows.columns:
+            return None
+        methods = sorted(
+            kind_rows["prediction_method_name"].dropna().unique()
+        )
+        if len(methods) <= 1:
+            return None
+
+        left_per_method = []
+        right_per_method = []
+        saved_override = ctx._method_override
+        try:
+            for m in methods:
+                ctx._method_override = (kind_val, m)
+                left_per_method.append(self.left.eval(ctx))
+                right_per_method.append(self.right.eval(ctx))
+        finally:
+            ctx._method_override = saved_override
+
+        left_df = pd.concat(left_per_method, axis=1)
+        right_df = pd.concat(right_per_method, axis=1)
+
+        # For "lower is better" comparisons (<, <=), aggregate the LHS
+        # with nanmin and the RHS with nanmax — giving the "any method
+        # satisfies" interpretation the issue specifies.  Mirrored for
+        # >, >=.
+        if self.op in (operator.lt, operator.le):
+            left_agg = left_df.min(axis=1, skipna=True)
+            right_agg = right_df.max(axis=1, skipna=True)
+        else:
+            left_agg = left_df.max(axis=1, skipna=True)
+            right_agg = right_df.min(axis=1, skipna=True)
+
+        return self.op(left_agg, right_agg)
 
     def __repr__(self):
         sym = _CMP_SYMBOLS.get(self.op, "?")


### PR DESCRIPTION
## Summary

Closes #118. Inside `apply_filter`, a `Comparison` with unqualified same-kind refs auto-aggregates across methods instead of raising the ambiguity error:

```python
# On a frame with both mhcflurry and netmhcpan affinity rows:
apply_filter(df, Affinity <= 500)   # no raise
# Keeps groups where ANY method has value <= 500.
```

Aggregator is picked by the comparison direction:

| Operator | Aggregator | Equivalent OR expansion |
|---|---|---|
| `<`, `<=` | `nanmin` across methods | `(aff[m1] < k) \| (aff[m2] < k) \| ...` |
| `>`, `>=` | `nanmax` across methods | `(aff[m1] > k) \| (aff[m2] > k) \| ...` |

## Scope (narrow on purpose)

Auto-agg fires only when **all** of these hold:

1. The node is a `Comparison` with `<`, `<=`, `>`, or `>=`.
2. It's evaluated under a filter context (`apply_filter` sets `EvalContext.filter_context=True`).
3. All unqualified `Field` refs in the comparison are the same kind. Cross-kind (`affinity.rank <= processing.rank`) stays strict.
4. The DataFrame actually has >1 method for that kind. Single-method frames fast-path through strict eval.

`apply_sort`, scalar score arithmetic (`0.5 * ba.score + 0.5 * el.score`), `==` / `!=`, and qualified refs (`Affinity['netmhcpan'] <= 500`) all keep the current strict behavior.

## Changes

- `EvalContext(df, filter_context=False)` — public kwarg. `apply_filter` sets it to `True`.
- `EvalContext._method_override` — internal `(kind_value, method)` tuple the Comparison auto-agg loop sets when iterating per method.
- `Field.eval` honors `ctx._method_override` when `self.method is None` and kind matches.
- `Comparison.eval` — new `_should_auto_aggregate` gate + `_auto_aggregate` loop that evals both sides per method and aggregates LHS via nanmin/nanmax and RHS via the opposite (for the "any method pair" union interpretation).
- `_collect_unqualified_kinds(node)` — tree walker.
- CHANGELOG + version bump to 5.10.0.

## Back-compat

One test in `tests/test_io_lens.py` previously asserted `apply_filter(r.df, Affinity <= 500)` raised on a multi-model LENS frame. That was the behavior being relaxed. Replaced with:
- `test_unqualified_autoaggregates_in_filter` — verifies no raise + valid shape.
- `test_unqualified_ambiguous_still_raises_in_sort` — verifies the sort path keeps strict.

No other callers were relying on the filter-side raise.

## Test plan

- [x] `<=` / `<` auto-agg via nanmin; `>=` / `>` via nanmax
- [x] "Any method passes" — group kept; "no method passes" — group dropped
- [x] `apply_sort` still raises `Ambiguous` on unqualified multi-method refs
- [x] Bare `(Affinity.value <= 200).evaluate(df)` outside filter still raises
- [x] Cross-kind comparison (`Affinity.rank <= Processing.rank`) stays strict
- [x] `==` / `!=` stay strict
- [x] Single-method frame: no auto-agg overhead, same result
- [x] Qualified side (`Affinity['mhcflurry'] <= 200`) bypasses auto-agg
- [x] Compound boolean (`(aff <= 200) & (aff.score >= 0.5)`) auto-aggs each comparison
- [x] `Const >= Field` (Const on left) mirrors correctly
- [x] Full suite: `pytest tests/` → 1192 passed, 3 skipped