### PR TITLE
[codex] Improve CLI validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.10.1
+
+**CLI validation errors:**
+
+- Bare `topiary` invocations and other missing-argument validation
+  failures now render as normal argparse errors with usage text instead
+  of printing the full parsed namespace followed by a traceback.
+- Missing prediction requests report both required parts: an MHC source
+  (`--mhc-predictor` or cached predictions) and an input source.
+
 ## 5.10.0
 
 **`evaluate_scores(df, node)` — row-aligned DSL helper (#126):**

--- a/tests/test_cli_script.py
+++ b/tests/test_cli_script.py
@@ -1,0 +1,34 @@
+import pytest
+
+from topiary.cli.script import main
+
+
+def test_main_without_args_reports_cli_error(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main([])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "usage: topiary" in captured.err
+    assert "topiary: error:" in captured.err
+    assert "No prediction request specified" in captured.err
+    assert "--mhc-predictor" in captured.err
+    assert "No input specified" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Namespace(" not in captured.out
+
+
+def test_main_missing_mhc_source_reports_cli_error(tmp_path, capsys):
+    peptide_csv = tmp_path / "peptides.csv"
+    peptide_csv.write_text("peptide\nSLLQHLIGL\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--peptide-csv", str(peptide_csv)])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "usage: topiary" in captured.err
+    assert "--mhc-predictor" in captured.err
+    assert "--mhc-cache-file / --mhc-cache-directory" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Namespace(" not in captured.out

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.0"
+__version__ = "5.10.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -14,7 +14,7 @@
 Common commandline arguments used by scripts
 """
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import pandas as pd
 from mhctools.cli import add_mhc_args, predictors_from_args
@@ -192,6 +192,20 @@ def _add_input_args(arg_parser):
     return input_group
 
 
+MHC_SOURCE_ERROR = (
+    "Must supply either --mhc-predictor (live predictor) or "
+    "--mhc-cache-file / --mhc-cache-directory (cached predictions). "
+    "Both are missing."
+)
+
+INPUT_SOURCE_ERROR = (
+    "No input specified. Use one of: "
+    "--peptide-csv, --sequence-csv, --fasta, --peptide-fasta, "
+    "--gene-names, --gene-ids, --transcript-ids, --cta, "
+    "--ensembl-proteome, --vcf, --maf, --variant, --json-variants"
+)
+
+
 def create_arg_parser(
     rna=True,
     expression=True,
@@ -204,7 +218,22 @@ def create_arg_parser(
     output=True,
     direct_inputs=True,
 ):
-    arg_parser = ArgumentParser()
+    arg_parser = ArgumentParser(
+        prog="topiary",
+        description=(
+            "Predict, filter, and rank MHC-presented peptides from "
+            "sequence or variant inputs."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  topiary --mhc-predictor random --mhc-alleles A0201 "
+            "--peptide-csv peptides.csv --output-csv predictions.csv\n"
+            "  topiary --mhc-cache-file predictions.tsv "
+            "--mhc-cache-format topiary_output --peptide-csv peptides.csv\n\n"
+            "Run 'topiary --help' to see all options."
+        ),
+        formatter_class=RawDescriptionHelpFormatter,
+    )
     if expression:
         add_expression_args(arg_parser)
     if rna:
@@ -518,6 +547,40 @@ def _validate_input_modes(args):
         )
 
 
+def _has_prediction_input(args):
+    return any([
+        getattr(args, "peptide_csv", None),
+        getattr(args, "sequence_csv", None),
+        getattr(args, "fasta", None),
+        getattr(args, "peptide_fasta", None),
+        getattr(args, "gene_names", None),
+        getattr(args, "gene_ids", None),
+        getattr(args, "transcript_ids", None),
+        getattr(args, "cta", False),
+        getattr(args, "ensembl_proteome", False),
+        getattr(args, "vcf", None),
+        getattr(args, "maf", None),
+        getattr(args, "variant", None),
+        getattr(args, "json_variants", None),
+        getattr(args, "protein_change", None),
+    ])
+
+
+def _validate_required_prediction_args(args):
+    missing = []
+    if not cached_predictor_in_use(args) and not getattr(args, "mhc_predictor", None):
+        missing.append(MHC_SOURCE_ERROR)
+    if not _has_prediction_input(args):
+        missing.append(INPUT_SOURCE_ERROR)
+
+    if len(missing) > 1:
+        raise ValueError(
+            "No prediction request specified.\n\n" + "\n\n".join(missing)
+        )
+    if missing:
+        raise ValueError(missing[0])
+
+
 def predict_epitopes_from_args(args):
     """
     Returns an epitope collection from the given commandline arguments.
@@ -527,15 +590,11 @@ def predict_epitopes_from_args(args):
     args : argparse.Namespace
         Parsed commandline arguments for Topiary
     """
+    _validate_required_prediction_args(args)
+
     if cached_predictor_in_use(args):
         models = cached_predictor_from_args(args)
     else:
-        if not getattr(args, "mhc_predictor", None):
-            raise ValueError(
-                "Must supply either --mhc-predictor (live predictor) or "
-                "--mhc-cache-file / --mhc-cache-directory (cached "
-                "predictions).  Both are missing."
-            )
         models = predictors_from_args(args)
 
     filter_by, sort_by, sort_direction = _build_filter_and_sort(args)
@@ -572,12 +631,7 @@ def predict_epitopes_from_args(args):
         getattr(args, "protein_change", None),
     ])
     if not has_variant_input:
-        raise ValueError(
-            "No input specified. Use one of: "
-            "--peptide-csv, --sequence-csv, --fasta, --peptide-fasta, "
-            "--gene-names, --gene-ids, --transcript-ids, --cta, "
-            "--ensembl-proteome, --vcf, --maf, --variant, --json-variants"
-        )
+        raise ValueError(INPUT_SOURCE_ERROR)
 
     # Use variant pipeline
     variants = variant_collection_from_args(args)

--- a/topiary/cli/script.py
+++ b/topiary/cli/script.py
@@ -48,8 +48,10 @@ def main(args_list=None):
     Topiary.
     """
     args = parse_args(args_list)
-    print("Topiary commandline arguments:")
-    print(args)
-    df = predict_epitopes_from_args(args)
+    try:
+        df = predict_epitopes_from_args(args)
+    except (OSError, ValueError) as e:
+        arg_parser.error(str(e))
     write_outputs(df, args)
     print("Total count: %d" % len(df))
+    return 0


### PR DESCRIPTION
## Summary

This PR improves the user-facing CLI error path for missing prediction requests.

- Stops printing the full parsed argparse namespace before every run.
- Converts ValueError and OSError failures from the CLI prediction pipeline into normal argparse errors with usage text and exit code 2.
- Adds upfront validation for missing MHC source and missing input source so bare topiary reports both required parts instead of surfacing a traceback.
- Adds regression coverage for bare topiary and missing MHC source errors.
- Bumps the package version to 5.10.1 and updates the changelog.

## Root Cause

script.main printed parsed arguments unconditionally and let validation errors raised from predict_epitopes_from_args escape as normal Python exceptions. That made missing-argument mistakes look like internal crashes.

## Validation

- ./lint.sh
- ./test.sh (1239 passed, 3 skipped, 11 warnings)