### PR TITLE
Plumb mhctools kind_support metadata through topiary predictors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.0.0
-mhctools>=3.7.0
+mhctools>=3.13.7
 varcode>=0.3.17
 gtfparse>=0.0.4
 mhcnames

--- a/tests/test_kind_support.py
+++ b/tests/test_kind_support.py
@@ -2,10 +2,38 @@
 and CachedPredictor (mhctools >=3.13.7 metadata API)."""
 
 import pandas as pd
-import pytest
-from mhctools import Kind, RandomBindingPredictor
+from mhctools import (
+    Kind,
+    MHC_CLASS_VALUES,
+    MHC_DEPENDENCE_VALUES,
+    RandomBindingPredictor,
+)
 
 from topiary import CachedPredictor, TopiaryPredictor
+
+
+class FakeProcessingPredictor:
+    """Minimal mhctools-shaped predictor with no allele dependence.
+
+    Mirrors what real processing predictors (Pepsickle, NetChop) report
+    via ``kind_support()`` without needing the external binary.
+    """
+    prediction_method_name = "fake-processing"
+    predictor_version = "0.0.0"
+    default_peptide_lengths = [9]
+    alleles = []
+
+    def kind_support(self):
+        return {
+            Kind.proteasome_cleavage: {
+                "mhc_dependence": "none",
+                "mhc_class": "none",
+            }
+        }
+
+    @property
+    def supported_kinds(self):
+        return tuple(self.kind_support())
 
 
 def _cache_row(
@@ -73,6 +101,66 @@ class TestTopiaryPredictorKindSupport:
             == "I"
         )
 
+    def test_processing_predictor_reports_none_dependence(self):
+        """Allele-independent predictors flow through with mhc_dependence='none'."""
+        binding = RandomBindingPredictor(alleles=["A0201"])
+        processing = FakeProcessingPredictor()
+        predictor = TopiaryPredictor(
+            models=[binding, processing], alleles=["A0201"]
+        )
+        support = predictor.kind_support
+        # Both predictors present, each with their own kind/dependence
+        binding_entry = support["RandomBindingPredictor"]
+        processing_entry = support["fake-processing"]
+        assert binding_entry[Kind.pMHC_affinity]["mhc_dependence"] == "single_allele"
+        assert processing_entry[Kind.proteasome_cleavage] == {
+            "mhc_dependence": "none",
+            "mhc_class": "none",
+        }
+        assert set(predictor.supported_kinds) == {
+            Kind.pMHC_affinity,
+            Kind.proteasome_cleavage,
+        }
+
+
+class TestCompatibilityWithMhctools:
+    """The (model_key, kind) inner dict must stay byte-compatible with what
+    mhctools' own ``kind_support()`` returns — same keys, same value
+    vocabulary — so consumers can pass topiary's metadata anywhere mhctools'
+    is accepted without translation."""
+
+    def test_inner_dict_matches_mhctools_for_each_model(self):
+        model = RandomBindingPredictor(alleles=["A0201"])
+        predictor = TopiaryPredictor(models=model, alleles=["A0201"])
+        wrapped = predictor.kind_support
+        assert len(wrapped) == 1
+        ((_, support),) = wrapped.items()
+        assert support == model.kind_support()
+
+    def test_values_are_in_mhctools_vocabulary(self):
+        predictor = TopiaryPredictor(
+            models=[
+                RandomBindingPredictor(alleles=["A0201"]),
+                FakeProcessingPredictor(),
+            ],
+            alleles=["A0201"],
+        )
+        for model_support in predictor.kind_support.values():
+            for meta in model_support.values():
+                assert meta["mhc_dependence"] in MHC_DEPENDENCE_VALUES
+                assert meta["mhc_class"] in MHC_CLASS_VALUES
+
+    def test_cached_predictor_values_are_in_mhctools_vocabulary(self):
+        cache = CachedPredictor(
+            pd.DataFrame([
+                _cache_row(kind="pMHC_affinity"),
+                _cache_row(peptide="ELAGIGILTV", kind="proteasome_cleavage"),
+            ])
+        )
+        for meta in cache.kind_support().values():
+            assert meta["mhc_dependence"] in MHC_DEPENDENCE_VALUES
+            assert meta["mhc_class"] in MHC_CLASS_VALUES
+
 
 class TestCachedPredictorKindSupport:
     def test_kinds_from_cache_default_to_single_allele(self):
@@ -129,3 +217,48 @@ class TestCachedPredictorKindSupport:
         assert support["pMHC_presentation"]["mhc_dependence"] == "haplotype"
         # Cache had no affinity rows, so fallback's affinity entry isn't surfaced
         assert "pMHC_affinity" not in support
+
+    def test_proteasome_cleavage_rows_default_to_single_allele(self):
+        """No-fallback default for any kind is single_allele/I (the
+        cache stores rows per (peptide, allele, kind), so we can't
+        downgrade to 'none' without external context). This is the
+        documented conservative behavior — a fallback is the way to
+        report 'none' faithfully."""
+        cache = CachedPredictor(
+            pd.DataFrame([_cache_row(kind="proteasome_cleavage")])
+        )
+        support = cache.kind_support()
+        assert support == {
+            "proteasome_cleavage": {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "I",
+            }
+        }
+
+    def test_proteasome_cleavage_via_fallback_reports_none(self):
+        """A fallback that knows it's a processing predictor flows
+        ``mhc_dependence='none'``/``mhc_class='none'`` through to the
+        cache's reported metadata."""
+
+        class FakeProcessingFallback:
+            prediction_method_name = "fake-processing"
+            predictor_version = "0.0.0"
+            alleles = []
+            default_peptide_lengths = [9]
+
+            def kind_support(self):
+                return {
+                    "proteasome_cleavage": {
+                        "mhc_dependence": "none",
+                        "mhc_class": "none",
+                    }
+                }
+
+        cache = CachedPredictor(
+            pd.DataFrame([_cache_row(kind="proteasome_cleavage")]),
+            fallback=FakeProcessingFallback(),
+        )
+        assert cache.kind_support()["proteasome_cleavage"] == {
+            "mhc_dependence": "none",
+            "mhc_class": "none",
+        }

--- a/tests/test_kind_support.py
+++ b/tests/test_kind_support.py
@@ -1,0 +1,131 @@
+"""Tests for kind_support / supported_kinds plumbing on TopiaryPredictor
+and CachedPredictor (mhctools >=3.13.7 metadata API)."""
+
+import pandas as pd
+import pytest
+from mhctools import Kind, RandomBindingPredictor
+
+from topiary import CachedPredictor, TopiaryPredictor
+
+
+def _cache_row(
+    peptide="SIINFEKLA",
+    allele="HLA-A*02:01",
+    *,
+    kind="pMHC_affinity",
+    score=0.5,
+    affinity=150.0,
+    percentile_rank=2.0,
+):
+    return {
+        "peptide": peptide,
+        "allele": allele,
+        "peptide_length": len(peptide),
+        "kind": kind,
+        "score": score,
+        "affinity": affinity,
+        "percentile_rank": percentile_rank,
+        "prediction_method_name": "random",
+        "predictor_version": "1.0",
+    }
+
+
+class TestTopiaryPredictorKindSupport:
+    def test_single_model_reports_kind_support(self):
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"]
+        )
+        support = predictor.kind_support
+        assert list(support.keys()) == ["RandomBindingPredictor"]
+        entry = support["RandomBindingPredictor"]
+        assert entry == {
+            Kind.pMHC_affinity: {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "I",
+            }
+        }
+
+    def test_supported_kinds_dedupes_across_models(self):
+        a = RandomBindingPredictor(alleles=["A0201"])
+        b = RandomBindingPredictor(alleles=["A0201"])
+        predictor = TopiaryPredictor(models=[a, b], alleles=["A0201"])
+        # Two instances of the same predictor still emit the same kind once
+        assert predictor.supported_kinds == (Kind.pMHC_affinity,)
+        # But kind_support keeps both model entries (uniquified keys)
+        assert len(predictor.kind_support) == 2
+
+    def test_kind_support_keys_match_model_keys(self):
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"]
+        )
+        assert set(predictor.kind_support) == set(predictor._model_keys)
+
+    def test_kind_support_returns_dict_copies(self):
+        """Mutating returned dicts must not poison subsequent reads."""
+        predictor = TopiaryPredictor(
+            models=RandomBindingPredictor, alleles=["A0201"]
+        )
+        first = predictor.kind_support
+        first["RandomBindingPredictor"][Kind.pMHC_affinity]["mhc_class"] = "II"
+        second = predictor.kind_support
+        assert (
+            second["RandomBindingPredictor"][Kind.pMHC_affinity]["mhc_class"]
+            == "I"
+        )
+
+
+class TestCachedPredictorKindSupport:
+    def test_kinds_from_cache_default_to_single_allele(self):
+        cache = CachedPredictor(
+            pd.DataFrame([
+                _cache_row(kind="pMHC_affinity"),
+                _cache_row(peptide="ELAGIGILTV", kind="pMHC_presentation"),
+            ])
+        )
+        support = cache.kind_support()
+        assert support == {
+            "pMHC_affinity": {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "I",
+            },
+            "pMHC_presentation": {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "I",
+            },
+        }
+        assert set(cache.supported_kinds) == {
+            "pMHC_affinity",
+            "pMHC_presentation",
+        }
+
+    def test_fallback_kind_support_overrides_for_shared_kinds(self):
+        """If the fallback predictor reports a richer mapping, prefer it
+        for kinds the cache also carries — single-allele vs haplotype is
+        a property of (predictor, kind), not just kind."""
+
+        class FakeFallback:
+            prediction_method_name = "random"
+            predictor_version = "1.0"
+            alleles = ["HLA-A*02:01"]
+            default_peptide_lengths = [9]
+
+            def kind_support(self):
+                return {
+                    "pMHC_affinity": {
+                        "mhc_dependence": "single_allele",
+                        "mhc_class": "I",
+                    },
+                    "pMHC_presentation": {
+                        "mhc_dependence": "haplotype",
+                        "mhc_class": "I",
+                    },
+                }
+
+        cache = CachedPredictor(
+            pd.DataFrame([_cache_row(kind="pMHC_presentation")]),
+            fallback=FakeFallback(),
+        )
+        support = cache.kind_support()
+        assert support["pMHC_presentation"]["mhc_dependence"] == "haplotype"
+        # Cache had no affinity rows, so fallback's affinity entry isn't surfaced
+        assert "pMHC_affinity" not in support

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -51,7 +51,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.10.8"
+__version__ = "5.11.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -323,6 +323,33 @@ class CachedPredictor:
             lengths.update(getattr(self.fallback, "default_peptide_lengths", []))
         return sorted(lengths)
 
+    def kind_support(self):
+        """MHC context for kinds present in the cache.
+
+        Mirrors ``mhctools.BasePredictor.kind_support()``. If a fallback is
+        configured and exposes ``kind_support``, its entries are preferred
+        for the kinds it shares with the cache (so haplotype-mode
+        presentation, etc., is reported faithfully). Kinds present only in
+        the cache default to ``single_allele`` / class I — the cache stores
+        rows per ``(peptide, allele, kind)``, so this is the most
+        conservative truthful description.
+        """
+        cached_kinds = sorted({str(k) for k in self._df["kind"].unique().tolist()})
+        fallback_support = {}
+        if self.fallback is not None and hasattr(self.fallback, "kind_support"):
+            fallback_support = dict(self.fallback.kind_support())
+        support = {}
+        for kind in cached_kinds:
+            if kind in fallback_support:
+                support[kind] = dict(fallback_support[kind])
+            else:
+                support[kind] = {"mhc_dependence": "single_allele", "mhc_class": "I"}
+        return support
+
+    @property
+    def supported_kinds(self):
+        return tuple(self.kind_support())
+
     def _cache_alleles(self):
         return sorted(set(self._df["allele"].unique().tolist()))
 

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -502,6 +502,36 @@ class TopiaryPredictor(object):
         """Backward-compatible alias for ``models``."""
         return self.models
 
+    @property
+    def kind_support(self):
+        """Per-model MHC context for each emitted prediction kind.
+
+        Returns a dict mapping ``model_key -> {kind -> {"mhc_dependence",
+        "mhc_class"}}``, mirroring ``mhctools.BasePredictor.kind_support()``
+        per configured model. ``mhc_dependence`` is one of ``"none"``,
+        ``"single_allele"``, ``"haplotype"``; ``mhc_class`` is one of
+        ``"none"``, ``"I"``, ``"II"``, ``"both"``. Properties are
+        per-(model, kind), not per-kind alone — e.g. MHCflurry reports
+        ``pMHC_presentation`` as ``single_allele`` or ``haplotype`` depending
+        on its configured ``presentation_allele_mode``.
+        """
+        return {
+            key: dict(model.kind_support())
+            for key, model in zip(self._model_keys, self.models)
+        }
+
+    @property
+    def supported_kinds(self):
+        """Tuple of unique prediction kinds emitted across configured models."""
+        seen = []
+        seen_set = set()
+        for model in self.models:
+            for kind in model.supported_kinds:
+                if kind not in seen_set:
+                    seen_set.add(kind)
+                    seen.append(kind)
+        return tuple(seen)
+
     # ------------------------------------------------------------------
     # Prediction entry-points
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expose mhctools 3.13.7's per-(predictor, kind) MHC context metadata on `TopiaryPredictor` and `CachedPredictor` so downstream consumers can branch on `mhc_dependence` (`none` / `single_allele` / `haplotype`) and `mhc_class` (`none` / `I` / `II` / `both`) without re-deriving it. The properties are per-(predictor, kind), not per-kind alone — e.g. MHCflurry reports `pMHC_presentation` as `single_allele` or `haplotype` depending on its configured `presentation_allele_mode`.

- `TopiaryPredictor.kind_support` → `{model_key: {kind: {"mhc_dependence", "mhc_class"}}}`
- `TopiaryPredictor.supported_kinds` → tuple of unique kinds across configured models
- `CachedPredictor.kind_support()` → inferred from kinds present in the cache; if a fallback exposes `kind_support`, its entries are preferred for shared kinds so haplotype semantics survive caching. `supported_kinds` property mirrors.
- Bumps `mhctools` floor to `>=3.13.7` (the release that ships the API).
- Bumps `topiary` to `5.11.0` (additive minor).

This is purely additive — no existing code paths consume the new fields yet. Future work (filter aggregation, wide-form pivots, etc.) can opt into kind-aware behavior on top of this.

## Test plan
- [x] `pytest tests/test_kind_support.py` — 6 new tests covering: single-model passthrough, dedup across duplicate models, model-key alignment, defensive copies, cache-default `single_allele`/`I`, fallback-overrides-for-shared-kinds (haplotype example).
- [x] `pytest tests/` — full suite (1283 passed, 3 skipped).