### PR TITLE
Clean up DSL version syntax docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.10.4
+
+**DSL version syntax cleanup:**
+
+- Removed the experimental `model:version:kind` string form, e.g.
+  `mhcflurry:release-2.2.0:ba.score`. Use bracketed model versions
+  instead: `mhcflurry[release-2.2.0]:ba.score`.
+- Kept the compact dash form for numeric-leading versions, e.g.
+  `mhcflurry-4.1b:affinity.score`.
+- Documented the recommended string DSL syntax separately from accepted
+  compatibility aliases.
+
 ## 5.10.3
 
 **Quote-free model-qualified kind syntax (#150):**

--- a/README.md
+++ b/README.md
@@ -204,12 +204,18 @@ Every filter and ranking expression has a string form for use at the CLI or in c
 | `Affinity.rank <= 2` | `affinity.rank <= 2` |
 | `Presentation.score >= 0.5` | `el.score >= 0.5` |
 | `(Affinity <= 500) \| (Presentation.rank <= 2)` | `affinity <= 500 \| el.rank <= 2` |
-| `Affinity["netmhcpan"] <= 500` | `netmhcpan_ba <= 500` |
+| `Affinity["netmhcpan"] <= 500` | `netmhcpan:affinity <= 500` |
+| `Affinity["netmhcpan", "4.1b"].score` | `netmhcpan[4.1b]:affinity.score` |
 | `0.5 * Affinity.score + 0.5 * Presentation.score` | `0.5 * affinity.score + 0.5 * presentation.score` |
 | `Affinity.logistic(350, 150)` | `affinity.logistic(350, 150)` |
 | `mean(Affinity.score, Presentation.score)` | `mean(affinity.score, presentation.score)` |
 | `Column("gene_tpm") >= 5` | `gene_tpm >= 5` |
 | `Column("gene_tpm").log()` | `gene_tpm.log()` |
+
+For method-qualified predictions, prefer `model:kind` and
+`model[version]:kind`; `model-version:kind` is accepted for
+numeric-leading versions such as `netmhcpan-4.1b:affinity`. See
+[docs/ranking.md](docs/ranking.md) for the full syntax and alias table.
 
 ### Column references
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,7 +214,9 @@ Apply with `apply_filter(df, node)` and `apply_sort(df, [nodes])`.
 
 ### Tool-qualified kinds
 
-Prefix with tool name and underscore: `netmhcpan_affinity`, `mhcflurry_el`, `netmhcpan_ba`.
+Prefer colon syntax: `netmhcpan:affinity`, `mhcflurry:el`,
+`netmhcpan:ba`. The older underscore aliases also work:
+`netmhcpan_affinity`, `mhcflurry_el`, `netmhcpan_ba`.
 
 ### parse
 
@@ -229,6 +231,7 @@ The unified DSL parser. Returns a `DSLNode`.
 | `"netmhcpan.affinity <= 500"` | `Comparison(Field(pMHC_affinity, "value", method="netmhcpan"), <=, 500)` |
 | `"netmhcpan[4.1b]:affinity.score"` | `Field(pMHC_affinity, "score", method="netmhcpan", version="4.1b")` |
 | `"netmhcpan-4.1b:affinity.score"` | `Field(pMHC_affinity, "score", method="netmhcpan", version="4.1b")` |
+| `"netmhcpan[release-2.2.0]:affinity.score"` | `Field(pMHC_affinity, "score", method="netmhcpan", version="release-2.2.0")` |
 | `"affinity['netmhcpan', '4.1b'].value <= 500"` | `Comparison(Field(..., method="netmhcpan", version="4.1b"), <=, 500)` |
 | `"column(cysteine_count) <= 2"` | `Comparison(Column("cysteine_count"), <=, 2)` |
 | `"a <= 500 \| b <= 2"` | `BoolOp(\|, [Comparison(a), Comparison(b)])` |

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -229,18 +229,19 @@ count('KR') >= 2              # filter: at least 2 basic residues
 Affinity["netmhcpan", "4.1b"].value    # only NetMHCpan v4.1b rows
 ```
 
-In the string DSL, both forms work:
+In the string DSL, prefer these forms:
 
 ```
-affinity['netmhcpan'].value <= 500
-affinity['netmhcpan', '4.1b'].value <= 500
 affinity[netmhcpan, 4.1b].value <= 500
 affinity[netmhcpan, release-2.2.0].value <= 500
 netmhcpan[4.1b]:affinity.value <= 500
-netmhcpan:4.1b:affinity.value <= 500
 netmhcpan-4.1b:affinity.value <= 500
 wt.netmhcpan[4.1b]:ba.score
 ```
+
+Use brackets for arbitrary version labels. The dash form is a compact
+shortcut for numeric-leading versions; the required `:kind` suffix keeps
+it distinct from ordinary subtraction.
 
 ## Parsing strings
 
@@ -264,20 +265,29 @@ The `--filter-by` flag and `--sort-by` flag accept string expressions:
 | `Affinity <= 500` | `affinity <= 500` or `ba <= 500` |
 | `Affinity.rank <= 2` | `affinity.rank <= 2` |
 | `Affinity.score >= 0.5` | `affinity.score >= 0.5` |
-| `Affinity["netmhcpan"] <= 500` | `netmhcpan:affinity <= 500`, `affinity:netmhcpan <= 500`, `netmhcpan.affinity <= 500`, `affinity[netmhcpan] <= 500`, `netmhcpan_ba <= 500` |
-| `Affinity["netmhcpan", "4.1b"].score` | `netmhcpan[4.1b]:affinity.score`, `netmhcpan:affinity[4.1b].score`, `affinity[netmhcpan, 4.1b].score` |
+| `Affinity["netmhcpan"] <= 500` | `netmhcpan:affinity <= 500` |
+| `Affinity["netmhcpan", "4.1b"].score` | `netmhcpan[4.1b]:affinity.score` or `netmhcpan-4.1b:affinity.score` |
 | `Presentation["mhcflurry"].rank <= 2` | `mhcflurry:el.rank <= 2` or `mhcflurry_el.rank <= 2` |
 | `Column("cysteine_count") <= 2` | `column(cysteine_count) <= 2` |
 | `(A <= 500) \| (B.rank <= 2)` | `affinity <= 500 \| presentation.rank <= 2` |
 | `(A <= 500) & (B.rank <= 2)` | `affinity <= 500 & presentation.rank <= 2` |
 
-**Kind aliases:** `ba` / `aff` / `ic50` = Affinity, `el` = Presentation.
+**Recommended model-qualified syntax:**
 
-**Model-qualified kinds:** Canonical serialization still uses bracket
-form (`affinity[netmhcpan]`), but model-first forms read better in
-configuration: `netmhcpan:affinity`, `netmhcpan.affinity`, and
-`netmhcpan[4.1b]:affinity`. Versioned model-first refs can also use
-`netmhcpan:4.1b:affinity` or `netmhcpan-4.1b:affinity`.
+| Meaning | Prefer |
+|---|---|
+| Method-specific kind | `netmhcpan:affinity.score` |
+| Method-specific alias | `mhcflurry:ba.score`, `mhcflurry:el.rank` |
+| Method + arbitrary version | `netmhcpan[release-2.2.0]:affinity.score` |
+| Method + numeric-leading version | `netmhcpan-4.1b:affinity.score` |
+| Wildtype scope | `wt.netmhcpan[4.1b]:ba.score` |
+
+**Accepted aliases:** `ba` / `aff` / `ic50` = Affinity, `el` =
+Presentation. Canonical serialization still uses bracket form
+(`affinity[netmhcpan]`). The parser also accepts compatibility forms
+such as `affinity:netmhcpan`, `netmhcpan.affinity`,
+`affinity[netmhcpan]`, and `netmhcpan_ba`, but new docs and configs
+should use the recommended forms above.
 
 **All features work in both Python and CLI string form** (`--sort-by`):
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1967,11 +1967,9 @@ def test_parse_identifier_leading_model_version_unquoted():
     assert expr.version == "release-2.2.0"
 
 
-def test_parse_model_colon_version_colon_kind():
-    expr = parse("mhcflurry:release-2.2.0:ba.score")
-    bracket = parse("ba[mhcflurry, release-2.2.0].score")
-    assert isinstance(expr, Field)
-    assert expr.to_ast_string() == bracket.to_ast_string()
+def test_parse_model_colon_version_colon_kind_rejected():
+    with pytest.raises(ValueError, match="prediction kind"):
+        parse("mhcflurry:release-2.2.0:ba.score")
 
 
 def test_parse_model_dash_version_colon_kind():
@@ -1982,8 +1980,8 @@ def test_parse_model_dash_version_colon_kind():
 
 
 def test_parse_scoped_model_dash_version_colon_kind():
-    expr = parse("wt.mhcflurry-release-2.2.0:ba.score")
-    bracket = parse("wt.ba[mhcflurry, release-2.2.0].score")
+    expr = parse("wt.mhcflurry-4.1b:ba.score")
+    bracket = parse("wt.ba[mhcflurry, 4.1b].score")
     assert isinstance(expr, Field)
     assert expr.to_ast_string() == bracket.to_ast_string()
 

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.3"
+__version__ = "5.10.4"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/parser.py
+++ b/topiary/ranking/parser.py
@@ -15,7 +15,7 @@ Grammar (lowest precedence first)::
     atom     := NUMBER | '(' top ')' | abs(expr) | agg(expr,...)
               | count(STR) | column(IDENT) | len
               | IDENT ('[' BRACKET_ARG ']')? (':' | '.') kind_ref
-              | IDENT (':' | '-') BRACKET_ARG ':' kind_ref
+              | IDENT '-' numeric_version ':' kind_ref
               | CONTEXT '.' scoped_atom | kind_ref | IDENT
 """
 
@@ -407,9 +407,9 @@ class _Parser:
             versioned_model_accessor = self._try_versioned_model_kind_accessor()
             if versioned_model_accessor is not None:
                 return versioned_model_accessor
-            separated_version_accessor = self._try_separated_version_kind_accessor()
-            if separated_version_accessor is not None:
-                return separated_version_accessor
+            dash_version_accessor = self._try_dash_version_kind_accessor()
+            if dash_version_accessor is not None:
+                return dash_version_accessor
             colon_accessor = self._try_colon_kind_accessor()
             if colon_accessor is not None:
                 return colon_accessor
@@ -443,11 +443,11 @@ class _Parser:
         versioned_model_accessor = self._try_versioned_model_kind_accessor(scope=scope)
         if versioned_model_accessor is not None:
             return versioned_model_accessor
-        separated_version_accessor = self._try_separated_version_kind_accessor(
+        dash_version_accessor = self._try_dash_version_kind_accessor(
             scope=scope,
         )
-        if separated_version_accessor is not None:
-            return separated_version_accessor
+        if dash_version_accessor is not None:
+            return dash_version_accessor
         colon_accessor = self._try_colon_kind_accessor(scope=scope)
         if colon_accessor is not None:
             return colon_accessor
@@ -522,11 +522,12 @@ class _Parser:
             kind, method=method, version=version, scope=scope,
         )
 
-    def _try_separated_version_kind_accessor(self, scope=""):
-        if self.tokenizer.peek_at(0)[0] != "IDENT":
-            return None
-        separator = self.tokenizer.peek_at(1)
-        if separator not in (("COLON", ":"), ("OP", "-")):
+    def _try_dash_version_kind_accessor(self, scope=""):
+        if (
+            self.tokenizer.peek_at(0)[0] != "IDENT"
+            or self.tokenizer.peek_at(1) != ("OP", "-")
+            or self.tokenizer.peek_at(2)[0] != "NUMBER"
+        ):
             return None
         saved_idx = self.tokenizer.mark()
         method = self.tokenizer.advance()[1]


### PR DESCRIPTION
## Summary

- remove the experimental `model:version:kind` parser form, e.g. `mhcflurry:release-2.2.0:ba.score`
- keep `model-version:kind` for numeric-leading versions, e.g. `mhcflurry-4.1b:affinity.score`
- document recommended DSL forms separately from accepted compatibility aliases
- bump version to 5.10.4

## Verification

- `pytest tests/test_ranking.py -q`
- `./lint.sh`
- `./test.sh`
