### PR TITLE
Restore Varcode CLI parser delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.10.8
+
+**Restore Varcode CLI parser delegation:**
+
+- Reverted Topiary's local copy of Varcode variant CLI arguments so
+  `topiary.cli.args` again delegates `add_variant_args` and
+  `variant_collection_from_args` to `varcode.cli`.
+- Kept the narrower lazy imports for non-CLI Varcode helpers, so plain
+  `import topiary` still avoids loading Varcode.
+
 ## 5.10.7
 
 **Lazy Varcode imports (#122):**

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -25,19 +25,15 @@ def test_import_topiary_does_not_import_varcode():
     )
 
 
-def test_cli_direct_parser_does_not_import_varcode():
+def test_cli_variant_helpers_delegate_to_varcode():
     _run_import_check(
         """
-        import sys
-        from topiary.cli.args import arg_parser
+        import topiary.cli.args as cli_args
+        import varcode.cli
 
-        arg_parser.parse_args([
-            "--mhc-predictor", "random",
-            "--mhc-alleles", "A0201",
-            "--peptide-csv", "peptides.csv",
-        ])
-
-        if any(k == "varcode" or k.startswith("varcode.") for k in sys.modules):
-            raise SystemExit("direct CLI parser imported varcode")
+        if cli_args.add_variant_args is not varcode.cli.add_variant_args:
+            raise SystemExit("Topiary is not delegating variant CLI args to Varcode")
+        if cli_args.variant_collection_from_args is not varcode.cli.variant_collection_from_args:
+            raise SystemExit("Topiary is not delegating variant loading to Varcode")
         """
     )

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.7"
+__version__ = "5.10.8"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cli/args.py
+++ b/topiary/cli/args.py
@@ -18,6 +18,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import pandas as pd
 from mhctools.cli import add_mhc_args, predictors_from_args
+from varcode.cli import add_variant_args, variant_collection_from_args
 
 from .cached_predictor import (
     add_cached_predictor_args,
@@ -63,75 +64,6 @@ from ..ranking import (
     _resolve_qualified_kind,
     parse,
 )
-
-
-def add_variant_args(arg_parser):
-    """Add Varcode-compatible variant arguments without importing Varcode."""
-    variant_arg_group = arg_parser.add_argument_group(
-        title="Variants",
-        description="Genomic variant files",
-    )
-    variant_arg_group.add_argument(
-        "--vcf",
-        default=[],
-        action="append",
-        help="Genomic variants in VCF format",
-    )
-    variant_arg_group.add_argument(
-        "--maf",
-        default=[],
-        action="append",
-        help="Genomic variants in TCGA's MAF format",
-    )
-    variant_arg_group.add_argument(
-        "--variant",
-        default=[],
-        action="append",
-        nargs=4,
-        metavar=("CHR", "POS", "REF", "ALT"),
-        help=(
-            "Individual variant as 4 arguments giving chromosome, position, "
-            "ref, and alt. Example: chr1 3848 C G. Use '.' to indicate empty "
-            "alleles for insertions or deletions."
-        ),
-    )
-    variant_arg_group.add_argument(
-        "--genome",
-        type=str,
-        help=(
-            "What reference assembly your variant coordinates are using. "
-            "Examples: 'hg19', 'GRCh38', or 'mm9'. "
-            "This argument is ignored for MAF files, since each row includes "
-            "the reference. For VCF files, this is used if specified, and "
-            "otherwise is guessed from the header. For variants specified on "
-            "the commandline with --variant, this option is required."
-        ),
-    )
-    variant_arg_group.add_argument(
-        "--download-reference-genome-data",
-        action="store_true",
-        default=False,
-        help=(
-            "Automatically download genome reference data required for "
-            "annotation using PyEnsembl. Otherwise you must first run "
-            "'pyensembl install' for the release/species corresponding "
-            "to the genome used in your VCF."
-        ),
-    )
-    variant_arg_group.add_argument(
-        "--json-variants",
-        default=[],
-        action="append",
-        help="Path to Varcode.VariantCollection object serialized as a JSON file.",
-    )
-    return variant_arg_group
-
-
-def variant_collection_from_args(args, required=True):
-    """Load variants through Varcode only when the variant pipeline runs."""
-    from varcode.cli import variant_collection_from_args as _from_args
-
-    return _from_args(args, required=required)
 
 
 def _add_input_args(arg_parser):


### PR DESCRIPTION
## Summary

- restore `topiary.cli.args` to importing `add_variant_args` and `variant_collection_from_args` from `varcode.cli`
- remove Topiary-owned copies of Varcode variant CLI flag definitions to avoid downstream drift
- keep the narrower lazy imports outside CLI parser setup so plain `import topiary` still avoids Varcode
- update import tests to assert Varcode CLI helper delegation
- bump version to 5.10.8

## Related

- Corrects the parser ownership tradeoff from #156
- Upstream Varcode import-path issue remains tracked at openvax/varcode#355

## Verification

- `pytest tests/test_lazy_imports.py tests/test_direct_input_regressions.py tests/test_cli_protein_changes.py tests/test_args_outputs.py -q`
- `./lint.sh`
- `./test.sh`