### PR TITLE
Defer Varcode imports for direct workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 5.10.7
+
+**Lazy Varcode imports (#122):**
+
+- Topiary's CLI now registers Varcode-compatible variant arguments locally
+  and imports Varcode only when the variant-loading pipeline runs.
+- Moved Varcode imports in filtering and protein-change helpers into the
+  functions that actually need Varcode objects.
+- Added import-guard tests so `import topiary` and direct CLI parser setup do
+  not load Varcode or its VCF dependency stack.
+
 ## 5.10.6
 
 **CachedPredictor index memory footprint (#134):**

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import textwrap
+
+
+def _run_import_check(code):
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_import_topiary_does_not_import_varcode():
+    _run_import_check(
+        """
+        import sys
+        import topiary
+
+        if any(k == "varcode" or k.startswith("varcode.") for k in sys.modules):
+            raise SystemExit("import topiary imported varcode")
+        """
+    )
+
+
+def test_cli_direct_parser_does_not_import_varcode():
+    _run_import_check(
+        """
+        import sys
+        from topiary.cli.args import arg_parser
+
+        arg_parser.parse_args([
+            "--mhc-predictor", "random",
+            "--mhc-alleles", "A0201",
+            "--peptide-csv", "peptides.csv",
+        ])
+
+        if any(k == "varcode" or k.startswith("varcode.") for k in sys.modules):
+            raise SystemExit("direct CLI parser imported varcode")
+        """
+    )

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.6"
+__version__ = "5.10.7"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -18,7 +18,6 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import pandas as pd
 from mhctools.cli import add_mhc_args, predictors_from_args
-from varcode.cli import add_variant_args, variant_collection_from_args
 
 from .cached_predictor import (
     add_cached_predictor_args,
@@ -64,6 +63,75 @@ from ..ranking import (
     _resolve_qualified_kind,
     parse,
 )
+
+
+def add_variant_args(arg_parser):
+    """Add Varcode-compatible variant arguments without importing Varcode."""
+    variant_arg_group = arg_parser.add_argument_group(
+        title="Variants",
+        description="Genomic variant files",
+    )
+    variant_arg_group.add_argument(
+        "--vcf",
+        default=[],
+        action="append",
+        help="Genomic variants in VCF format",
+    )
+    variant_arg_group.add_argument(
+        "--maf",
+        default=[],
+        action="append",
+        help="Genomic variants in TCGA's MAF format",
+    )
+    variant_arg_group.add_argument(
+        "--variant",
+        default=[],
+        action="append",
+        nargs=4,
+        metavar=("CHR", "POS", "REF", "ALT"),
+        help=(
+            "Individual variant as 4 arguments giving chromosome, position, "
+            "ref, and alt. Example: chr1 3848 C G. Use '.' to indicate empty "
+            "alleles for insertions or deletions."
+        ),
+    )
+    variant_arg_group.add_argument(
+        "--genome",
+        type=str,
+        help=(
+            "What reference assembly your variant coordinates are using. "
+            "Examples: 'hg19', 'GRCh38', or 'mm9'. "
+            "This argument is ignored for MAF files, since each row includes "
+            "the reference. For VCF files, this is used if specified, and "
+            "otherwise is guessed from the header. For variants specified on "
+            "the commandline with --variant, this option is required."
+        ),
+    )
+    variant_arg_group.add_argument(
+        "--download-reference-genome-data",
+        action="store_true",
+        default=False,
+        help=(
+            "Automatically download genome reference data required for "
+            "annotation using PyEnsembl. Otherwise you must first run "
+            "'pyensembl install' for the release/species corresponding "
+            "to the genome used in your VCF."
+        ),
+    )
+    variant_arg_group.add_argument(
+        "--json-variants",
+        default=[],
+        action="append",
+        help="Path to Varcode.VariantCollection object serialized as a JSON file.",
+    )
+    return variant_arg_group
+
+
+def variant_collection_from_args(args, required=True):
+    """Load variants through Varcode only when the variant pipeline runs."""
+    from varcode.cli import variant_collection_from_args as _from_args
+
+    return _from_args(args, required=required)
 
 
 def _add_input_args(arg_parser):

--- a/topiary/cli/protein_changes.py
+++ b/topiary/cli/protein_changes.py
@@ -11,10 +11,6 @@
 # limitations under the License.
 
 import logging
-from pyensembl import ensembl_grch38
-from varcode import EffectCollection
-from varcode.effects import Substitution
-from varcode.reference import infer_genome
 import re
 
 
@@ -37,9 +33,13 @@ def add_protein_change_args(arg_parser):
 
 def genome_from_args(args):
     if args.genome:
+        from varcode.reference import infer_genome
+
         genome, _ = infer_genome(args.genome)
         return genome
     else:
+        from pyensembl import ensembl_grch38
+
         # no genome specified, assume it can be inferred from the file(s)
         # we're loading
         return ensembl_grch38
@@ -74,6 +74,9 @@ def best_transcript(transcripts):
 
 
 def protein_change_effects_from_args(args):
+    from varcode import EffectCollection
+    from varcode.effects import Substitution
+
     genome = genome_from_args(args)
     valid_gene_names = set(genome.gene_names())
     substitution_regex = re.compile("([A-Z]+)([0-9]+)([A-Z]+)")

--- a/topiary/filters.py
+++ b/topiary/filters.py
@@ -16,8 +16,6 @@ Helper functions for filtering variants, effects, and epitope predictions
 
 import logging
 
-from varcode import NonsilentCodingMutation
-
 
 def apply_filter(
     filter_fn, collection, result_fn=None, filter_name="", collection_name=""
@@ -51,6 +49,8 @@ def filter_silent_and_noncoding_effects(effects):
     ----------
     effects : varcode.EffectCollection
     """
+    from varcode import NonsilentCodingMutation
+
     return apply_filter(
         filter_fn=lambda effect: isinstance(effect, NonsilentCodingMutation),
         collection=effects,


### PR DESCRIPTION
## Summary

- register Varcode-compatible variant CLI flags locally so parser setup does not import Varcode
- lazy-import Varcode only when variant loading, effect filtering, or protein-change construction actually runs
- add subprocess import guards for `import topiary` and direct CLI parser setup
- bump version to 5.10.7

## Related

- Addresses the Topiary side of #122
- Upstream Varcode/PyVCF3 follow-up filed as openvax/varcode#355

## Verification

- `pytest tests/test_lazy_imports.py tests/test_direct_input_regressions.py tests/test_cli_protein_changes.py tests/test_args_outputs.py -q`
- `./lint.sh`
- `./test.sh`