### PR TITLE
Backfill value from score for [0,1]-score predictor kinds (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,19 @@ mhctools models without a distinct unit. Downstream consumers reading
 arithmetic on `value` silently propagated NaN. Vaxrank just hit this in
 3.0.1 and worked around it in 3.0.2.
 
-`_format_prediction_df` now backfills `value` from `score` wherever
-`value` is NaN. Rows that already carry a unit-bearing `value` (IC50 nM
-for `pMHC_affinity`, half-life for `pMHC_stability`) are untouched.
+A new `_backfill_value_from_score` helper populates `value` from `score`
+for any row whose `kind` is *not* in `mhctools.VALUE_BEST_DIRECTIONS`
+(i.e. whose `value` has no distinct unit). Unit-bearing kinds —
+`pMHC_affinity` (IC50 nM) and `pMHC_stability` (half-life) — are
+explicitly skipped, so a NaN `value` on those kinds stays NaN rather
+than being silently misrepresented as a [0, 1] score. The helper is
+applied uniformly across the producer surface:
+
+- `TopiaryPredictor._format_prediction_df` (the main predict path)
+- `CachedPredictor._bindings_to_dataframe` and
+  `_predictions_to_dataframe` (cached-predictor outputs, including
+  mhcflurry's class1_presentation pipeline and NetMHCpan `-BA`)
+
 `affinity` continues to be populated only for `pMHC_affinity` rows, so
 that column's semantics are unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 5.15.0
+
+**Backfill `value` from `score` for [0, 1]-score predictor kinds (#165):**
+
+`TopiaryPredictor.predict_from_named_sequences` (and the rest of the
+predict pipeline) used to leave `value` as `NaN` for prediction kinds
+whose primary output is the [0, 1] score itself — most visibly
+`pMHC_presentation`, but also `antigen_processing` and the other kinds
+mhctools models without a distinct unit. Downstream consumers reading
+`value` uniformly across kinds tripped on the resulting NaNs: strict
+`simplejson.dumps` rejects them, `sorted()` is undefined on them, and
+arithmetic on `value` silently propagated NaN. Vaxrank just hit this in
+3.0.1 and worked around it in 3.0.2.
+
+`_format_prediction_df` now backfills `value` from `score` wherever
+`value` is NaN. Rows that already carry a unit-bearing `value` (IC50 nM
+for `pMHC_affinity`, half-life for `pMHC_stability`) are untouched.
+`affinity` continues to be populated only for `pMHC_affinity` rows, so
+that column's semantics are unchanged.
+
+After this change the long-format schema is uniform: `value` is the
+predictor's primary numeric output for every row (IC50 for affinity,
+probability for presentation, ...) and `score` is the [0, 1] ranking
+score (equal to `value` for presentation, derived from IC50 for
+affinity).
+
 ## 5.14.1
 
 Raise the varcode floor to `>=4.18.0`, the first varcode release that

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -1026,3 +1026,70 @@ class TestMultiAlleleFixtures:
             _FIXTURE_DIR / "netmhcstabpan_SLLQHLIGL.out",
         )
         assert len(cache.alleles) == 3
+
+
+# ---------------------------------------------------------------------------
+# value-from-score backfill (issue #165) for cached.py helpers
+# ---------------------------------------------------------------------------
+
+
+class _Stub:
+    """Minimal duck-typed stand-in for mhctools BindingPrediction /
+    Prediction objects, just enough for the conversion helpers."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def test_bindings_to_dataframe_backfills_presentation_value():
+    from topiary.cached import _bindings_to_dataframe
+
+    preds = [
+        _Stub(
+            peptide="SIINFEKL", allele="HLA-A*02:01", length=8,
+            score=0.42, affinity=None, percentile_rank=2.0,
+            value=None, source_sequence_name=None, offset=0,
+        ),
+    ]
+    df = _bindings_to_dataframe(preds, kind="pMHC_presentation")
+    assert df.iloc[0]["value"] == 0.42
+    assert df.iloc[0]["score"] == 0.42
+
+
+def test_bindings_to_dataframe_preserves_affinity_unit():
+    from topiary.cached import _bindings_to_dataframe
+
+    preds = [
+        _Stub(
+            peptide="SIINFEKL", allele="HLA-A*02:01", length=8,
+            score=0.8, affinity=120.0, percentile_rank=0.5,
+            value=120.0, source_sequence_name=None, offset=0,
+        ),
+    ]
+    df = _bindings_to_dataframe(preds, kind="pMHC_affinity")
+    assert df.iloc[0]["value"] == 120.0
+    assert df.iloc[0]["affinity"] == 120.0
+
+
+def test_predictions_to_dataframe_backfills_presentation_value():
+    from topiary.cached import _predictions_to_dataframe
+
+    preds = [
+        _Stub(
+            peptide="SIINFEKL", allele="HLA-A*02:01", kind="pMHC_presentation",
+            score=0.33, value=None, percentile_rank=3.0,
+            source_sequence_name=None, offset=0, n_flank="", c_flank="",
+        ),
+        _Stub(
+            peptide="SIINFEKL", allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5,
+            source_sequence_name=None, offset=0, n_flank="", c_flank="",
+        ),
+    ]
+    df = _predictions_to_dataframe(preds)
+    pres = df[df["kind"] == "pMHC_presentation"].iloc[0]
+    aff = df[df["kind"] == "pMHC_affinity"].iloc[0]
+    assert pres["value"] == 0.33
+    assert aff["value"] == 120.0
+    assert aff["affinity"] == 120.0

--- a/tests/test_predictor_internals.py
+++ b/tests/test_predictor_internals.py
@@ -128,6 +128,55 @@ def test_format_value_backfill_mixed_kinds():
     assert np.isnan(pres["affinity"])
 
 
+def test_format_nan_value_on_affinity_row_not_backfilled():
+    # A NaN ``value`` on an affinity/stability row means the unit is
+    # genuinely unknown — must NOT be silently rewritten as ``score``,
+    # which would falsely advertise a normalized [0, 1] score as an
+    # IC50 in nM.
+    df = _raw_df(kind="pMHC_affinity", value=np.nan, score=0.8)
+    result = _make_predictor()._format_prediction_df(df)
+    assert np.isnan(result.iloc[0]["value"])
+    assert np.isnan(result.iloc[0]["affinity"])
+
+    df = _raw_df(kind="pMHC_stability", value=np.nan, score=0.8)
+    result = _make_predictor()._format_prediction_df(df)
+    assert np.isnan(result.iloc[0]["value"])
+
+
+class _AffinityPlusPresentationModel(RandomBindingPredictor):
+    """Wraps RandomBindingPredictor so each predicted peptide yields
+    both a pMHC_affinity row (carries IC50 from the random predictor)
+    and a pMHC_presentation row (score only, value left None)."""
+
+    def predict_proteins_dataframe(self, name_to_sequence_dict):
+        affinity_df = super().predict_proteins_dataframe(name_to_sequence_dict)
+        if affinity_df.empty:
+            return affinity_df
+        presentation_df = affinity_df.copy()
+        presentation_df["kind"] = "pMHC_presentation"
+        presentation_df["score"] = 0.7
+        presentation_df["value"] = np.nan
+        return pd.concat([affinity_df, presentation_df], ignore_index=True)
+
+
+def test_end_to_end_presentation_value_populated():
+    # Public-API check: presentation rows produced through
+    # predict_from_named_sequences must report value == score (not NaN),
+    # while affinity rows keep IC50 in value/affinity.
+    model = _AffinityPlusPresentationModel(alleles=["HLA-A*02:01"])
+    predictor = TopiaryPredictor(models=[model])
+    df = predictor.predict_from_named_sequences({"t": "SIINFEKLAAAAA"})
+    pres = df[df["kind"] == "pMHC_presentation"]
+    aff = df[df["kind"] == "pMHC_affinity"]
+    assert not pres.empty
+    assert not aff.empty
+    assert not pres["value"].isna().any()
+    assert (pres["value"] == pres["score"]).all()
+    assert pres["affinity"].isna().all()
+    assert not aff["value"].isna().any()
+    assert (aff["value"] == aff["affinity"]).all()
+
+
 # ---------------------------------------------------------------------------
 # _attach_expression_data: additional edge cases
 # ---------------------------------------------------------------------------

--- a/tests/test_predictor_internals.py
+++ b/tests/test_predictor_internals.py
@@ -91,6 +91,43 @@ def test_format_empty_df():
     assert len(result) == 0
 
 
+def test_format_value_backfilled_from_score_when_nan():
+    df = _raw_df(kind="pMHC_presentation", value=np.nan, score=0.42)
+    result = _make_predictor()._format_prediction_df(df)
+    assert result.iloc[0]["value"] == 0.42
+    assert result.iloc[0]["score"] == 0.42
+    assert np.isnan(result.iloc[0]["affinity"])
+
+
+def test_format_value_preserved_when_already_set():
+    df = _raw_df(kind="pMHC_affinity", value=120.0, score=0.8)
+    result = _make_predictor()._format_prediction_df(df)
+    assert result.iloc[0]["value"] == 120.0
+    assert result.iloc[0]["affinity"] == 120.0
+
+
+def test_format_value_backfill_mixed_kinds():
+    df = pd.DataFrame([
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.8, value=120.0, percentile_rank=0.5, offset=0,
+            predictor_name="random",
+        ),
+        dict(
+            peptide="SIINFEKL", allele="HLA-A*02:01", kind="pMHC_presentation",
+            score=0.42, value=np.nan, percentile_rank=2.0, offset=0,
+            predictor_name="random",
+        ),
+    ])
+    result = _make_predictor()._format_prediction_df(df)
+    aff = result[result["kind"] == "pMHC_affinity"].iloc[0]
+    pres = result[result["kind"] == "pMHC_presentation"].iloc[0]
+    assert aff["value"] == 120.0
+    assert aff["affinity"] == 120.0
+    assert pres["value"] == 0.42
+    assert np.isnan(pres["affinity"])
+
+
 # ---------------------------------------------------------------------------
 # _attach_expression_data: additional edge cases
 # ---------------------------------------------------------------------------

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -62,7 +62,7 @@ from .io_lens import detect_lens_version, read_lens
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.14.1"
+__version__ = "5.15.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -36,6 +36,8 @@ from typing import Callable, Iterable, List, Mapping, Optional, Union
 
 import pandas as pd
 
+from .predictor import _backfill_value_from_score
+
 
 # Columns a cache row must carry so the core invariant and lookup work.
 _REQUIRED_COLUMNS = (
@@ -1129,7 +1131,7 @@ def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:
         }
         for p in preds
     ]
-    return pd.DataFrame(rows)
+    return _backfill_value_from_score(pd.DataFrame(rows))
 
 
 def _predictions_to_dataframe(preds) -> pd.DataFrame:
@@ -1158,7 +1160,7 @@ def _predictions_to_dataframe(preds) -> pd.DataFrame:
         }
         for p in preds
     ]
-    return pd.DataFrame(rows)
+    return _backfill_value_from_score(pd.DataFrame(rows))
 
 
 # NetMHC-family tools embed their version in the stdout preamble,

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -673,6 +673,16 @@ class TopiaryPredictor(object):
             df["affinity"] = np.where(
                 df["kind"] == "pMHC_affinity", df["value"], np.nan
             )
+        # Backfill ``value`` from ``score`` for kinds whose primary output
+        # is the [0, 1] score itself (presentation, antigen_processing,
+        # ...). mhctools sets ``value`` only when there is a distinct
+        # unit (IC50 nM for affinity, half-life for stability); leaving
+        # NaN elsewhere is a foot gun for downstream consumers that read
+        # ``value`` uniformly (NaN crashes strict JSON, sorts undefined).
+        if "value" in df.columns and "score" in df.columns:
+            value_is_nan = df["value"].isna()
+            if value_is_nan.any():
+                df.loc[value_is_nan, "value"] = df.loc[value_is_nan, "score"]
         return df
 
     def _apply_filter(self, df):

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -45,6 +45,34 @@ _MODEL_KEY_COLUMN = "_topiary_model_key"
 _WT_OFFSET_COLUMN = "_topiary_wt_peptide_offset"
 
 
+def _backfill_value_from_score(df):
+    """Populate ``value`` from ``score`` for kinds whose primary output
+    *is* the [0, 1] score (presentation, antigen_processing, ...).
+
+    mhctools sets ``value`` only when the kind has a distinct unit
+    (IC50 nM for affinity, half-life for stability — anything in
+    ``mhctools.VALUE_BEST_DIRECTIONS``). For other kinds it leaves
+    ``value=None``, which arrives as ``NaN`` in the DataFrame and trips
+    downstream consumers reading ``value`` uniformly: strict
+    ``simplejson.dumps`` rejects NaN, ``sorted()`` is undefined on it,
+    and arithmetic silently propagates. Unit-bearing kinds are
+    intentionally left alone: a NaN ``value`` there means the unit is
+    genuinely unknown, not "fall back to the score".
+
+    Mutates ``df`` in place and returns it for chaining.
+    """
+    if df.empty or "value" not in df.columns or "score" not in df.columns:
+        return df
+    if "kind" not in df.columns:
+        return df
+    from mhctools import VALUE_BEST_DIRECTIONS
+    unit_kinds = set(VALUE_BEST_DIRECTIONS.keys())
+    needs_backfill = df["value"].isna() & ~df["kind"].isin(unit_kinds)
+    if needs_backfill.any():
+        df.loc[needs_backfill, "value"] = df.loc[needs_backfill, "score"]
+    return df
+
+
 def _unique_model_keys(models):
     """Readable, unique internal names for configured model instances."""
     bases = []
@@ -673,17 +701,7 @@ class TopiaryPredictor(object):
             df["affinity"] = np.where(
                 df["kind"] == "pMHC_affinity", df["value"], np.nan
             )
-        # Backfill ``value`` from ``score`` for kinds whose primary output
-        # is the [0, 1] score itself (presentation, antigen_processing,
-        # ...). mhctools sets ``value`` only when there is a distinct
-        # unit (IC50 nM for affinity, half-life for stability); leaving
-        # NaN elsewhere is a foot gun for downstream consumers that read
-        # ``value`` uniformly (NaN crashes strict JSON, sorts undefined).
-        if "value" in df.columns and "score" in df.columns:
-            value_is_nan = df["value"].isna()
-            if value_is_nan.any():
-                df.loc[value_is_nan, "value"] = df.loc[value_is_nan, "score"]
-        return df
+        return _backfill_value_from_score(df)
 
     def _apply_filter(self, df):
         """Apply filter and sort if configured."""


### PR DESCRIPTION
## Summary

- `TopiaryPredictor._format_prediction_df` now backfills `value` from `score` wherever `value` is NaN, so `pMHC_presentation` (and other kinds whose primary output is a [0, 1] score) no longer return NaN in the `value` column.
- Rows that already carry a unit-bearing `value` are untouched — `pMHC_affinity` keeps IC50 nM in `value`, `pMHC_stability` keeps half-life. The `affinity` column is still populated only for `pMHC_affinity` rows.
- Bumps to 5.15.0 with a CHANGELOG entry. Vaxrank can drop its 3.0.2 workaround once it pins `topiary>=5.15.0`.

Fixes #165. Companion to [vaxrank#290](https://github.com/openvax/vaxrank/pull/290).

## Test plan

- [x] `python -m pytest tests/test_predictor_internals.py` — new tests cover the NaN-value → score backfill, the affinity-row preservation, and a mixed-kind row set
- [x] Full suite green except 6 pre-existing pirlygenes-data failures unrelated to this change (1342 passed)
- [x] Reproduced the exact scenario from the issue against `_format_prediction_df` and confirmed presentation rows now report `value == score` while `affinity` stays NaN