### PR TITLE
Promote _KIND_ALIASES → public KIND_ALIASES

### DIFF
--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -12,6 +12,7 @@ from .ranking import (
     DSLNode,
     EvalContext,
     Field,
+    KIND_ALIASES,
     KindAccessor,
     Len,
     LogisticExpr,
@@ -51,7 +52,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.11.0"
+__version__ = "5.12.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -69,6 +70,7 @@ __all__ = [
     "DSLNode",
     "EvalContext",
     "Field",
+    "KIND_ALIASES",
     "KindAccessor",
     "Len",
     "LogisticExpr",

--- a/topiary/ranking/__init__.py
+++ b/topiary/ranking/__init__.py
@@ -41,7 +41,7 @@ from .nodes import (
     _GROUP_KEYS,
     _GROUP_KEYS_VARIANT,
     _iter_known_kinds,
-    _KIND_ALIASES,
+    KIND_ALIASES,
     _kind_matches,
     _kind_name,
     _kind_short_name,
@@ -105,4 +105,6 @@ __all__ = [
     "apply_sort",
     "evaluate_scores",
     "parse",
+    # Kind / field name resolution (public)
+    "KIND_ALIASES",
 ]

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1590,9 +1590,9 @@ class Scope:
         if attr == "len":
             return Len(scope=self.prefix)
         attr_lower = attr.lower()
-        if attr_lower in _KIND_ALIASES:
-            return KindAccessor(_KIND_ALIASES[attr_lower], scope=self.prefix)
-        available = sorted(_KIND_ALIASES.keys())
+        if attr_lower in KIND_ALIASES:
+            return KindAccessor(KIND_ALIASES[attr_lower], scope=self.prefix)
+        available = sorted(KIND_ALIASES.keys())
         raise AttributeError(
             f"Unknown kind {attr!r} in scope {self.name!r}. "
             f"Available: {available}"
@@ -1622,7 +1622,12 @@ self_nearest = Scope("self_nearest")
 # Kind / field name resolution — used by both the parser and callers
 # =============================================================================
 
-_KIND_ALIASES = _build_kind_aliases()
+KIND_ALIASES = _build_kind_aliases()
+"""Public mapping of every accepted kind spelling (canonical, short
+name, common abbreviations like ``"ba"``/``"el"``) to the
+``mhctools.Kind`` constant. Stable across topiary minor releases —
+external consumers (e.g. vaxrank) can rely on this name.
+"""
 
 _FIELD_ALIASES = {
     "value": "value", "val": "value", "ic50": "value",
@@ -1634,9 +1639,9 @@ _FIELD_ALIASES = {
 
 def _resolve_kind(name):
     key = name.strip().lower()
-    if key in _KIND_ALIASES:
-        return _KIND_ALIASES[key]
-    available = sorted(_KIND_ALIASES.keys())
+    if key in KIND_ALIASES:
+        return KIND_ALIASES[key]
+    available = sorted(KIND_ALIASES.keys())
     close = get_close_matches(key, available, n=3, cutoff=0.6)
     msg = f"Unknown prediction kind {name!r}."
     if close:
@@ -1649,15 +1654,15 @@ def _resolve_kind(name):
 def _resolve_qualified_kind(name):
     """Resolve ``tool_kind`` or plain ``kind`` to ``(Kind, method|None)``."""
     key = name.strip().lower()
-    if key in _KIND_ALIASES:
-        return _KIND_ALIASES[key], None
+    if key in KIND_ALIASES:
+        return KIND_ALIASES[key], None
     parts = key.split("_")
     for i in range(1, len(parts)):
         tool = "_".join(parts[:i])
         kind_str = "_".join(parts[i:])
-        if kind_str in _KIND_ALIASES:
-            return _KIND_ALIASES[kind_str], tool
-    available = sorted(_KIND_ALIASES.keys())
+        if kind_str in KIND_ALIASES:
+            return KIND_ALIASES[kind_str], tool
+    available = sorted(KIND_ALIASES.keys())
     close = get_close_matches(key, available, n=3, cutoff=0.6)
     msg = f"Unknown prediction kind {name!r}. Use 'kind' or 'tool_kind' format."
     if close:

--- a/topiary/ranking/parser.py
+++ b/topiary/ranking/parser.py
@@ -41,7 +41,7 @@ from .nodes import (
     Stability,
     _CONTEXT_KEYWORDS,
     _FIELD_ALIASES,
-    _KIND_ALIASES,
+    KIND_ALIASES,
     _combine_bool,
     _resolve_qualified_kind,
     geomean,
@@ -683,7 +683,7 @@ class _Parser:
             return False
 
     def _prediction_kind_for_name(self, name):
-        return _KIND_ALIASES.get(name.strip().lower())
+        return KIND_ALIASES.get(name.strip().lower())
 
 
 def parse(text: str) -> DSLNode:

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .ranking import _iter_known_kinds, _kind_name, _kind_short_name, _KIND_ALIASES
+from .ranking import _iter_known_kinds, _kind_name, _kind_short_name, KIND_ALIASES
 
 # Columns that are prediction-specific and get pivoted in wide form.
 PREDICTION_COLUMNS = frozenset({
@@ -44,7 +44,7 @@ def _known_kind_short_names():
 
 def _kind_short_to_canonical(short_name):
     """Map a short kind name back to the canonical mhctools kind name string."""
-    kind = _KIND_ALIASES.get(short_name)
+    kind = KIND_ALIASES.get(short_name)
     if kind is None:
         return short_name
     return _kind_name(kind)


### PR DESCRIPTION
Carved out of the #161 discussion. Declines the larger PeptideContext relocation but keeps the one independently-useful ask: promote the kind-name alias table to a public name.

## Summary

- Rename ``_KIND_ALIASES`` → ``KIND_ALIASES`` in ``topiary.ranking.nodes`` and update all callsites (parser.py, wide.py, ranking/__init__.py).
- Export from ``topiary.ranking.__all__`` and the top-level ``topiary`` namespace + ``__all__``, so ``from topiary import KIND_ALIASES`` works.
- Add a docstring promising the name is stable across topiary minor releases.
- Bump to 5.12.0 (additive minor).

## Why

External consumers (vaxrank's ``peptide_context.py``) need this table for kind-name resolution. Today they reach past the API boundary with a defensive import that prefers the public name and falls back to the private one. After this lands + a release cuts, the cross-package private-name dance disappears for free — vaxrank versions already shipped will pick up the public name automatically.

No compat shim for ``_KIND_ALIASES``: the underscore prefix marked it private by convention. Anyone using it was already reaching past the boundary at their own risk.

## Test plan
- [x] ``from topiary import KIND_ALIASES`` works; ``topiary.KIND_ALIASES is topiary.ranking.KIND_ALIASES`` (same object, not a copy).
- [x] Full suite: 1289 passed, 3 skipped.