### PR TITLE
[codex] Add optional WT peptide prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   aligned.
 - Rows without a length-compatible WT peptide keep NaN `wt_*`
   prediction values.
+- The CLI now exposes the same behavior with `--predict-wt`, enabling
+  `wt.*` sort expressions on variant-derived outputs.
 
 ## 5.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.10.2
+
+**Wildtype MHC scoring (#123):**
+
+- `TopiaryPredictor(predict_wt=True)` now scores populated
+  `wt_peptide` values with the configured MHC model(s) and attaches
+  `wt_value`, `wt_score`, `wt_affinity`, `wt_percentile_rank`,
+  `wt_prediction_method_name`, and `wt_predictor_version`.
+- WT predictions are joined back by allele, peptide length, prediction
+  kind, method, and version so affinity and presentation rows stay
+  aligned.
+- Rows without a length-compatible WT peptide keep NaN `wt_*`
+  prediction values.
+
 ## 5.10.1
 
 **CLI validation errors:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   prediction values.
 - The CLI now exposes the same behavior with `--predict-wt`, enabling
   `wt.*` sort expressions on variant-derived outputs.
+- WT scoring uses the baseline protein context, not isolated peptide
+  scoring, so context-sensitive predictors keep the correct flanks.
 
 ## 5.10.1
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ from topiary import Affinity, wt
 sort_by = Affinity.score - wt.Affinity.score  # mutant advantage
 ```
 
+For CLI variant runs, add `--predict-wt` before using `wt.*` in
+`--sort-by`:
+
+```bash
+--predict-wt --sort-by "affinity.score - wt.affinity.score"
+```
+
 `shuffled.` and `self.` prefixes work the same way for shuffled-decoy and self-proteome contexts.
 
 ### Peptide-level expressions

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Remove peptides found in reference proteomes — for tumor-specific or pathogen-
 
 **All predictions:** `source_sequence_name`, `peptide`, `peptide_offset`, `peptide_length`, `allele`, `kind`, `score`, `value`, `affinity`, `percentile_rank`, `prediction_method_name`
 
-**ProteinFragment predictions add** (both `predict_from_fragments` and the variant-based methods that build fragments internally): `fragment_id`, `source_type`, `overlaps_target`, `wt_peptide`, `wt_peptide_length`, plus any fragment-level annotations flattened to columns.
+**ProteinFragment predictions add** (both `predict_from_fragments` and the variant-based methods that build fragments internally): `fragment_id`, `source_type`, `overlaps_target`, `wt_peptide`, `wt_peptide_length`, plus any fragment-level annotations flattened to columns. With `TopiaryPredictor(predict_wt=True)`, they also add WT prediction columns such as `wt_value`, `wt_score`, `wt_affinity`, and `wt_percentile_rank`.
 
 **Variant predictions additionally add:** `variant`, `gene`, `gene_id`, `transcript_id`, `transcript_name`, `effect`, `effect_type`, `contains_mutant_residues`, `mutation_start_in_peptide`, `mutation_end_in_peptide`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ Boolean and numeric nodes compose freely — `(Affinity <= 500) * Affinity.score
 
 ## wt (scope prefix)
 
-Wildtype scope prefix. Reads `wt_*` columns for ranking expressions:
+Wildtype scope prefix. Reads `wt_*` columns for ranking expressions. For `predict_from_fragments()` and variant-derived predictions, `TopiaryPredictor(predict_wt=True)` populates WT prediction columns by scoring `wt_peptide` with the configured MHC model(s):
 
 ```python
 # Python API (capitalized kind names)
@@ -134,7 +134,7 @@ wt.Affinity["netmhcpan"].score    # qualified WT
 # wt.affinity["netmhcpan"].score
 ```
 
-For ranking expressions only (not filters). Returns NaN when WT columns absent.
+For ranking expressions only (not filters). Returns NaN when WT columns are absent or the row has no length-compatible WT peptide.
 
 ## len and count()
 

--- a/docs/expression-semantics.md
+++ b/docs/expression-semantics.md
@@ -224,21 +224,16 @@ The `wt.`, `shuffled.`, and `self.` scope prefixes read predictions for comparis
 **What the predictor needs to do:**
 
 1. During `predict_from_variants(effects)`: retain the reference protein sequence from each varcode effect, extract WT peptides at the same offsets as mutant peptides, store as `wt_peptide` column
-2. `predictor.predict_wildtype(df)`: re-run all models on the `wt_peptide` column, add `wt_value`, `wt_score`, `wt_percentile_rank` (per kind x method), add `wt_peptide_length`
+2. With `TopiaryPredictor(predict_wt=True)`: re-run the configured models on populated `wt_peptide` values and add `wt_value`, `wt_score`, `wt_percentile_rank` (per kind x method), and `wt_peptide_length`
 
 ```python
-# Automatic: predictor generates wt_peptide during variant prediction
+predictor = TopiaryPredictor(
+    models=[...],
+    alleles=[...],
+    predict_wt=True,
+)
 df = predictor.predict_from_variants(variants)
-# df now has wt_peptide column
-
-# Then score the WT peptides with the same models
-df = predictor.predict_wildtype(df)
-# Adds wt_value, wt_score, wt_percentile_rank
-
-# Or: user provides wt_peptide in a CSV
-df = predictor.predict_from_named_peptides({"pep1": "YLQLVFGIEV"})
-df["wt_peptide"] = "YLQLIFGIEV"  # user knows the WT
-df = predictor.predict_wildtype(df)
+# Adds wt_peptide plus wt_value, wt_score, wt_percentile_rank, ...
 ```
 
 **Loading WT data from external tools:**
@@ -251,10 +246,11 @@ df = predictor.predict_wildtype(df)
 --variant-expression wt_peptide:pvacseq_results.tsv:variant:"WT Epitope Seq"
 ```
 
-In the Python API, any DataFrame column named `wt_peptide` can be scored:
+In the Python API, fragment and variant predictions can score generated `wt_peptide` values:
+
 ```python
-df["wt_peptide"] = load_wt_peptides_from_pvactools("pvacseq.tsv")
-df = predictor.predict_wildtype(df)
+predictor = TopiaryPredictor(models=[...], alleles=[...], predict_wt=True)
+df = predictor.predict_from_fragments(fragments)
 ```
 
 ### Shuffled (shuffled.)
@@ -320,7 +316,7 @@ df = predictor.predict_self_match(df)  # just re-predicts the self_peptide colum
 ### Loading comparison data from external tools
 
 All three comparison types can be populated from external tool outputs instead of computed by topiary. The pattern is always: load a column into the DataFrame, then either:
-- Re-predict it with topiary's models (`predictor.predict_wildtype(df)`)
+- Re-predict it with topiary's models where that comparison has predictor support (`TopiaryPredictor(predict_wt=True)` for fragment / variant WT peptides)
 - Or load pre-computed predictions directly as columns
 
 ```python
@@ -704,7 +700,7 @@ The old flags would remain as deprecated aliases during a transition period.
 | `WT()` wrapper | **Removed** — replaced by `wt.` prefix |
 | `len` | Precomputed column (`peptide_length` / `wt_peptide_length`) |
 | `count("X")` | Dynamic — reads peptide string at eval time |
-| Comparison peptides | Explicit methods: `predict_wildtype()`, `predict_shuffled()`, `predict_self_match()` — no generic abstraction |
+| Comparison peptides | Explicit comparison-specific support: `TopiaryPredictor(predict_wt=True)` for WT fragment / variant peptides, `predict_shuffled()`, `predict_self_match()` — no generic abstraction |
 | Missing context | NaN at eval time, warning at build time |
 | Backward compat for `WT()` | **None** — clean break |
 | Expression loading | `--gene-expression`, `--transcript-expression`, `--variant-expression` (join key baked into flag) |

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -39,6 +39,7 @@ Output DataFrame columns, beyond the standard prediction fields:
 | `overlaps_target` | `True` / `False` / NaN — whether the peptide overlaps any of the fragment's target intervals |
 | `contains_mutant_residues` | Backwards-compat alias — `True` iff `source_type.startswith("variant")` AND `overlaps_target` is True |
 | `wt_peptide`, `wt_peptide_length` | Derived by slicing `effective_baseline` at the peptide's offset. Only populated for substitution-compatible fragments (baseline and `sequence` the same length); `None` otherwise or when no baseline exists. |
+| `wt_value`, `wt_score`, `wt_affinity`, `wt_percentile_rank`, `wt_prediction_method_name`, `wt_predictor_version` | Populated when `TopiaryPredictor(predict_wt=True)` scores non-null `wt_peptide` values with the configured MHC model(s). Rows without a length-compatible WT peptide keep NaN values. |
 | *(each annotation key)* | Flattened from every fragment's `annotations` dict. Underscore-prefixed keys (e.g. `_subsequence_offset`) are reserved for internal plumbing and never surface as columns. |
 
 ## source_type vocabulary (recommended, not enforced)
@@ -166,7 +167,6 @@ Prefix is sanitized to `[A-Za-z0-9._:-]`; runs of other characters collapse to `
 
 ## What's not in this release
 
-- **WT model predictions** (`wt_value`, `wt_score`, `wt_percentile_rank`) — `wt_peptide` is derived but not fed through the MHC predictor. `wt.Affinity.score` returns NaN until a future PR populates these.
 - **Coordinate remapping for indel / frameshift `wt_peptide`** — `wt_peptide` is only populated when the baseline is the same length as the mutant sequence (substitution-compatible). Length-changing edits yield `None` until remapping lands.
 - **Nearest-self compute** — the scope is reserved but no Topiary module produces the columns. Populate externally for now.
 - **Format-specific loaders** (`read_pvacseq_fragments`, `read_isovar_fragments`, `read_exacto_fragments`) — each ~50-100 lines on top of the core abstraction; separate PRs. `read_lens` is already shipped (5.1.0).

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -164,18 +164,17 @@ Only numeric columns can be used in ranking expressions.
 
 ## wt. — wildtype comparison
 
-> **Not yet implemented.** Topiary populates `wt_peptide` (the
-> wildtype sequence at the same position) but does not yet run the MHC
-> predictor on it. `wt.Affinity.score` and other `wt.*` expressions
-> return NaN until `TopiaryPredictor(predict_wt=True)` ships (tracked
-> as [#123](https://github.com/openvax/topiary/issues/123)). The
-> syntax below is correct and will work once WT predictions are
-> populated.
-
-The `wt.` scope prefix reads wildtype prediction columns (`wt_value`, `wt_score`, `wt_percentile_rank`). These columns will be populated when `predict_wt=True` is implemented:
+The `wt.` scope prefix reads wildtype prediction columns (`wt_value`, `wt_score`, `wt_percentile_rank`). For `predict_from_fragments()` and the variant-based APIs that build fragments internally, pass `predict_wt=True` to score each populated `wt_peptide` with the same MHC model(s):
 
 ```python
-from topiary import Affinity, wt
+from topiary import Affinity, TopiaryPredictor, wt
+
+predictor = TopiaryPredictor(
+    models=[...],
+    alleles=[...],
+    predict_wt=True,
+)
+df = predictor.predict_from_variants(variants)
 
 # Read WT binding values (Python API — capitalized kind names)
 wt.Affinity.value                         # wt_value column
@@ -199,7 +198,7 @@ affinity.score - wt.affinity.score
 ```
 
 !!! note
-    `wt.` is for **sorting expressions only**, not filters. Use it in `sort_by`, not in `filter`. When WT columns don't exist (non-variant inputs), expressions evaluate to NaN.
+    `wt.` is for **sorting expressions only**, not filters. Use it in `sort_by`, not in `filter`. When WT columns don't exist, expressions evaluate to NaN. Rows without a length-compatible WT peptide also keep NaN WT prediction values.
 
 ## len and count() — peptide-level expressions
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -197,6 +197,13 @@ wt.affinity["netmhcpan"].score
 affinity.score - wt.affinity.score
 ```
 
+In the CLI, pass `--predict-wt` with variant-derived inputs before
+using `wt.*` in `--sort-by`:
+
+```bash
+topiary ... --predict-wt --sort-by "affinity.score - wt.affinity.score"
+```
+
 !!! note
     `wt.` is for **sorting expressions only**, not filters. Use it in `sort_by`, not in `filter`. When WT columns don't exist, expressions evaluate to NaN. Rows without a length-compatible WT peptide also keep NaN WT prediction values.
 

--- a/tests/test_predict_from_fragments.py
+++ b/tests/test_predict_from_fragments.py
@@ -159,6 +159,77 @@ class DuplicateIdentityPredictor:
         return pd.DataFrame(rows)
 
 
+class ContextSensitivePredictor:
+    """Predictor whose score depends on source-protein flank context."""
+
+    default_peptide_lengths = [4]
+
+    def _row(self, name, sequence, offset):
+        peptide = sequence[offset:offset + 4]
+        n_flank = sequence[:offset]
+        c_flank = sequence[offset + 4:]
+        value = len(n_flank) + (10 * len(c_flank))
+        return {
+            "source_sequence_name": name,
+            "offset": offset,
+            "peptide": peptide,
+            "allele": ALLELE,
+            "kind": "pMHC_presentation",
+            "value": float(value),
+            "score": float(value) / 100.0,
+            "affinity": math.nan,
+            "percentile_rank": float(value),
+            "predictor_name": "context-sensitive",
+            "predictor_version": "1.0",
+            "n_flank": n_flank,
+            "c_flank": c_flank,
+        }
+
+    def predict_peptides_dataframe(self, peptides):
+        return pd.DataFrame([
+            {
+                "peptide": peptide,
+                "allele": ALLELE,
+                "kind": "pMHC_presentation",
+                "value": -1.0,
+                "score": -1.0,
+                "affinity": math.nan,
+                "percentile_rank": -1.0,
+                "predictor_name": "context-sensitive",
+                "predictor_version": "1.0",
+                "n_flank": "",
+                "c_flank": "",
+            }
+            for peptide in peptides
+        ])
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        rows = []
+        for name, sequence in name_to_sequence.items():
+            for offset in range(len(sequence) - 3):
+                rows.append(self._row(name, sequence, offset))
+        return pd.DataFrame(rows)
+
+
+class AmbiguousWtContextPredictor(ContextSensitivePredictor):
+    """Emits an extra WT row from the wrong flank context."""
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        df = super().predict_proteins_dataframe(name_to_sequence)
+        extras = []
+        for _, row in df[df["peptide"].eq("YYYY")].iterrows():
+            wrong = row.copy()
+            wrong["value"] = 999.0
+            wrong["score"] = 9.99
+            wrong["percentile_rank"] = 999.0
+            wrong["n_flank"] = "WRONG"
+            wrong["c_flank"] = "WRONG"
+            extras.append(wrong)
+        if extras:
+            df = pd.concat([df, pd.DataFrame(extras)], ignore_index=True)
+        return df
+
+
 def _predictor(lengths=(9,), **kwargs):
     return TopiaryPredictor(
         models=RandomBindingPredictor(
@@ -462,6 +533,35 @@ class TestWtPeptide:
             (1.0, 101.0),
             (2.0, 202.0),
         }
+
+    def test_predict_wt_true_scores_wt_in_baseline_protein_context(self):
+        f = ProteinFragment.from_variant(
+            sequence="AAAXXXXBB",
+            reference_sequence="CCCYYYYDD",
+            mutation_start=3, mutation_end=7, inframe=True,
+        )
+        df = TopiaryPredictor(
+            models=ContextSensitivePredictor(), predict_wt=True,
+        ).predict_from_fragments([f])
+        row = df[df["peptide"].eq("XXXX")].iloc[0]
+        assert row["n_flank"] == "AAA"
+        assert row["c_flank"] == "BB"
+        assert row["wt_peptide"] == "YYYY"
+        # WT baseline context is CCC + YYYY + DD:
+        # len("CCC") + 10 * len("DD") = 23.
+        assert row["wt_value"] == 23.0
+
+    def test_predict_wt_true_filters_wt_rows_to_baseline_flank_context(self):
+        f = ProteinFragment.from_variant(
+            sequence="AAAXXXXBB",
+            reference_sequence="CCCYYYYDD",
+            mutation_start=3, mutation_end=7, inframe=True,
+        )
+        df = TopiaryPredictor(
+            models=AmbiguousWtContextPredictor(), predict_wt=True,
+        ).predict_from_fragments([f])
+        row = df[df["peptide"].eq("XXXX")].iloc[0]
+        assert row["wt_value"] == 23.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_from_fragments.py
+++ b/tests/test_predict_from_fragments.py
@@ -115,6 +115,50 @@ class LengthStrictPredictor:
         return pd.DataFrame(rows)
 
 
+class DuplicateIdentityPredictor:
+    """Same public method/version across instances, different scores."""
+
+    default_peptide_lengths = [8]
+
+    def __init__(self, mutant_value, wt_value):
+        self.mutant_value = mutant_value
+        self.wt_value = wt_value
+
+    def _prediction_rows(self, peptide, source_sequence_name=None, offset=0):
+        if peptide == "SIINFEKL":
+            value = self.mutant_value
+        elif peptide == "GILGFVFT":
+            value = self.wt_value
+        else:
+            raise ValueError(f"Unexpected peptide {peptide!r}")
+        return [{
+            "source_sequence_name": source_sequence_name,
+            "offset": offset,
+            "peptide": peptide,
+            "allele": ALLELE,
+            "kind": "pMHC_affinity",
+            "value": value,
+            "score": value / 100.0,
+            "affinity": value,
+            "percentile_rank": value,
+            "predictor_name": "duplicate-identity",
+            "predictor_version": "1.0",
+        }]
+
+    def predict_peptides_dataframe(self, peptides):
+        rows = []
+        for peptide in peptides:
+            rows.extend(self._prediction_rows(peptide))
+        return pd.DataFrame(rows)
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        rows = []
+        for name, sequence in name_to_sequence.items():
+            peptide = sequence[:8]
+            rows.extend(self._prediction_rows(peptide, name, 0))
+        return pd.DataFrame(rows)
+
+
 def _predictor(lengths=(9,), **kwargs):
     return TopiaryPredictor(
         models=RandomBindingPredictor(
@@ -398,6 +442,26 @@ class TestWtPeptide:
             assert not rows.empty
             assert set(rows["peptide_length"]) == {length}
             assert set(rows["wt_peptide_length"]) == {length}
+
+    def test_predict_wt_true_keeps_duplicate_predictor_instances_separate(self):
+        f = ProteinFragment.from_variant(
+            sequence="SIINFEKL",
+            reference_sequence="GILGFVFT",
+            mutation_start=0, mutation_end=8, inframe=True,
+        )
+        df = TopiaryPredictor(
+            models=[
+                DuplicateIdentityPredictor(mutant_value=1.0, wt_value=101.0),
+                DuplicateIdentityPredictor(mutant_value=2.0, wt_value=202.0),
+            ],
+            predict_wt=True,
+        ).predict_from_fragments([f])
+        assert len(df) == 2
+        assert "_topiary_model_key" not in df.columns
+        assert set(zip(df["value"], df["wt_value"])) == {
+            (1.0, 101.0),
+            (2.0, 202.0),
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_from_fragments.py
+++ b/tests/test_predict_from_fragments.py
@@ -14,17 +14,71 @@ from topiary import (
     apply_filter,
     apply_sort,
     self_nearest,
+    wt,
 )
 
 
 ALLELE = "HLA-A*02:01"
 
 
-def _predictor(lengths=(9,)):
+class MultiKindPredictor:
+    """Small deterministic predictor with affinity and presentation rows."""
+
+    default_peptide_lengths = [8]
+
+    def __init__(self):
+        self.values = {
+            "SIINFEKL": {
+                "pMHC_affinity": 1.0,
+                "pMHC_presentation": 2.0,
+            },
+            "GILGFVFT": {
+                "pMHC_affinity": 10.0,
+                "pMHC_presentation": 20.0,
+            },
+        }
+
+    def _prediction_rows(self, peptide):
+        rows = []
+        for kind, value in self.values[peptide].items():
+            rows.append({
+                "peptide": peptide,
+                "allele": ALLELE,
+                "kind": kind,
+                "value": value,
+                "score": value / 100.0,
+                "affinity": value if kind == "pMHC_affinity" else math.nan,
+                "percentile_rank": value,
+                "predictor_name": "multi-kind",
+                "predictor_version": "1.0",
+            })
+        return rows
+
+    def predict_peptides_dataframe(self, peptides):
+        rows = []
+        for peptide in peptides:
+            rows.extend(self._prediction_rows(peptide))
+        return pd.DataFrame(rows)
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        rows = []
+        for name, sequence in name_to_sequence.items():
+            for offset in range(len(sequence) - 7):
+                peptide = sequence[offset:offset + 8]
+                for row in self._prediction_rows(peptide):
+                    row = row.copy()
+                    row["source_sequence_name"] = name
+                    row["offset"] = offset
+                    rows.append(row)
+        return pd.DataFrame(rows)
+
+
+def _predictor(lengths=(9,), **kwargs):
     return TopiaryPredictor(
         models=RandomBindingPredictor(
             alleles=[ALLELE], default_peptide_lengths=list(lengths),
         ),
+        **kwargs,
     )
 
 
@@ -214,6 +268,76 @@ class TestWtPeptide:
         df = _predictor().predict_from_fragments([f])
         aff = df[df["kind"] == "pMHC_affinity"]
         assert aff["wt_peptide"].isna().all()
+
+    def test_predict_wt_false_does_not_score_wt_peptides(self):
+        f = ProteinFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            reference_sequence="MAAGVTDVGMAA",
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        df = _predictor().predict_from_fragments([f])
+        assert "wt_score" not in df.columns
+        assert "wt_value" not in df.columns
+
+    def test_predict_wt_true_scores_wt_peptides(self):
+        f = ProteinFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            reference_sequence="MAAGVTDVGMAA",
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        df = _predictor(predict_wt=True).predict_from_fragments([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        for col in (
+            "wt_value", "wt_score", "wt_affinity", "wt_percentile_rank",
+            "wt_prediction_method_name", "wt_predictor_version",
+        ):
+            assert col in aff.columns
+            assert aff[col].notna().all()
+
+    def test_predict_wt_true_leaves_length_changing_wt_predictions_nan(self):
+        f = ProteinFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            reference_sequence="MAAGVTDVGMA",
+            mutation_start=10, mutation_end=12, inframe=True,
+        )
+        df = _predictor(predict_wt=True).predict_from_fragments([f])
+        aff = df[df["kind"] == "pMHC_affinity"]
+        assert aff["wt_peptide"].isna().all()
+        assert aff["wt_score"].isna().all()
+        assert aff["wt_value"].isna().all()
+
+    def test_predict_wt_true_allows_wt_sort_expression(self):
+        f = ProteinFragment.from_variant(
+            sequence="MAAGVTDVGMAV",
+            reference_sequence="MAAGVTDVGMAA",
+            mutation_start=11, mutation_end=12, inframe=True,
+        )
+        pred = TopiaryPredictor(
+            models=RandomBindingPredictor(
+                alleles=[ALLELE], default_peptide_lengths=[9],
+            ),
+            predict_wt=True,
+            sort_by=[Affinity.score - wt.Affinity.score],
+        )
+        df = pred.predict_from_fragments([f])
+        assert not df.empty
+        assert df["wt_score"].notna().all()
+
+    def test_predict_wt_true_aligns_multi_kind_rows(self):
+        """WT predictions join by kind and predictor identity, so an
+        affinity row does not pick up the WT presentation value."""
+        f = ProteinFragment.from_variant(
+            sequence="SIINFEKL",
+            reference_sequence="GILGFVFT",
+            mutation_start=0, mutation_end=8, inframe=True,
+        )
+        df = TopiaryPredictor(
+            models=MultiKindPredictor(), predict_wt=True,
+        ).predict_from_fragments([f])
+        assert len(df) == 2
+        by_kind = df.set_index("kind")
+        assert by_kind.loc["pMHC_affinity", "wt_value"] == 10.0
+        assert by_kind.loc["pMHC_presentation", "wt_value"] == 20.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_from_fragments.py
+++ b/tests/test_predict_from_fragments.py
@@ -73,6 +73,48 @@ class MultiKindPredictor:
         return pd.DataFrame(rows)
 
 
+class LengthStrictPredictor:
+    """Predictor that raises if asked to score unsupported lengths."""
+
+    def __init__(self, peptide_length):
+        self.peptide_length = peptide_length
+        self.default_peptide_lengths = [peptide_length]
+
+    def _prediction_rows(self, peptide, source_sequence_name=None, offset=0):
+        if len(peptide) != self.peptide_length:
+            raise ValueError(
+                f"strict-{self.peptide_length} cannot score {len(peptide)}mers"
+            )
+        return [{
+            "source_sequence_name": source_sequence_name,
+            "offset": offset,
+            "peptide": peptide,
+            "allele": ALLELE,
+            "kind": "pMHC_affinity",
+            "value": float(self.peptide_length),
+            "score": float(self.peptide_length) / 100.0,
+            "affinity": float(self.peptide_length),
+            "percentile_rank": float(self.peptide_length),
+            "predictor_name": f"strict-{self.peptide_length}",
+            "predictor_version": "1.0",
+        }]
+
+    def predict_peptides_dataframe(self, peptides):
+        rows = []
+        for peptide in peptides:
+            rows.extend(self._prediction_rows(peptide))
+        return pd.DataFrame(rows)
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        rows = []
+        length = self.peptide_length
+        for name, sequence in name_to_sequence.items():
+            for offset in range(len(sequence) - length + 1):
+                peptide = sequence[offset:offset + length]
+                rows.extend(self._prediction_rows(peptide, name, offset))
+        return pd.DataFrame(rows)
+
+
 def _predictor(lengths=(9,), **kwargs):
     return TopiaryPredictor(
         models=RandomBindingPredictor(
@@ -338,6 +380,24 @@ class TestWtPeptide:
         by_kind = df.set_index("kind")
         assert by_kind.loc["pMHC_affinity", "wt_value"] == 10.0
         assert by_kind.loc["pMHC_presentation", "wt_value"] == 20.0
+
+    def test_predict_wt_true_filters_wt_peptides_by_model_length(self):
+        f = ProteinFragment.from_variant(
+            sequence="SIINFEKLA",
+            reference_sequence="GILGFVFTA",
+            mutation_start=0, mutation_end=9, inframe=True,
+        )
+        df = TopiaryPredictor(
+            models=[LengthStrictPredictor(8), LengthStrictPredictor(9)],
+            predict_wt=True,
+        ).predict_from_fragments([f])
+        assert set(df["prediction_method_name"]) == {"strict-8", "strict-9"}
+        assert df["wt_value"].notna().all()
+        for method, length in [("strict-8", 8), ("strict-9", 9)]:
+            rows = df[df["prediction_method_name"] == method]
+            assert not rows.empty
+            assert set(rows["peptide_length"]) == {length}
+            assert set(rows["wt_peptide_length"]) == {length}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_from_variants_refactor.py
+++ b/tests/test_predict_from_variants_refactor.py
@@ -145,6 +145,17 @@ class TestFragmentColumnsOnVariantPath:
         mutant = aff[aff["contains_mutant_residues"].eq(True)]
         assert (mutant["peptide"] != mutant["wt_peptide"]).all()
 
+    def test_predict_wt_populates_wt_prediction_columns(self):
+        """predict_wt=True should run on the variant path after legacy
+        mutation columns are attached but before filter/sort."""
+        df = _predictor(predict_wt=True).predict_from_variants(
+            cancer_test_variants
+        )
+        aff = df[df["kind"] == "pMHC_affinity"]
+        for col in ("wt_value", "wt_score", "wt_affinity", "wt_percentile_rank"):
+            assert col in aff.columns
+            assert aff[col].notna().all()
+
 
 # ---------------------------------------------------------------------------
 # _fragment_from_effect unit tests (varcode-free via mock)

--- a/tests/test_validation_and_edge_cases.py
+++ b/tests/test_validation_and_edge_cases.py
@@ -185,6 +185,34 @@ def test_multiple_predictors_parse_from_one_cli_invocation():
     assert len(predictors) == 2
 
 
+def test_predict_wt_cli_flag_passed_to_predictor(monkeypatch):
+    path = _tmpfile("name,peptide\npep1,SIINFEKLA\n")
+    seen = {}
+
+    class FakeTopiaryPredictor:
+        def __init__(self, **kwargs):
+            seen["predict_wt"] = kwargs["predict_wt"]
+
+        def predict_from_named_peptides(self, _peptides):
+            return pd.DataFrame()
+
+    monkeypatch.setattr(
+        "topiary.cli.args.TopiaryPredictor", FakeTopiaryPredictor
+    )
+    try:
+        args = arg_parser.parse_args([
+            "--mhc-predictor", "random",
+            "--mhc-alleles", "A0201",
+            "--peptide-csv", path,
+            "--predict-wt",
+        ])
+        predict_epitopes_from_args(args)
+    finally:
+        os.unlink(path)
+
+    assert seen["predict_wt"] is True
+
+
 # ---------------------------------------------------------------------------
 # Bug #7: empty gene/tissue lists rejected
 # ---------------------------------------------------------------------------

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.1"
+__version__ = "5.10.2"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -609,6 +609,7 @@ def predict_epitopes_from_args(args):
         min_gene_expression=args.rna_min_gene_expression,
         only_novel_epitopes=args.only_novel_epitopes,
         raise_on_error=not args.skip_variant_errors,
+        predict_wt=getattr(args, "predict_wt", False),
     )
 
     _validate_input_modes(args)

--- a/topiary/cli/filtering.py
+++ b/topiary/cli/filtering.py
@@ -93,6 +93,18 @@ def add_filter_args(arg_parser):
     )
 
     filter_group.add_argument(
+        "--predict-wt",
+        help=(
+            "For variant-derived predictions, score populated wildtype "
+            "peptides with the configured MHC model(s) so wt.* sort "
+            "expressions can use wt_value, wt_score, wt_affinity, and "
+            "wt_percentile_rank."
+        ),
+        default=False,
+        action="store_true",
+    )
+
+    filter_group.add_argument(
         "--sort-direction",
         help=(
             "Sort direction for --sort-by: 'asc', 'desc', or 'auto'. "

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import logging
+from collections import Counter
 
 import numpy as np
 import pandas as pd
@@ -39,6 +40,32 @@ _JOIN_COLUMNS = {
     "transcript": "transcript_id",
     "variant": "variant",
 }
+
+_MODEL_KEY_COLUMN = "_topiary_model_key"
+
+
+def _unique_model_keys(models):
+    """Readable, unique internal names for configured model instances."""
+    bases = []
+    for model in models:
+        base = (
+            getattr(model, "prediction_method_name", None)
+            or getattr(model, "predictor_name", None)
+            or getattr(model, "name", None)
+            or type(model).__name__
+        )
+        bases.append(str(base) or type(model).__name__)
+
+    totals = Counter(bases)
+    seen = Counter()
+    keys = []
+    for base in bases:
+        seen[base] += 1
+        if totals[base] == 1:
+            keys.append(base)
+        else:
+            keys.append(f"{base}__{seen[base]}")
+    return keys
 
 
 def _build_model_lookup():
@@ -441,6 +468,7 @@ class TopiaryPredictor(object):
                 self.models.append(m(alleles=alleles))
             else:
                 self.models.append(m)
+        self._model_keys = _unique_model_keys(self.models)
 
         # Padding uses the union of all models' peptide lengths
         all_lengths = set()
@@ -492,7 +520,7 @@ class TopiaryPredictor(object):
             prediction_method_name, predictor_version, n_flank, c_flank
         """
         df = self._predict_raw(name_to_sequence_dict)
-        return self._apply_filter(df)
+        return self._strip_internal_columns(self._apply_filter(df))
 
     def predict_from_named_peptides(self, name_to_peptide_dict):
         """
@@ -509,14 +537,18 @@ class TopiaryPredictor(object):
             prediction_method_name, predictor_version, n_flank, c_flank
         """
         df = self._predict_raw_peptides(name_to_peptide_dict)
-        return self._apply_filter(df)
+        return self._strip_internal_columns(self._apply_filter(df))
 
     def _predict_raw(self, name_to_sequence_dict):
         """Run models and format output, without applying filter/ranking."""
         dfs = []
-        for model in self.models:
+        for model, model_key in zip(self.models, self._model_keys):
             model_df = model.predict_proteins_dataframe(name_to_sequence_dict)
-            dfs.append(self._format_prediction_df(model_df))
+            dfs.append(
+                self._attach_model_key(
+                    self._format_prediction_df(model_df), model_key
+                )
+            )
         if not dfs:
             return pd.DataFrame()
         return pd.concat(dfs, ignore_index=True)
@@ -524,16 +556,18 @@ class TopiaryPredictor(object):
     def _predict_raw_peptides(self, name_to_peptide_dict):
         """Run models on peptides as-is, without sliding-window scanning."""
         dfs = []
-        for model in self.models:
+        for model, model_key in zip(self.models, self._model_keys):
             model_df = self._predict_raw_peptides_for_model(
-                model, name_to_peptide_dict
+                model, name_to_peptide_dict, model_key=model_key
             )
             dfs.append(model_df)
         if not dfs:
             return pd.DataFrame()
         return pd.concat(dfs, ignore_index=True)
 
-    def _predict_raw_peptides_for_model(self, model, name_to_peptide_dict):
+    def _predict_raw_peptides_for_model(
+        self, model, name_to_peptide_dict, model_key=None
+    ):
         """Run one model on peptides as-is, without sliding-window scanning."""
         peptide_names_df = pd.DataFrame(
             {
@@ -552,7 +586,21 @@ class TopiaryPredictor(object):
         expanded_df = self._expand_named_peptide_predictions(
             model_df, peptide_names_df
         )
-        return self._format_prediction_df(expanded_df)
+        return self._attach_model_key(
+            self._format_prediction_df(expanded_df), model_key
+        )
+
+    def _attach_model_key(self, df, model_key):
+        """Attach the configured-model key used for internal joins."""
+        if df.empty or model_key is None:
+            return df
+        df = df.copy()
+        df[_MODEL_KEY_COLUMN] = model_key
+        return df
+
+    def _strip_internal_columns(self, df):
+        """Remove private Topiary plumbing columns from public output."""
+        return df.drop(columns=[_MODEL_KEY_COLUMN], errors="ignore")
 
     def _expand_named_peptide_predictions(self, model_df, peptide_names_df):
         """Attach the original peptide names to model predictions."""
@@ -644,22 +692,28 @@ class TopiaryPredictor(object):
         if not valid.any():
             return _ensure_wt_columns(df)
 
-        wt_candidates = df.loc[
-            valid, ["wt_peptide", "wt_peptide_length"]
-        ].drop_duplicates()
+        candidate_cols = ["wt_peptide", "wt_peptide_length"]
+        if _MODEL_KEY_COLUMN in df.columns:
+            candidate_cols.insert(0, _MODEL_KEY_COLUMN)
+        wt_candidates = df.loc[valid, candidate_cols].drop_duplicates()
         wt_raw_dfs = []
-        for model in self.models:
+        for model, model_key in zip(self.models, self._model_keys):
+            model_candidates = wt_candidates
+            if _MODEL_KEY_COLUMN in model_candidates.columns:
+                model_candidates = model_candidates[
+                    model_candidates[_MODEL_KEY_COLUMN].eq(model_key)
+                ]
             model_lengths = set(model.default_peptide_lengths)
             model_peptides = sorted(set(
-                wt_candidates.loc[
-                    wt_candidates["wt_peptide_length"].isin(model_lengths),
+                model_candidates.loc[
+                    model_candidates["wt_peptide_length"].isin(model_lengths),
                     "wt_peptide",
                 ].astype(str)
             ))
             if not model_peptides:
                 continue
             model_raw = self._predict_raw_peptides_for_model(
-                model, {p: p for p in model_peptides}
+                model, {p: p for p in model_peptides}, model_key=model_key
             )
             if not model_raw.empty:
                 wt_raw_dfs.append(model_raw)
@@ -679,8 +733,9 @@ class TopiaryPredictor(object):
         wt_join["wt_predictor_version"] = wt_join.get("predictor_version")
 
         join_cols = [
-            "wt_peptide", "allele", "wt_peptide_length", "kind",
-            "prediction_method_name", "predictor_version",
+            _MODEL_KEY_COLUMN, "wt_peptide", "allele",
+            "wt_peptide_length", "kind", "prediction_method_name",
+            "predictor_version",
         ]
         join_cols = [
             col for col in join_cols if col in df.columns and col in wt_join.columns
@@ -699,10 +754,24 @@ class TopiaryPredictor(object):
             columns=[col for col in wt_columns if col in df.columns],
             errors="ignore",
         )
+        wt_payload = wt_join[join_cols + payload_cols].drop_duplicates()
+        duplicates = wt_payload.duplicated(subset=join_cols, keep=False)
+        if duplicates.any():
+            examples = (
+                wt_payload.loc[duplicates, join_cols]
+                .drop_duplicates()
+                .head()
+                .to_dict("records")
+            )
+            raise ValueError(
+                "WT predictions are not unique for the configured-model "
+                f"join key; examples: {examples}"
+            )
         out = out.merge(
-            wt_join[join_cols + payload_cols].drop_duplicates(),
+            wt_payload,
             on=join_cols,
             how="left",
+            validate="many_to_one",
         )
         return _ensure_wt_columns(out)
 
@@ -716,6 +785,7 @@ class TopiaryPredictor(object):
         df = self._apply_filter(df)
         if self.only_novel_epitopes:
             df = df[df["contains_mutant_residues"].eq(True)]
+        df = self._strip_internal_columns(df)
         return df.reset_index(drop=True)
 
     def predict_from_fragments(self, fragments):

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -42,6 +42,7 @@ _JOIN_COLUMNS = {
 }
 
 _MODEL_KEY_COLUMN = "_topiary_model_key"
+_WT_OFFSET_COLUMN = "_topiary_wt_peptide_offset"
 
 
 def _unique_model_keys(models):
@@ -543,15 +544,21 @@ class TopiaryPredictor(object):
         """Run models and format output, without applying filter/ranking."""
         dfs = []
         for model, model_key in zip(self.models, self._model_keys):
-            model_df = model.predict_proteins_dataframe(name_to_sequence_dict)
             dfs.append(
-                self._attach_model_key(
-                    self._format_prediction_df(model_df), model_key
+                self._predict_raw_for_model(
+                    model, name_to_sequence_dict, model_key=model_key
                 )
             )
         if not dfs:
             return pd.DataFrame()
         return pd.concat(dfs, ignore_index=True)
+
+    def _predict_raw_for_model(self, model, name_to_sequence_dict, model_key=None):
+        """Run one model on proteins, preserving source-sequence context."""
+        model_df = model.predict_proteins_dataframe(name_to_sequence_dict)
+        return self._attach_model_key(
+            self._format_prediction_df(model_df), model_key
+        )
 
     def _predict_raw_peptides(self, name_to_peptide_dict):
         """Run models on peptides as-is, without sliding-window scanning."""
@@ -600,7 +607,10 @@ class TopiaryPredictor(object):
 
     def _strip_internal_columns(self, df):
         """Remove private Topiary plumbing columns from public output."""
-        return df.drop(columns=[_MODEL_KEY_COLUMN], errors="ignore")
+        return df.drop(
+            columns=[_MODEL_KEY_COLUMN, _WT_OFFSET_COLUMN],
+            errors="ignore",
+        )
 
     def _expand_named_peptide_predictions(self, model_df, peptide_names_df):
         """Attach the original peptide names to model predictions."""
@@ -660,7 +670,7 @@ class TopiaryPredictor(object):
         nearest = self.self_proteome.nearest(unique)
         return df.merge(nearest, on="peptide", how="left")
 
-    def _maybe_predict_wt_peptides(self, df):
+    def _maybe_predict_wt_peptides(self, df, fragments=None):
         """Score populated ``wt_peptide`` values and attach ``wt_*``
         columns.
 
@@ -684,15 +694,37 @@ class TopiaryPredictor(object):
                     out[col] = np.nan
             return out
 
+        if (
+            fragments is None
+            or _WT_OFFSET_COLUMN not in df.columns
+            or "fragment_id" not in df.columns
+        ):
+            return _ensure_wt_columns(df)
+
+        baseline_by_fragment_id = {
+            f.fragment_id: f.effective_baseline
+            for f in fragments
+            if (
+                f.effective_baseline is not None
+                and len(f.effective_baseline) == len(f.sequence)
+            )
+        }
+
         valid = (
             df["wt_peptide"].notna()
             & df["allele"].notna()
             & df["wt_peptide_length"].notna()
+            & df["fragment_id"].notna()
+            & df[_WT_OFFSET_COLUMN].notna()
+            & df["fragment_id"].isin(baseline_by_fragment_id)
         )
         if not valid.any():
             return _ensure_wt_columns(df)
 
-        candidate_cols = ["wt_peptide", "wt_peptide_length"]
+        candidate_cols = [
+            "fragment_id", _WT_OFFSET_COLUMN, "wt_peptide",
+            "wt_peptide_length",
+        ]
         if _MODEL_KEY_COLUMN in df.columns:
             candidate_cols.insert(0, _MODEL_KEY_COLUMN)
         wt_candidates = df.loc[valid, candidate_cols].drop_duplicates()
@@ -712,8 +744,19 @@ class TopiaryPredictor(object):
             ))
             if not model_peptides:
                 continue
-            model_raw = self._predict_raw_peptides_for_model(
-                model, {p: p for p in model_peptides}, model_key=model_key
+            fragment_ids = model_candidates.loc[
+                model_candidates["wt_peptide_length"].isin(model_lengths),
+                "fragment_id",
+            ].drop_duplicates()
+            baseline_sequences = {
+                fid: baseline_by_fragment_id[fid]
+                for fid in fragment_ids
+                if fid in baseline_by_fragment_id
+            }
+            if not baseline_sequences:
+                continue
+            model_raw = self._predict_raw_for_model(
+                model, baseline_sequences, model_key=model_key
             )
             if not model_raw.empty:
                 wt_raw_dfs.append(model_raw)
@@ -723,19 +766,24 @@ class TopiaryPredictor(object):
 
         wt_join = wt_raw.rename(
             columns={
+                "source_sequence_name": "fragment_id",
                 "peptide": "wt_peptide",
+                "peptide_offset": _WT_OFFSET_COLUMN,
                 "peptide_length": "wt_peptide_length",
             }
         ).copy()
+        wt_join = self._filter_wt_rows_to_baseline_context(
+            wt_join, baseline_by_fragment_id
+        )
         wt_join["wt_prediction_method_name"] = wt_join.get(
             "prediction_method_name"
         )
         wt_join["wt_predictor_version"] = wt_join.get("predictor_version")
 
         join_cols = [
-            _MODEL_KEY_COLUMN, "wt_peptide", "allele",
-            "wt_peptide_length", "kind", "prediction_method_name",
-            "predictor_version",
+            _MODEL_KEY_COLUMN, "fragment_id", _WT_OFFSET_COLUMN,
+            "wt_peptide", "allele", "wt_peptide_length", "kind",
+            "prediction_method_name", "predictor_version",
         ]
         join_cols = [
             col for col in join_cols if col in df.columns and col in wt_join.columns
@@ -775,13 +823,41 @@ class TopiaryPredictor(object):
         )
         return _ensure_wt_columns(out)
 
-    def _finalize_rows(self, df):
+    def _filter_wt_rows_to_baseline_context(self, wt_join, baseline_by_fragment_id):
+        """Keep cached/context rows compatible with the WT baseline flank."""
+        if wt_join.empty or not {"n_flank", "c_flank"}.intersection(wt_join.columns):
+            return wt_join
+
+        def _matches(row):
+            baseline = baseline_by_fragment_id.get(row.get("fragment_id"))
+            if baseline is None:
+                return False
+            try:
+                start = int(row[_WT_OFFSET_COLUMN])
+                length = int(row["wt_peptide_length"])
+            except (TypeError, ValueError):
+                return False
+            end = start + length
+
+            if "n_flank" in row.index and pd.notna(row["n_flank"]):
+                n_flank = str(row["n_flank"])
+                if n_flank and not baseline[:start].endswith(n_flank):
+                    return False
+            if "c_flank" in row.index and pd.notna(row["c_flank"]):
+                c_flank = str(row["c_flank"])
+                if c_flank and not baseline[end:].startswith(c_flank):
+                    return False
+            return True
+
+        return wt_join[wt_join.apply(_matches, axis=1)]
+
+    def _finalize_rows(self, df, fragments=None):
         """Apply filter / sort, drop non-mutant rows when
         ``only_novel_epitopes`` is set, and reset the index.  Shared
         tail for every ProteinFragment-producing entry point."""
         if df.empty:
             return df
-        df = self._maybe_predict_wt_peptides(df)
+        df = self._maybe_predict_wt_peptides(df, fragments=fragments)
         df = self._apply_filter(df)
         if self.only_novel_epitopes:
             df = df[df["contains_mutant_residues"].eq(True)]
@@ -822,7 +898,10 @@ class TopiaryPredictor(object):
         without a length-compatible WT peptide keep NaN WT prediction
         values.
         """
-        return self._finalize_rows(self._build_fragment_rows(fragments))
+        fragments = list(fragments)
+        return self._finalize_rows(
+            self._build_fragment_rows(fragments), fragments=fragments,
+        )
 
     def _build_fragment_rows(self, fragments):
         """Run models on *fragments* and overlay all fragment-derived
@@ -898,6 +977,9 @@ class TopiaryPredictor(object):
         df["wt_peptide"] = df.apply(_wt_peptide, axis=1)
         df["wt_peptide_length"] = df["wt_peptide"].map(
             lambda p: len(p) if isinstance(p, str) else None
+        )
+        df[_WT_OFFSET_COLUMN] = df["peptide_offset"].where(
+            df["wt_peptide"].notna(), other=None,
         )
 
         all_annotation_keys = set()
@@ -1027,7 +1109,7 @@ class TopiaryPredictor(object):
         df = _add_legacy_mutation_columns(df, fragments)
         if expression_data:
             df = _attach_expression_data(df, expression_data)
-        return self._finalize_rows(df)
+        return self._finalize_rows(df, fragments=fragments)
 
     def predict_from_variants(
         self, variants, transcript_expression_dict=None, gene_expression_dict=None,

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -357,6 +357,7 @@ class TopiaryPredictor(object):
         mhc_model=None,
         mhc_models=None,
         self_proteome=None,
+        predict_wt=False,
     ):
         """
         Parameters
@@ -414,6 +415,12 @@ class TopiaryPredictor(object):
             Raise on variant-effect errors vs. skip.
 
         mhc_model, mhc_models : legacy aliases for ``models``.
+
+        predict_wt : bool
+            If True, run the configured MHC model(s) on each populated
+            ``wt_peptide`` and attach ``wt_*`` prediction columns before
+            filter/sort expressions are evaluated.  Rows without a
+            length-compatible wildtype peptide keep NaN ``wt_*`` values.
         """
         # --- model setup ---
         raw_models = models or mhc_models or (mhc_model and [mhc_model])
@@ -454,6 +461,7 @@ class TopiaryPredictor(object):
         self.only_novel_epitopes = only_novel_epitopes
         self.raise_on_error = raise_on_error
         self.self_proteome = self_proteome
+        self.predict_wt = predict_wt
 
     @property
     def mhc_model(self):
@@ -597,12 +605,89 @@ class TopiaryPredictor(object):
         nearest = self.self_proteome.nearest(unique)
         return df.merge(nearest, on="peptide", how="left")
 
+    def _maybe_predict_wt_peptides(self, df):
+        """Score populated ``wt_peptide`` values and attach ``wt_*``
+        columns.
+
+        ``wt_peptide`` itself is derived while building fragment rows.
+        This helper performs the optional second prediction pass and
+        joins each WT prediction back to the matching mutant row by
+        allele, peptide length, prediction kind, and predictor identity.
+        """
+        if not self.predict_wt or df.empty or "wt_peptide" not in df.columns:
+            return df
+
+        wt_columns = (
+            "wt_value", "wt_score", "wt_affinity", "wt_percentile_rank",
+            "wt_prediction_method_name", "wt_predictor_version",
+        )
+
+        def _ensure_wt_columns(out):
+            out = out.copy()
+            for col in wt_columns:
+                if col not in out.columns:
+                    out[col] = np.nan
+            return out
+
+        valid = (
+            df["wt_peptide"].notna()
+            & df["allele"].notna()
+            & df["wt_peptide_length"].notna()
+        )
+        if not valid.any():
+            return _ensure_wt_columns(df)
+
+        wt_peptides = sorted(set(df.loc[valid, "wt_peptide"].astype(str)))
+        wt_raw = self._predict_raw_peptides({p: p for p in wt_peptides})
+        if wt_raw.empty:
+            return _ensure_wt_columns(df)
+
+        wt_join = wt_raw.rename(
+            columns={
+                "peptide": "wt_peptide",
+                "peptide_length": "wt_peptide_length",
+            }
+        ).copy()
+        wt_join["wt_prediction_method_name"] = wt_join.get(
+            "prediction_method_name"
+        )
+        wt_join["wt_predictor_version"] = wt_join.get("predictor_version")
+
+        join_cols = [
+            "wt_peptide", "allele", "wt_peptide_length", "kind",
+            "prediction_method_name", "predictor_version",
+        ]
+        join_cols = [
+            col for col in join_cols if col in df.columns and col in wt_join.columns
+        ]
+
+        rename = {}
+        for col in wt_join.columns:
+            if col in join_cols or col.startswith("wt_"):
+                continue
+            rename[col] = f"wt_{col}"
+        wt_join = wt_join.rename(columns=rename)
+        payload_cols = [col for col in wt_columns if col in wt_join.columns]
+        # predict_wt=True means computed WT predictions are authoritative
+        # for the columns this helper writes.
+        out = df.drop(
+            columns=[col for col in wt_columns if col in df.columns],
+            errors="ignore",
+        )
+        out = out.merge(
+            wt_join[join_cols + payload_cols].drop_duplicates(),
+            on=join_cols,
+            how="left",
+        )
+        return _ensure_wt_columns(out)
+
     def _finalize_rows(self, df):
         """Apply filter / sort, drop non-mutant rows when
         ``only_novel_epitopes`` is set, and reset the index.  Shared
         tail for every ProteinFragment-producing entry point."""
         if df.empty:
             return df
+        df = self._maybe_predict_wt_peptides(df)
         df = self._apply_filter(df)
         if self.only_novel_epitopes:
             df = df[df["contains_mutant_residues"].eq(True)]
@@ -638,9 +723,9 @@ class TopiaryPredictor(object):
           ``None`` / NaN when no baseline is present.
 
         WT model predictions (``wt_value``, ``wt_score``, etc.) are
-        **not populated** in this release — populate them externally
-        or wait for a follow-up PR.  The DSL's ``wt.*`` scope returns
-        NaN for those columns until they're written.
+        populated when ``TopiaryPredictor(predict_wt=True)``.  Rows
+        without a length-compatible WT peptide keep NaN WT prediction
+        values.
         """
         return self._finalize_rows(self._build_fragment_rows(fragments))
 

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -523,6 +523,18 @@ class TopiaryPredictor(object):
 
     def _predict_raw_peptides(self, name_to_peptide_dict):
         """Run models on peptides as-is, without sliding-window scanning."""
+        dfs = []
+        for model in self.models:
+            model_df = self._predict_raw_peptides_for_model(
+                model, name_to_peptide_dict
+            )
+            dfs.append(model_df)
+        if not dfs:
+            return pd.DataFrame()
+        return pd.concat(dfs, ignore_index=True)
+
+    def _predict_raw_peptides_for_model(self, model, name_to_peptide_dict):
+        """Run one model on peptides as-is, without sliding-window scanning."""
         peptide_names_df = pd.DataFrame(
             {
                 "source_sequence_name": list(name_to_peptide_dict.keys()),
@@ -533,19 +545,14 @@ class TopiaryPredictor(object):
             return pd.DataFrame()
 
         peptide_list = peptide_names_df["peptide"].drop_duplicates().tolist()
-        dfs = []
-        for model in self.models:
-            if hasattr(model, "predict_dataframe"):
-                model_df = model.predict_dataframe(peptide_list)
-            else:
-                model_df = model.predict_peptides_dataframe(peptide_list)
-            expanded_df = self._expand_named_peptide_predictions(
-                model_df, peptide_names_df
-            )
-            dfs.append(self._format_prediction_df(expanded_df))
-        if not dfs:
-            return pd.DataFrame()
-        return pd.concat(dfs, ignore_index=True)
+        if hasattr(model, "predict_dataframe"):
+            model_df = model.predict_dataframe(peptide_list)
+        else:
+            model_df = model.predict_peptides_dataframe(peptide_list)
+        expanded_df = self._expand_named_peptide_predictions(
+            model_df, peptide_names_df
+        )
+        return self._format_prediction_df(expanded_df)
 
     def _expand_named_peptide_predictions(self, model_df, peptide_names_df):
         """Attach the original peptide names to model predictions."""
@@ -637,10 +644,28 @@ class TopiaryPredictor(object):
         if not valid.any():
             return _ensure_wt_columns(df)
 
-        wt_peptides = sorted(set(df.loc[valid, "wt_peptide"].astype(str)))
-        wt_raw = self._predict_raw_peptides({p: p for p in wt_peptides})
-        if wt_raw.empty:
+        wt_candidates = df.loc[
+            valid, ["wt_peptide", "wt_peptide_length"]
+        ].drop_duplicates()
+        wt_raw_dfs = []
+        for model in self.models:
+            model_lengths = set(model.default_peptide_lengths)
+            model_peptides = sorted(set(
+                wt_candidates.loc[
+                    wt_candidates["wt_peptide_length"].isin(model_lengths),
+                    "wt_peptide",
+                ].astype(str)
+            ))
+            if not model_peptides:
+                continue
+            model_raw = self._predict_raw_peptides_for_model(
+                model, {p: p for p in model_peptides}
+            )
+            if not model_raw.empty:
+                wt_raw_dfs.append(model_raw)
+        if not wt_raw_dfs:
             return _ensure_wt_columns(df)
+        wt_raw = pd.concat(wt_raw_dfs, ignore_index=True)
 
         wt_join = wt_raw.rename(
             columns={


### PR DESCRIPTION
## Summary

- Add `TopiaryPredictor(predict_wt=True)` to score populated `wt_peptide` values with the configured MHC model(s).
- Join WT scores back by peptide, allele, length, prediction kind, method, and version so affinity and presentation rows remain aligned.
- Update ranking/API/fragment docs, README, changelog, and bump the package version to 5.10.2.

Closes #123.

## Validation

- `python -m pytest tests/test_predict_from_fragments.py::TestWtPeptide tests/test_predict_from_variants_refactor.py::TestFragmentColumnsOnVariantPath::test_predict_wt_populates_wt_prediction_columns`
- `./lint.sh`
- `./test.sh`