### PR TITLE
Shrink CachedPredictor row index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.10.6
+
+**CachedPredictor index memory footprint (#134):**
+
+- `CachedPredictor` now stores row positions in its internal key index
+  instead of duplicating each cached row as a Python dictionary.
+- Added a prefix index for `(peptide, allele, peptide_length)` lookups
+  so cache hits no longer scan every full row key.
+
 ## 5.10.5
 
 **Deploy script interpreter selection (#149):**

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -122,6 +122,31 @@ class TestPredictPeptides:
         assert out.iloc[0]["peptide"] == "SIINFEKLA"
         assert out.iloc[0]["affinity"] == 150.0
 
+    def test_index_stores_row_positions_not_row_dicts(self):
+        cache = CachedPredictor.from_dataframe(_df([
+            _row(peptide="SIINFEKLA", kind="pMHC_affinity"),
+            _row(peptide="SIINFEKLA", kind="pMHC_presentation"),
+        ]))
+        key = ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
+        assert isinstance(cache._index[key], int)
+        assert cache._prefix_index[("SIINFEKLA", "HLA-A*02:01", 9)] == [0, 1]
+
+    def test_build_index_does_not_materialize_record_dicts(self, monkeypatch):
+        original_to_dict = pd.DataFrame.to_dict
+
+        def fail_records(frame, orient="dict", *args, **kwargs):
+            if orient == "records":
+                raise AssertionError("index build materialized row dicts")
+            return original_to_dict(frame, orient=orient, *args, **kwargs)
+
+        monkeypatch.setattr(pd.DataFrame, "to_dict", fail_records)
+        cache = CachedPredictor.from_dataframe(_df([
+            _row(peptide="SIINFEKLA", kind="pMHC_affinity"),
+            _row(peptide="SIINFEKLA", kind="pMHC_presentation"),
+        ]))
+        key = ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
+        assert cache._index[key] == 0
+
     def test_miss_raises_without_fallback(self):
         cache = CachedPredictor.from_dataframe(_df([_row()]))
         with pytest.raises(KeyError, match="missed"):
@@ -262,9 +287,10 @@ class TestFallback:
         # preserve-existing guard, the random-predictor output would
         # overwrite the 42.0 sentinel.
         cache.predict_peptides_dataframe(["SIINFEKLA"])
-        preserved = cache._index[
+        preserved_idx = cache._index[
             ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
         ]
+        preserved = cache._df.iloc[preserved_idx]
         assert preserved["affinity"] == 42.0
 
 

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.5"
+__version__ = "5.10.6"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -30,6 +30,7 @@ Fallback semantics
 from __future__ import annotations
 
 import re
+from itertools import repeat
 from pathlib import Path
 from typing import Callable, Iterable, List, Mapping, Optional, Union
 
@@ -138,12 +139,13 @@ class CachedPredictor:
             self.prediction_method_name = None
             self.predictor_version = None
             self._index = {}
+            self._prefix_index = {}
             return
 
         self._df = self._normalize(df)
         self.prediction_method_name, self.predictor_version = \
             self._unique_version_pair(self._df)
-        self._index = self._build_index(self._df)
+        self._index, self._prefix_index = self._build_index(self._df)
 
     # --- normalization + invariants ---------------------------------
 
@@ -229,24 +231,81 @@ class CachedPredictor:
         return row["prediction_method_name"], row["predictor_version"]
 
     @staticmethod
-    def _build_index(df: pd.DataFrame) -> dict:
+    def _row_key(row):
+        """Composite cache key for one normalized prediction row."""
+        return CachedPredictor._row_key_from_values(
+            row["peptide"],
+            row["allele"],
+            row["peptide_length"],
+            row["kind"],
+            row.get("n_flank"),
+            row.get("c_flank"),
+        )
+
+    @staticmethod
+    def _row_key_from_values(
+        peptide,
+        allele,
+        peptide_length,
+        kind,
+        n_flank,
+        c_flank,
+    ):
+        """Composite cache key from already-extracted row values."""
+        return (
+            str(peptide),
+            str(allele),
+            int(peptide_length),
+            str(kind),
+            _flank_key(n_flank),
+            _flank_key(c_flank),
+        )
+
+    @classmethod
+    def _row_keys_from_frame(cls, df: pd.DataFrame):
+        """Yield cache keys by walking columns, not materialized row dicts."""
+        n = len(df)
+        n_flanks = (
+            df["n_flank"].to_numpy(copy=False)
+            if "n_flank" in df.columns
+            else repeat(None, n)
+        )
+        c_flanks = (
+            df["c_flank"].to_numpy(copy=False)
+            if "c_flank" in df.columns
+            else repeat(None, n)
+        )
+        for values in zip(
+            df["peptide"].to_numpy(copy=False),
+            df["allele"].to_numpy(copy=False),
+            df["peptide_length"].to_numpy(copy=False),
+            df["kind"].to_numpy(copy=False),
+            n_flanks,
+            c_flanks,
+        ):
+            yield cls._row_key_from_values(*values)
+
+    @classmethod
+    def _build_index(cls, df: pd.DataFrame) -> tuple[dict, dict]:
         """Build ``(peptide, allele, peptide_length, kind, n_flank,
-        c_flank) → row_dict`` index.  The full key lets a single cache
+        c_flank) → row_position`` index.  The full key lets a single cache
         hold multiple kinds per (peptide, allele) — and, within a kind
         that depends on flanking context (mhcflurry processing and
         presentation), distinguish the same peptide at different
-        source-protein positions."""
-        return {
-            (
-                str(r["peptide"]),
-                str(r["allele"]),
-                int(r["peptide_length"]),
-                str(r["kind"]),
-                _flank_key(r.get("n_flank")),
-                _flank_key(r.get("c_flank")),
-            ): r.to_dict()
-            for _, r in df.iterrows()
-        }
+        source-protein positions.
+
+        Store integer row positions rather than row dictionaries so
+        whole-proteome caches do not duplicate every row in Python
+        objects. A separate prefix index keeps batch lookups O(matches)
+        instead of scanning all keys.
+        """
+        index = {}
+        for pos, key in enumerate(cls._row_keys_from_frame(df)):
+            index[key] = pos
+        prefix_index = {}
+        for key, pos in index.items():
+            prefix_index.setdefault(key[:3], []).append(pos)
+        return index, prefix_index
 
     # --- mhctools protocol ------------------------------------------
 
@@ -329,10 +388,10 @@ class CachedPredictor:
         """Return every cached row matching ``(peptide, allele,
         peptide_length)`` — all kinds and flank contexts."""
         prefix = (str(peptide), str(allele), int(length))
-        return [
-            row for key, row in self._index.items()
-            if key[:3] == prefix
-        ]
+        row_positions = self._prefix_index.get(prefix, [])
+        if not row_positions:
+            return []
+        return self._df.iloc[row_positions].to_dict("records")
 
     def _cache_kinds(self):
         """Distinct kinds present in the cache."""
@@ -428,22 +487,11 @@ class CachedPredictor:
         # P present for allele A, missing for allele B) would see its
         # (P, A) row silently overwritten by the fallback's output
         # when (P, B) triggers a fallback call.  Preserve user intent.
-        def _row_key(row):
-            return (
-                str(row["peptide"]),
-                str(row["allele"]),
-                int(row["peptide_length"]),
-                str(row["kind"]),
-                _flank_key(row.get("n_flank")),
-                _flank_key(row.get("c_flank")),
-            )
-
-        novel_mask = new_rows.apply(
-            lambda r: _row_key(r) not in self._index, axis=1,
-        )
-        novel_rows = new_rows[novel_mask]
-        for _, r in novel_rows.iterrows():
-            self._index[_row_key(r)] = r.to_dict()
+        novel_mask = [
+            key not in self._index
+            for key in self._row_keys_from_frame(new_rows)
+        ]
+        novel_rows = new_rows[novel_mask].copy()
 
         if len(novel_rows) == 0:
             return
@@ -456,6 +504,7 @@ class CachedPredictor:
             self._df = pd.concat(
                 [self._df, novel_rows], ignore_index=True,
             )
+        self._index, self._prefix_index = self._build_index(self._df)
 
     @staticmethod
     def _conform_predictor_output(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary

- store integer row positions in `CachedPredictor._index` instead of duplicating every cached row as a Python dict
- add `_prefix_index` for `(peptide, allele, peptide_length)` hit lookups without scanning every full key
- keep fallback cache merge semantics by rebuilding the compact indexes after new rows are appended
- add a regression test for the compact internal index shape
- bump version to 5.10.6

Closes #134.

## Verification

- `pytest tests/test_cached_predictor.py -q`
- `./lint.sh`
- `./test.sh`
