### PR TITLE
Add biopython to requirements.txt (CI fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ varcode>=0.3.17
 gtfparse>=0.0.4
 mhcnames
 argcomplete>=1.10
+biopython>=1.80


### PR DESCRIPTION
## Summary

\`topiary.self_proteome\` imports \`from Bio.Align.substitution_matrices import load\` for BLOSUM62 scoring (added in v5.9.0, #138), but \`biopython\` was never added to \`requirements.txt\`. As a result, \`pip install -e .\` in CI does not pull it in, and any PR that exercises the \`test_self_proteome.py\` suite fails with:

\`\`\`
FAILED tests/test_self_proteome.py::TestNearest::test_exact_match_distance_zero - ModuleNotFoundError: No module named 'Bio'
... (17 failures)
\`\`\`

This is blocking CI on PRs #141, #142, #143, #144.

## Change

Add \`biopython>=1.80\` to \`requirements.txt\`. The 1.80 floor matches the \`substitution_matrices\` API surface and is conservative — any modern install will satisfy it.

No version bump; this is a declared-dependency correction, not a behavior change.

## Test plan

- [x] Local: \`import Bio; Bio.__version__\` → 1.84
- [ ] CI green on this branch after push