### PR TITLE
Accept bare IDENT in kind-qualified brackets (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 5.10.0
 
+**Bare identifier inside kind-qualified brackets (#119):**
+
+- The string DSL now accepts `affinity[netmhcpan]` and
+  `affinity[netmhcpan, "4.1b"]` in addition to the previously required
+  `affinity['netmhcpan']` / `affinity['netmhcpan', '4.1b']`.  Bare
+  identifiers read more cleanly in YAML configs, where
+  `"affinity[netmhcpan] <= 500"` drops the nested-quote gymnastics of
+  `"affinity['netmhcpan'] <= 500"`.
+- Non-IDENT values (e.g. a version string `"4.1b"` that starts with a
+  digit or contains a dot) still require quotes.
+- Fully backwards compatible — every previously-valid expression
+  still parses.  `to_expr_string()` continues to emit the
+  single-quoted canonical form, so round-trips stay deterministic.
+
 **Filter-context auto-aggregation across methods (#118):**
 
 - Inside `apply_filter` (and `TopiaryPredictor(filter_by=...)`), an

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1794,6 +1794,66 @@ def test_parse_expr_bracket_qualification():
     assert expr.method == "netmhcpan"
 
 
+# ---------------------------------------------------------------------------
+# Bare IDENT inside kind brackets  —  issue #119
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bare_ident_in_brackets():
+    """affinity[netmhcpan] parses the same as affinity['netmhcpan']."""
+    bare = parse("affinity[netmhcpan].score")
+    quoted = parse("affinity['netmhcpan'].score")
+    assert isinstance(bare, Field)
+    assert bare.method == "netmhcpan"
+    # Structural equivalence: same AST string
+    assert bare.to_ast_string() == quoted.to_ast_string()
+
+
+def test_parse_bare_ident_in_brackets_filter():
+    """YAML-friendly short form works in filter comparisons."""
+    expr = parse("affinity[netmhcpan] <= 500")
+    assert isinstance(expr, Comparison)
+    assert isinstance(expr.left, Field)
+    assert expr.left.method == "netmhcpan"
+
+
+def test_parse_bare_ident_version_still_quoted():
+    """Non-IDENT version strings (e.g. '4.1b') keep quotes."""
+    expr = parse('affinity[netmhcpan, "4.1b"].value')
+    assert isinstance(expr, Field)
+    assert expr.method == "netmhcpan"
+    assert expr.version == "4.1b"
+
+
+def test_parse_bare_ident_mixed_with_quoted():
+    """Mixed forms in the same bracket are allowed."""
+    expr = parse("affinity['netmhcpan', v4].value")
+    assert isinstance(expr, Field)
+    assert expr.method == "netmhcpan"
+    assert expr.version == "v4"
+
+
+def test_parse_bare_ident_on_kind_accessor_with_chain():
+    """Short form composes with transforms and fields."""
+    expr = parse("ba[mhcflurry].score.norm(0.5, 0.2)")
+    from topiary.ranking import NormExpr
+    assert isinstance(expr, NormExpr)
+
+
+def test_parse_bare_ident_roundtrip_emits_quoted():
+    """to_expr_string keeps the canonical single-quoted form."""
+    expr = parse("affinity[netmhcpan] <= 500")
+    # Round-trip should parse back to an equivalent tree.
+    reparsed = parse(expr.to_expr_string())
+    assert expr.to_ast_string() == reparsed.to_ast_string()
+
+
+def test_parse_bare_ident_rejects_number():
+    """Numeric token in bracket (without quotes) still errors."""
+    with pytest.raises(ValueError, match="STRING or IDENT"):
+        parse("affinity[netmhcpan, 4]")
+
+
 def test_parse_expr_norm_alias():
     """norm() is an alias for ascending_cdf()"""
     expr = parse("affinity.norm(500, 200)")

--- a/topiary/ranking/parser.py
+++ b/topiary/ranking/parser.py
@@ -10,7 +10,8 @@ Grammar (lowest precedence first)::
     term     := power (('*'|'/') power)*
     power    := unary ('**' power)?
     unary    := ('-' | '~') unary | postfix
-    postfix  := atom ('.' IDENT call? | '[' STRING (',' STRING)? ']')*
+    postfix  := atom ('.' IDENT call? | '[' BRACKET_ARG (',' BRACKET_ARG)? ']')*
+    BRACKET_ARG := STRING | IDENT   # bare idents read cleanly in YAML
     atom     := NUMBER | '(' top ')' | abs(expr) | agg(expr,...)
               | count(STR) | column(IDENT) | len
               | CONTEXT '.' scoped_atom | kind_ref | IDENT
@@ -169,6 +170,20 @@ class _Tokenizer:
             )
         return tok
 
+    def expect_string_or_ident(self):
+        """Bracket-arg primitive: accept ``'foo'`` or ``foo`` and return
+        the string value.  Used inside ``[...]`` for method/version
+        qualifiers where a bare identifier reads more cleanly than a
+        quoted string, especially in YAML.
+        """
+        tok = self.advance()
+        if tok[0] not in ("STRING", "IDENT"):
+            raise ValueError(
+                f"Expected STRING or IDENT but got {tok[0]} ({tok[1]!r}) "
+                f"in {self.text!r}"
+            )
+        return tok
+
 
 def _parser_as_node(x):
     """Coerce a parser result to a DSLNode."""
@@ -302,11 +317,11 @@ class _Parser:
                     node = self._apply_field_access(node, name)
             elif tok[0] == "LBRACKET":
                 self.tokenizer.advance()
-                method_tok = self.tokenizer.expect("STRING")
+                method_tok = self.tokenizer.expect_string_or_ident()
                 version = None
                 if self.tokenizer.peek()[0] == "COMMA":
                     self.tokenizer.advance()
-                    version_tok = self.tokenizer.expect("STRING")
+                    version_tok = self.tokenizer.expect_string_or_ident()
                     version = version_tok[1]
                 self.tokenizer.expect("RBRACKET")
                 node = self._apply_bracket(node, method_tok[1], version)
@@ -402,11 +417,11 @@ class _Parser:
             )
         if self.tokenizer.peek()[0] == "LBRACKET":
             self.tokenizer.advance()
-            method_tok = self.tokenizer.expect("STRING")
+            method_tok = self.tokenizer.expect_string_or_ident()
             version = None
             if self.tokenizer.peek()[0] == "COMMA":
                 self.tokenizer.advance()
-                version_tok = self.tokenizer.expect("STRING")
+                version_tok = self.tokenizer.expect_string_or_ident()
                 version = version_tok[1]
             self.tokenizer.expect("RBRACKET")
             accessor = accessor[method_tok[1], version] if version else accessor[method_tok[1]]


### PR DESCRIPTION
## Summary

Closes #119 (step 1 only — step 2 labels deferred until there's real demand).

The string DSL now accepts bare identifiers inside kind-qualified brackets in addition to the quoted form:

\`\`\`
affinity[netmhcpan] <= 500                    # new
affinity[netmhcpan, "4.1b"] <= 500            # version keeps quotes (not an IDENT)
affinity['netmhcpan'] <= 500                  # still parses
affinity['netmhcpan', '4.1b'].rank <= 2.0     # still parses
\`\`\`

Motivated by YAML-embedded configs (e.g. vaxrank scoring YAML), where \`"affinity[netmhcpan] <= 500"\` is much easier to read than \`"affinity['netmhcpan'] <= 500"\` with nested quote escaping.

## Changes

- \`_Tokenizer.expect_string_or_ident()\` — bracket-arg primitive that accepts either a STRING or IDENT token and returns it. Wraps the exact shape of \`expect()\`.
- \`_postfix\` (the chained \`[...]\` path) and \`_kind_accessor\` (the first-bracket path) now call the new helper at all four bracket-arg sites.
- Grammar comment updated: \`BRACKET_ARG := STRING | IDENT\`.
- \`to_expr_string()\` is unchanged — it still emits single-quoted canonical form, so round-trips and serialization are deterministic. The bare form is a read-only input sugar.

## Back-compat

Fully additive. Every previously-valid expression still parses. Error surface for genuinely invalid bracket args is clearer: \`parse("affinity[netmhcpan, 4]")\` → \`ValueError("Expected STRING or IDENT ...")\` instead of the old \`Expected STRING ...\`.

## Deferred (Step 2 of the issue)

Prometheus-style labels (\`affinity[predictor=netmhcpan, version="4.1b"]\`) are left out of this PR. They're the right escape hatch if positional order starts tripping users up, but Step 1 solves the immediate YAML ergonomics pain.

## Test plan

- [x] \`affinity[netmhcpan].score\` parses to \`Field(method="netmhcpan")\`; AST-equal to the quoted form
- [x] \`affinity[netmhcpan] <= 500\` parses as a Comparison with qualified LHS
- [x] \`affinity[netmhcpan, "4.1b"]\` carries method + version through
- [x] Mixed forms in one bracket (\`['netmhcpan', v4]\`) work
- [x] Bare form composes with \`.norm(...)\` transforms
- [x] \`to_expr_string()\` → re-parse round-trip is AST-equal
- [x] \`affinity[netmhcpan, 4]\` (number inside bracket) raises \`STRING or IDENT\`
- [x] Full suite: \`pytest tests/\` → 1187 passed, 3 skipped