### PR TITLE
Add model-qualified kind parser aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 5.10.3
+
+**Quote-free model-qualified kind syntax (#150):**
+
+- The string DSL now accepts `mhcflurry:affinity`,
+  `affinity:mhcflurry`, and `mhcflurry.affinity` as aliases for
+  `affinity[mhcflurry]` / `affinity['mhcflurry']`.
+- Model-first syntax can attach versions directly to the model:
+  `mhcflurry[2.1.5]:ba.score` parses like
+  `affinity[mhcflurry, 2.1.5].score`. Version slots accept common
+  unquoted labels such as `4.1b`, `v2.1`, `release-2.2.0`, and
+  `2.2.1+release-2.2.0`.
+- Colon-separated version forms are also accepted:
+  `mhcflurry:release-2.2.0:ba.score` and
+  `mhcflurry-4.1b:affinity.score`.
+- These aliases compose with fields, transforms, and scopes, e.g.
+  `netmhcpan:ba.score`, `mhcflurry[2.1.5]:processing.score`, and
+  `wt.mhcflurry[2.1.5]:ba.score`.
+- Existing bracket and underscore forms remain supported and canonical
+  string output still emits bracket form for deterministic round trips.
+
 ## 5.10.2
 
 **Wildtype MHC scoring (#123):**

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ topiary \
   --mhc-predictor netmhcpan mhcflurry \
   --mhc-alleles HLA-A*02:01 \
   --filter-by "ba <= 500" \
-  --sort-by "mean(affinity['netmhcpan'].logistic(350, 150), affinity['mhcflurry'].logistic(350, 150))" \
+  --sort-by "mean(netmhcpan:affinity.logistic(350, 150), mhcflurry:affinity.logistic(350, 150))" \
   --output-csv results.csv
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -224,6 +224,11 @@ The unified DSL parser. Returns a `DSLNode`.
 |--------|--------|
 | `"affinity <= 500"` | `Comparison(Field(pMHC_affinity, "value"), <=, 500)` |
 | `"netmhcpan_ba <= 500"` | `Comparison(Field(pMHC_affinity, "value", method="netmhcpan"), <=, 500)` |
+| `"netmhcpan:affinity <= 500"` | `Comparison(Field(pMHC_affinity, "value", method="netmhcpan"), <=, 500)` |
+| `"affinity:netmhcpan <= 500"` | `Comparison(Field(pMHC_affinity, "value", method="netmhcpan"), <=, 500)` |
+| `"netmhcpan.affinity <= 500"` | `Comparison(Field(pMHC_affinity, "value", method="netmhcpan"), <=, 500)` |
+| `"netmhcpan[4.1b]:affinity.score"` | `Field(pMHC_affinity, "score", method="netmhcpan", version="4.1b")` |
+| `"netmhcpan-4.1b:affinity.score"` | `Field(pMHC_affinity, "score", method="netmhcpan", version="4.1b")` |
 | `"affinity['netmhcpan', '4.1b'].value <= 500"` | `Comparison(Field(..., method="netmhcpan", version="4.1b"), <=, 500)` |
 | `"column(cysteine_count) <= 2"` | `Comparison(Column("cysteine_count"), <=, 2)` |
 | `"a <= 500 \| b <= 2"` | `BoolOp(\|, [Comparison(a), Comparison(b)])` |

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -234,6 +234,12 @@ In the string DSL, both forms work:
 ```
 affinity['netmhcpan'].value <= 500
 affinity['netmhcpan', '4.1b'].value <= 500
+affinity[netmhcpan, 4.1b].value <= 500
+affinity[netmhcpan, release-2.2.0].value <= 500
+netmhcpan[4.1b]:affinity.value <= 500
+netmhcpan:4.1b:affinity.value <= 500
+netmhcpan-4.1b:affinity.value <= 500
+wt.netmhcpan[4.1b]:ba.score
 ```
 
 ## Parsing strings
@@ -258,13 +264,20 @@ The `--filter-by` flag and `--sort-by` flag accept string expressions:
 | `Affinity <= 500` | `affinity <= 500` or `ba <= 500` |
 | `Affinity.rank <= 2` | `affinity.rank <= 2` |
 | `Affinity.score >= 0.5` | `affinity.score >= 0.5` |
-| `Affinity["netmhcpan"] <= 500` | `netmhcpan_affinity <= 500` or `netmhcpan_ba <= 500` |
-| `Presentation["mhcflurry"].rank <= 2` | `mhcflurry_el.rank <= 2` |
+| `Affinity["netmhcpan"] <= 500` | `netmhcpan:affinity <= 500`, `affinity:netmhcpan <= 500`, `netmhcpan.affinity <= 500`, `affinity[netmhcpan] <= 500`, `netmhcpan_ba <= 500` |
+| `Affinity["netmhcpan", "4.1b"].score` | `netmhcpan[4.1b]:affinity.score`, `netmhcpan:affinity[4.1b].score`, `affinity[netmhcpan, 4.1b].score` |
+| `Presentation["mhcflurry"].rank <= 2` | `mhcflurry:el.rank <= 2` or `mhcflurry_el.rank <= 2` |
 | `Column("cysteine_count") <= 2` | `column(cysteine_count) <= 2` |
 | `(A <= 500) \| (B.rank <= 2)` | `affinity <= 500 \| presentation.rank <= 2` |
 | `(A <= 500) & (B.rank <= 2)` | `affinity <= 500 & presentation.rank <= 2` |
 
 **Kind aliases:** `ba` / `aff` / `ic50` = Affinity, `el` = Presentation.
+
+**Model-qualified kinds:** Canonical serialization still uses bracket
+form (`affinity[netmhcpan]`), but model-first forms read better in
+configuration: `netmhcpan:affinity`, `netmhcpan.affinity`, and
+`netmhcpan[4.1b]:affinity`. Versioned model-first refs can also use
+`netmhcpan:4.1b:affinity` or `netmhcpan-4.1b:affinity`.
 
 **All features work in both Python and CLI string form** (`--sort-by`):
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1818,12 +1818,28 @@ def test_parse_bare_ident_in_brackets_filter():
     assert expr.left.method == "netmhcpan"
 
 
-def test_parse_bare_ident_version_still_quoted():
-    """Non-IDENT version strings (e.g. '4.1b') keep quotes."""
+def test_parse_bare_ident_version_quoted():
+    """Quoted versions still work."""
     expr = parse('affinity[netmhcpan, "4.1b"].value')
     assert isinstance(expr, Field)
     assert expr.method == "netmhcpan"
     assert expr.version == "4.1b"
+
+
+def test_parse_bare_ident_version_unquoted():
+    """Common version labels can omit quotes in the version slot."""
+    expr = parse("affinity[netmhcpan, 4.1b].value")
+    assert isinstance(expr, Field)
+    assert expr.method == "netmhcpan"
+    assert expr.version == "4.1b"
+
+
+def test_parse_identifier_leading_version_unquoted():
+    """Raw version labels may start with an identifier."""
+    expr = parse("affinity[netmhcpan, v2.1].value")
+    assert isinstance(expr, Field)
+    assert expr.method == "netmhcpan"
+    assert expr.version == "v2.1"
 
 
 def test_parse_bare_ident_mixed_with_quoted():
@@ -1850,9 +1866,157 @@ def test_parse_bare_ident_roundtrip_emits_quoted():
 
 
 def test_parse_bare_ident_rejects_number():
-    """Numeric token in bracket (without quotes) still errors."""
+    """The first legacy bracket slot is still a model/method name."""
     with pytest.raises(ValueError, match="STRING or IDENT"):
-        parse("affinity[netmhcpan, 4]")
+        parse("affinity[4]")
+
+
+# ---------------------------------------------------------------------------
+# Model-first / model-kind parser sugar  —  issues #150 and #152
+# ---------------------------------------------------------------------------
+
+
+def test_parse_model_colon_kind():
+    """mhcflurry:affinity parses like affinity[mhcflurry]."""
+    expr = parse("mhcflurry:affinity.score")
+    bracket = parse("affinity[mhcflurry].score")
+    assert isinstance(expr, Field)
+    assert expr.method == "mhcflurry"
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_colon_kind_short_alias_filter():
+    expr = parse("netmhcpan:ba <= 500")
+    assert isinstance(expr, Comparison)
+    assert isinstance(expr.left, Field)
+    assert expr.left.kind == Kind.pMHC_affinity
+    assert expr.left.method == "netmhcpan"
+
+
+def test_parse_kind_colon_model_reversed_form():
+    """Accept kind:model while downstream configs try syntax variants."""
+    expr = parse("affinity:mhcflurry.score")
+    bracket = parse("affinity[mhcflurry].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_dot_kind():
+    """mhcflurry.affinity is an experimental alias for affinity[mhcflurry]."""
+    expr = parse("mhcflurry.affinity.score")
+    bracket = parse("affinity[mhcflurry].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_kind_processing_alias():
+    expr = parse("mhcflurry:processing.score")
+    assert isinstance(expr, Field)
+    assert expr.kind == Kind.antigen_processing
+    assert expr.method == "mhcflurry"
+
+
+def test_parse_versioned_model_colon_kind():
+    """mhcflurry[2.1.5]:ba attaches the bracket to model version."""
+    expr = parse("mhcflurry[2.1.5]:ba.score")
+    bracket = parse("ba[mhcflurry, 2.1.5].score")
+    assert isinstance(expr, Field)
+    assert expr.method == "mhcflurry"
+    assert expr.version == "2.1.5"
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_versioned_model_dot_kind():
+    expr = parse("mhcflurry[2.1.5].ba.score")
+    colon = parse("mhcflurry[2.1.5]:ba.score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == colon.to_ast_string()
+
+
+def test_parse_model_colon_kind_version_bracket_suffix():
+    expr = parse("mhcflurry:ba[2.1.5].score")
+    colon = parse("mhcflurry[2.1.5]:ba.score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == colon.to_ast_string()
+
+
+def test_parse_kind_colon_model_version_bracket_suffix():
+    expr = parse("ba:mhcflurry[2.1.5].score")
+    colon = parse("mhcflurry[2.1.5]:ba.score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == colon.to_ast_string()
+
+
+def test_parse_scoped_versioned_model_colon_kind():
+    expr = parse("wt.mhcflurry[2.1.5]:ba.score")
+    bracket = parse("wt.ba[mhcflurry, 2.1.5].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_composite_unquoted_model_version():
+    expr = parse("mhcflurry[2.2.1+release-2.2.0]:ba.score")
+    assert isinstance(expr, Field)
+    assert expr.version == "2.2.1+release-2.2.0"
+
+
+def test_parse_identifier_leading_model_version_unquoted():
+    expr = parse("mhcflurry[release-2.2.0]:ba.score")
+    assert isinstance(expr, Field)
+    assert expr.method == "mhcflurry"
+    assert expr.version == "release-2.2.0"
+
+
+def test_parse_model_colon_version_colon_kind():
+    expr = parse("mhcflurry:release-2.2.0:ba.score")
+    bracket = parse("ba[mhcflurry, release-2.2.0].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_dash_version_colon_kind():
+    expr = parse("mhcflurry-4.1b:affinity.score")
+    bracket = parse("affinity[mhcflurry, 4.1b].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_scoped_model_dash_version_colon_kind():
+    expr = parse("wt.mhcflurry-release-2.2.0:ba.score")
+    bracket = parse("wt.ba[mhcflurry, release-2.2.0].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_colon_kind_with_transform():
+    expr = parse("mhcflurry:affinity.descending_cdf(500, 200)")
+    bracket = parse("affinity[mhcflurry].descending_cdf(500, 200)")
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_scoped_model_colon_kind():
+    expr = parse("wt.mhcflurry:affinity.score")
+    bracket = parse("wt.affinity[mhcflurry].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_scoped_model_dot_kind():
+    expr = parse("wt.mhcflurry.affinity.score")
+    bracket = parse("wt.affinity[mhcflurry].score")
+    assert isinstance(expr, Field)
+    assert expr.to_ast_string() == bracket.to_ast_string()
+
+
+def test_parse_model_colon_kind_roundtrip_emits_canonical_brackets():
+    expr = parse("mhcflurry:affinity.score")
+    assert expr.to_expr_string() == "affinity['mhcflurry'].score"
+    assert parse(expr.to_expr_string()).to_ast_string() == expr.to_ast_string()
+
+
+def test_parse_model_colon_kind_requires_known_kind_side():
+    with pytest.raises(ValueError, match="one side .* prediction kind"):
+        parse("foo:bar")
 
 
 def test_parse_expr_norm_alias():

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.2"
+__version__ = "5.10.3"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/parser.py
+++ b/topiary/ranking/parser.py
@@ -11,9 +11,11 @@ Grammar (lowest precedence first)::
     power    := unary ('**' power)?
     unary    := ('-' | '~') unary | postfix
     postfix  := atom ('.' IDENT call? | '[' BRACKET_ARG (',' BRACKET_ARG)? ']')*
-    BRACKET_ARG := STRING | IDENT   # bare idents read cleanly in YAML
+    BRACKET_ARG := STRING | IDENT | raw version token run
     atom     := NUMBER | '(' top ')' | abs(expr) | agg(expr,...)
               | count(STR) | column(IDENT) | len
+              | IDENT ('[' BRACKET_ARG ']')? (':' | '.') kind_ref
+              | IDENT (':' | '-') BRACKET_ARG ':' kind_ref
               | CONTEXT '.' scoped_atom | kind_ref | IDENT
 """
 
@@ -39,6 +41,7 @@ from .nodes import (
     Stability,
     _CONTEXT_KEYWORDS,
     _FIELD_ALIASES,
+    _KIND_ALIASES,
     _combine_bool,
     _resolve_qualified_kind,
     geomean,
@@ -92,7 +95,7 @@ class _Tokenizer:
                 continue
             m = re.match(r'(\d+\.?\d*([eE][+-]?\d+)?)', text[i:])
             if m:
-                self.tokens.append(("NUMBER", float(m.group())))
+                self.tokens.append(("NUMBER", m.group()))
                 i += m.end()
                 continue
             if text[i] in ('"', "'"):
@@ -141,6 +144,8 @@ class _Tokenizer:
                 self.tokens.append(("RBRACKET", c))
             elif c == '.':
                 self.tokens.append(("DOT", c))
+            elif c == ':':
+                self.tokens.append(("COLON", c))
             elif c == ',':
                 self.tokens.append(("COMMA", c))
             else:
@@ -152,6 +157,18 @@ class _Tokenizer:
 
     def peek(self):
         return self.tokens[self._idx]
+
+    def peek_at(self, offset):
+        idx = self._idx + offset
+        if idx >= len(self.tokens):
+            return ("EOF", None)
+        return self.tokens[idx]
+
+    def mark(self):
+        return self._idx
+
+    def restore(self, idx):
+        self._idx = idx
 
     def advance(self):
         tok = self.tokens[self._idx]
@@ -170,19 +187,33 @@ class _Tokenizer:
             )
         return tok
 
-    def expect_string_or_ident(self):
-        """Bracket-arg primitive: accept ``'foo'`` or ``foo`` and return
-        the string value.  Used inside ``[...]`` for method/version
-        qualifiers where a bare identifier reads more cleanly than a
-        quoted string, especially in YAML.
+    def expect_bracket_arg(self, allow_raw=False):
+        """Read one bracket argument.
+
+        Method names stay conservative (STRING or IDENT). Version slots
+        may use raw token runs so common versions like ``4.1b`` and
+        ``2.2.1+release-2.2.0`` do not need quotes.
         """
-        tok = self.advance()
-        if tok[0] not in ("STRING", "IDENT"):
+        tok = self.peek()
+        if tok[0] == "STRING":
+            return self.advance()[1]
+        if tok[0] == "IDENT" and not allow_raw:
+            return self.advance()[1]
+        if not allow_raw:
             raise ValueError(
                 f"Expected STRING or IDENT but got {tok[0]} ({tok[1]!r}) "
                 f"in {self.text!r}"
             )
-        return tok
+        return self.collect_raw_until({"COMMA", "RBRACKET", "EOF"})
+
+    def collect_raw_until(self, stop_types):
+        """Join token text until one of ``stop_types`` is reached."""
+        parts = []
+        while self.peek()[0] not in stop_types:
+            parts.append(str(self.advance()[1]))
+        if not parts:
+            raise ValueError(f"Expected raw token run in {self.text!r}")
+        return "".join(parts)
 
 
 def _parser_as_node(x):
@@ -317,14 +348,17 @@ class _Parser:
                     node = self._apply_field_access(node, name)
             elif tok[0] == "LBRACKET":
                 self.tokenizer.advance()
-                method_tok = self.tokenizer.expect_string_or_ident()
-                version = None
+                args = [
+                    self.tokenizer.expect_bracket_arg(
+                        allow_raw=isinstance(node, KindAccessor)
+                        and node.method is not None
+                    )
+                ]
                 if self.tokenizer.peek()[0] == "COMMA":
                     self.tokenizer.advance()
-                    version_tok = self.tokenizer.expect_string_or_ident()
-                    version = version_tok[1]
+                    args.append(self.tokenizer.expect_bracket_arg(allow_raw=True))
                 self.tokenizer.expect("RBRACKET")
-                node = self._apply_bracket(node, method_tok[1], version)
+                node = self._apply_bracket(node, args)
             else:
                 break
         return node
@@ -333,7 +367,7 @@ class _Parser:
         tok = self.tokenizer.peek()
         if tok[0] == "NUMBER":
             self.tokenizer.advance()
-            return Const(tok[1])
+            return Const(float(tok[1]))
         if tok[0] == "LPAREN":
             self.tokenizer.advance()
             expr = self._or()
@@ -370,6 +404,18 @@ class _Parser:
                     f"{name!r} is a reserved context keyword. "
                     f"Use '{name}.kind.field' syntax, e.g. '{name}.affinity.score'"
                 )
+            versioned_model_accessor = self._try_versioned_model_kind_accessor()
+            if versioned_model_accessor is not None:
+                return versioned_model_accessor
+            separated_version_accessor = self._try_separated_version_kind_accessor()
+            if separated_version_accessor is not None:
+                return separated_version_accessor
+            colon_accessor = self._try_colon_kind_accessor()
+            if colon_accessor is not None:
+                return colon_accessor
+            method_dot_accessor = self._try_method_dot_kind_accessor()
+            if method_dot_accessor is not None:
+                return method_dot_accessor
             if name == "column":
                 self.tokenizer.advance()
                 self.tokenizer.expect("LPAREN")
@@ -389,6 +435,25 @@ class _Parser:
                 f"Expected identifier after scope prefix in {self.text!r}"
             )
         name = tok[1].lower()
+        if name in _CONTEXT_KEYWORDS:
+            raise ValueError(
+                f"{name!r} is a reserved context keyword and cannot be "
+                f"used as a kind name in {self.text!r}"
+            )
+        versioned_model_accessor = self._try_versioned_model_kind_accessor(scope=scope)
+        if versioned_model_accessor is not None:
+            return versioned_model_accessor
+        separated_version_accessor = self._try_separated_version_kind_accessor(
+            scope=scope,
+        )
+        if separated_version_accessor is not None:
+            return separated_version_accessor
+        colon_accessor = self._try_colon_kind_accessor(scope=scope)
+        if colon_accessor is not None:
+            return colon_accessor
+        method_dot_accessor = self._try_method_dot_kind_accessor(scope=scope)
+        if method_dot_accessor is not None:
+            return method_dot_accessor
         if name == "len":
             self.tokenizer.advance()
             return Len(scope=scope)
@@ -417,15 +482,124 @@ class _Parser:
             )
         if self.tokenizer.peek()[0] == "LBRACKET":
             self.tokenizer.advance()
-            method_tok = self.tokenizer.expect_string_or_ident()
-            version = None
+            args = [self.tokenizer.expect_bracket_arg()]
             if self.tokenizer.peek()[0] == "COMMA":
                 self.tokenizer.advance()
-                version_tok = self.tokenizer.expect_string_or_ident()
-                version = version_tok[1]
+                args.append(self.tokenizer.expect_bracket_arg(allow_raw=True))
             self.tokenizer.expect("RBRACKET")
-            accessor = accessor[method_tok[1], version] if version else accessor[method_tok[1]]
+            accessor = self._apply_bracket(accessor, args)
         return accessor
+
+    def _try_versioned_model_kind_accessor(self, scope=""):
+        if (
+            self.tokenizer.peek_at(0)[0] != "IDENT"
+            or self.tokenizer.peek_at(1)[0] != "LBRACKET"
+        ):
+            return None
+        saved_idx = self.tokenizer.mark()
+        method = self.tokenizer.advance()[1]
+        self.tokenizer.expect("LBRACKET")
+        version = self.tokenizer.expect_bracket_arg(allow_raw=True)
+        if self.tokenizer.peek()[0] != "RBRACKET":
+            self.tokenizer.restore(saved_idx)
+            return None
+        self.tokenizer.advance()
+        separator = self.tokenizer.peek()
+        if separator[0] not in ("COLON", "DOT"):
+            self.tokenizer.restore(saved_idx)
+            return None
+        kind_tok = self.tokenizer.peek_at(1)
+        if kind_tok[0] != "IDENT":
+            self.tokenizer.restore(saved_idx)
+            return None
+        kind = self._prediction_kind_for_name(kind_tok[1])
+        if kind is None:
+            self.tokenizer.restore(saved_idx)
+            return None
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        return KindAccessor(
+            kind, method=method, version=version, scope=scope,
+        )
+
+    def _try_separated_version_kind_accessor(self, scope=""):
+        if self.tokenizer.peek_at(0)[0] != "IDENT":
+            return None
+        separator = self.tokenizer.peek_at(1)
+        if separator not in (("COLON", ":"), ("OP", "-")):
+            return None
+        saved_idx = self.tokenizer.mark()
+        method = self.tokenizer.advance()[1]
+        self.tokenizer.advance()
+        try:
+            version = self.tokenizer.collect_raw_until({"COLON", "EOF"})
+        except ValueError:
+            self.tokenizer.restore(saved_idx)
+            return None
+        if self.tokenizer.peek()[0] != "COLON":
+            self.tokenizer.restore(saved_idx)
+            return None
+        kind_tok = self.tokenizer.peek_at(1)
+        if kind_tok[0] != "IDENT":
+            self.tokenizer.restore(saved_idx)
+            return None
+        kind = self._prediction_kind_for_name(kind_tok[1])
+        if kind is None:
+            self.tokenizer.restore(saved_idx)
+            return None
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        return KindAccessor(
+            kind, method=method, version=version, scope=scope,
+        )
+
+    def _try_colon_kind_accessor(self, scope=""):
+        if (
+            self.tokenizer.peek_at(0)[0] != "IDENT"
+            or self.tokenizer.peek_at(1)[0] != "COLON"
+            or self.tokenizer.peek_at(2)[0] != "IDENT"
+        ):
+            return None
+        left = self.tokenizer.peek_at(0)[1]
+        right = self.tokenizer.peek_at(2)[1]
+        left_kind = self._prediction_kind_for_name(left)
+        right_kind = self._prediction_kind_for_name(right)
+        if left_kind is None and right_kind is None:
+            raise ValueError(
+                f"Expected one side of {left}:{right} to be a prediction "
+                f"kind in {self.text!r}"
+            )
+        # Prefer the explicit model:kind reading when both sides happen
+        # to be kind-shaped names. The reversed kind:model form remains
+        # accepted for downstream experiments.
+        if right_kind is not None:
+            method, kind = left, right_kind
+        else:
+            method, kind = right, left_kind
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        return KindAccessor(kind, method=method, scope=scope)
+
+    def _try_method_dot_kind_accessor(self, scope=""):
+        if (
+            self.tokenizer.peek_at(0)[0] != "IDENT"
+            or self.tokenizer.peek_at(1)[0] != "DOT"
+            or self.tokenizer.peek_at(2)[0] != "IDENT"
+        ):
+            return None
+        method = self.tokenizer.peek_at(0)[1]
+        kind_name = self.tokenizer.peek_at(2)[1]
+        kind = self._prediction_kind_for_name(kind_name)
+        if kind is None:
+            return None
+        # Preserve normal kind.field / kind.transform handling.
+        if self._is_kind_name(method):
+            return None
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        self.tokenizer.advance()
+        return KindAccessor(kind, method=method, scope=scope)
 
     def _call_args(self):
         self.tokenizer.expect("LPAREN")
@@ -481,11 +655,21 @@ class _Parser:
             )
         raise ValueError(f"Cannot access .{name} on {type(node).__name__}")
 
-    def _apply_bracket(self, node, method, version):
+    def _apply_bracket(self, node, args):
         if isinstance(node, KindAccessor):
-            if version is None:
-                return node[method]
-            return node[method, version]
+            if len(args) == 1:
+                if node.method is not None:
+                    return KindAccessor(
+                        node.kind, method=node.method, version=args[0],
+                        scope=node.scope,
+                    )
+                return node[args[0]]
+            if len(args) == 2:
+                return node[args[0], args[1]]
+            raise ValueError(
+                f"Kind qualifier accepts one or two bracket arguments "
+                f"in {self.text!r}"
+            )
         raise ValueError(f"Cannot use ['...'] on {type(node).__name__}")
 
     def _is_kind_name(self, name):
@@ -496,6 +680,9 @@ class _Parser:
             return True
         except ValueError:
             return False
+
+    def _prediction_kind_for_name(self, name):
+        return _KIND_ALIASES.get(name.strip().lower())
 
 
 def parse(text: str) -> DSLNode:


### PR DESCRIPTION
## Summary

- add quote-free model-qualified kind aliases: `model:kind`, `kind:model`, and `model.kind`
- add version-friendly model-first forms such as `mhcflurry[2.1.5]:ba`, `mhcflurry:ba[2.1.5]`, `mhcflurry:release-2.2.0:ba`, and `mhcflurry-4.1b:affinity`
- allow unquoted version labels in version slots, including identifier-leading labels such as `v2.1` and `release-2.2.0`
- keep canonical parser output on existing bracket syntax
- document the aliases and bump version to 5.10.3

Closes #150.
Closes #152.

## Verification

- `./lint.sh`
- `./test.sh`