### PR TITLE
Raise varcode floor to >=4.18.0 (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.14.1
+
+Raise the varcode floor to `>=4.18.0`, the first varcode release that
+drops PyVCF3 from the runtime import path. Together with topiary's
+existing lazy varcode imports (5.10.7) this closes #122: a fresh
+install no longer surfaces rpy2 / embedded-R noise when importing
+varcode or running varcode-dependent topiary workflows.
+
 ## 5.14.0
 
 **Peptide properties as DSL nodes (#95):**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.0.0
 mhctools>=3.14.1
-varcode>=0.3.17
+varcode>=4.18.0
 gtfparse>=0.0.4
 mhcnames
 argcomplete>=1.10

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -62,7 +62,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.14.0"
+__version__ = "5.14.1"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
varcode 4.18.0 dropped PyVCF3 from its runtime import path
(openvax/varcode#356, commit 33a32d4). With this floor in place,
fresh installs no longer surface the rpy2 / embedded-R logging that
motivated #122, both when importing varcode directly and when running
varcode-dependent topiary workflows.

Topiary's existing lazy-import work (5.10.7 / 5.10.8) already made
`import topiary` clean; this PR is the downstream-pin half of the
fix. Closes #122.

## Test plan

- [x] Local upgrade to varcode 4.19.0
- [x] `./test.sh` — 1346 passed
- [x] `./lint.sh` clean