### PR TITLE
Use one Python interpreter in deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.10.5
+
+**Deploy script interpreter selection (#149):**
+
+- `deploy.sh` now uses one configurable Python interpreter throughout
+  the release flow (`PYTHON=${PYTHON:-python3}`), including version
+  detection, the PyPI version check, build, and twine upload.
+- The build step removes both `dist/` and `build/` before packaging so
+  stale local build outputs cannot shadow the PyPA `build` module.
+
 ## 5.10.4
 
 **DSL version syntax cleanup:**

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,9 +3,13 @@ set -euo pipefail
 
 # Deploy topiary to PyPI
 # Usage: ./deploy.sh
+# Override the interpreter with PYTHON=/path/to/python ./deploy.sh
 
-VERSION=$(python3 -c "import topiary; print(topiary.__version__)")
+PYTHON=${PYTHON:-python3}
+PYTHON_BIN=$("${PYTHON}" -c "import sys; print(sys.executable)")
+VERSION=$("${PYTHON}" -c "import topiary; print(topiary.__version__)")
 echo "Deploying topiary v${VERSION}"
+echo "Using Python: ${PYTHON_BIN}"
 
 # Check we're on master
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -22,7 +26,7 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 # Check version isn't already on PyPI
-if pip index versions topiary 2>/dev/null | grep -q "${VERSION}"; then
+if "${PYTHON}" -m pip index versions topiary 2>/dev/null | grep -q "${VERSION}"; then
     echo "ERROR: topiary ${VERSION} already exists on PyPI"
     exit 1
 fi
@@ -34,14 +38,14 @@ fi
 ./test.sh
 
 # Build
-rm -rf dist
-python3 -m build
+rm -rf dist build
+"${PYTHON}" -m build
 echo ""
 echo "Uploading:"
 ls -lh dist/
 
 # Upload
-python3 -m twine upload dist/*
+"${PYTHON}" -m twine upload dist/*
 
 # Tag and push
 git tag "v${VERSION}"

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -1,0 +1,26 @@
+"""Regression tests for deploy.sh release safety checks."""
+
+import re
+from pathlib import Path
+
+
+def test_deploy_script_uses_one_configured_python():
+    """deploy.sh should not mix python3 and a different pip executable."""
+    script = Path("deploy.sh").read_text()
+    assert "PYTHON=${PYTHON:-python3}" in script
+    assert 'VERSION=$("${PYTHON}" -c' in script
+    assert '"${PYTHON}" -m pip index versions topiary' in script
+    assert '"${PYTHON}" -m build' in script
+    assert '"${PYTHON}" -m twine upload dist/*' in script
+    assert "rm -rf dist build" in script
+
+    for line in script.splitlines():
+        command = line.strip()
+        if (
+            not command
+            or command.startswith("#")
+            or command.startswith("PYTHON=")
+        ):
+            continue
+        assert re.search(r"(^|[;&|]\s*)python3(\s|$)", command) is None
+        assert re.search(r"(^|[;&|]\s*)pip(\s|$)", command) is None

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.4"
+__version__ = "5.10.5"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
## Summary

- make `deploy.sh` use one configurable interpreter via `PYTHON=${PYTHON:-python3}`
- run PyPI version checks, build, and twine upload through `$PYTHON -m ...`
- remove both `dist/` and `build/` before packaging
- add a lightweight regression test for the deploy script
- bump version to 5.10.5

Closes #149.

## Verification

- `pytest tests/test_deploy_script.py -q`
- `bash -n deploy.sh`
- `PYTHON=python3.9 bash -c 'source deploy.sh'` (confirmed branch guard stops before release work)
- `./lint.sh`
- `./test.sh`
