### PR TITLE
Use pirlygenes 5.1 expression accessor; min-version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.16.1
 
 **pirlygenes 5.1.0 integration:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+**pirlygenes 5.1.0 integration:**
+
+`tissue_expressed_gene_ids` and `available_tissues` in
+`topiary.sources` now call the typed
+`pirlygenes.pan_cancer_expression()` accessor introduced in
+pirlygenes 5.1.0 instead of indexing
+`load_all_dataframes_dict()["pan-cancer-expression.csv"]`. pirlygenes
+5.0.x had stripped the expression CSVs entirely, which broke the
+tissue-exclusion path with a `KeyError` for anyone on that release
+line; the 5.1.0 restore puts the data back next to the curated gene
+lists, and the new accessor is the canonical handle.
+
+`_check_pirlygenes` now also enforces `pirlygenes>=5.1.0` so a stale
+install surfaces a clear upgrade message rather than a downstream
+`AttributeError`. pirlygenes remains an optional dependency — only
+the CTA / tissue-exclusion paths require it.
+
 ## 5.16.0
 
 **pVACseq report loader (#94):**

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -83,6 +83,25 @@ def test_check_pirlygenes_rejects_old_version(monkeypatch):
         _check_pirlygenes()
 
 
+@pytest.mark.parametrize(
+    "version, accepted",
+    [
+        ("5.0.2", False),
+        ("5.1.0rc1", False),
+        ("5.1.0.dev1", False),
+        ("5.1.0", True),
+        ("5.1", True),
+        ("5.1.0+local", True),
+        ("5.1.0.post1", True),
+        ("5.1.1", True),
+    ],
+)
+def test_pirlygenes_version_check(version, accepted):
+    from topiary.sources import _pirlygenes_version_at_least
+
+    assert _pirlygenes_version_at_least(version) is accepted
+
+
 def test_predictor_with_alleles_and_model_classes():
     from mhctools import RandomBindingPredictor
     from topiary import TopiaryPredictor, Affinity

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -74,6 +74,15 @@ def test_tissue_expressed_gene_ids_strict():
     assert len(strict) < len(loose)
 
 
+def test_check_pirlygenes_rejects_old_version(monkeypatch):
+    pirlygenes = pytest.importorskip("pirlygenes")
+    from topiary.sources import _check_pirlygenes
+
+    monkeypatch.setattr(pirlygenes, "__version__", "5.0.2")
+    with pytest.raises(ImportError, match="pirlygenes>=5.1.0"):
+        _check_pirlygenes()
+
+
 def test_predictor_with_alleles_and_model_classes():
     from mhctools import RandomBindingPredictor
     from topiary import TopiaryPredictor, Affinity

--- a/tests/test_sources_optional.py
+++ b/tests/test_sources_optional.py
@@ -15,5 +15,5 @@ def test_check_pirlygenes_raises_clear_error(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    with pytest.raises(ImportError, match="pip install pirlygenes"):
+    with pytest.raises(ImportError, match="pirlygenes>=5.1.0"):
         sources._check_pirlygenes()

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -71,7 +71,7 @@ from .io_pvacseq import (
 from .result import TopiaryResult, concat
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.16.0"
+__version__ = "5.16.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/sources.py
+++ b/topiary/sources.py
@@ -16,6 +16,7 @@ Ensembl data is downloaded on first use via pyensembl.
 """
 
 import logging
+import re
 
 from pyensembl import EnsemblRelease, ensembl_grch38
 
@@ -299,6 +300,12 @@ def _validate_tissue_cols(pce, cols):
 
 
 _PIRLYGENES_MIN = (5, 1, 0)
+_PIRLYGENES_MIN_TEXT = "5.1.0"
+_PIRLYGENES_VERSION_RE = re.compile(r"^\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+_PIRLYGENES_PRERELEASE_RE = re.compile(
+    r"^\s*[-_.]?\s*(?:a|alpha|b|beta|rc|c|pre|preview|dev)",
+    re.I,
+)
 
 
 def _check_pirlygenes():
@@ -310,12 +317,24 @@ def _check_pirlygenes():
             "Install with: pip install 'pirlygenes>=5.1.0'"
         ) from None
     version = getattr(pirlygenes, "__version__", "0.0.0")
-    parts = tuple(int(p) for p in version.split(".")[:3] if p.isdigit())
-    if parts < _PIRLYGENES_MIN:
+    if not _pirlygenes_version_at_least(version):
         raise ImportError(
-            f"pirlygenes>=5.1.0 required for tissue-expression access; "
-            f"found {version}. Upgrade with: pip install -U 'pirlygenes>=5.1.0'"
+            f"pirlygenes>={_PIRLYGENES_MIN_TEXT} required for CTA/tissue "
+            f"gene lists; found {version}. Upgrade with: "
+            f"pip install -U 'pirlygenes>={_PIRLYGENES_MIN_TEXT}'"
         )
+
+
+def _pirlygenes_version_at_least(version):
+    text = str(version)
+    match = _PIRLYGENES_VERSION_RE.match(text)
+    if match is None:
+        return False
+    parts = tuple(int(p) if p is not None else 0 for p in match.groups())
+    if parts != _PIRLYGENES_MIN:
+        return parts > _PIRLYGENES_MIN
+    suffix = text[match.end():]
+    return _PIRLYGENES_PRERELEASE_RE.match(suffix) is None
 
 
 def _pirlygenes_cta_gene_ids():

--- a/topiary/sources.py
+++ b/topiary/sources.py
@@ -212,8 +212,8 @@ def tissue_expressed_gene_ids(tissues, min_ntpm=1.0):
     if not tissues:
         raise ValueError("tissues must be a non-empty list")
     _check_pirlygenes()
-    from pirlygenes import load_all_dataframes_dict
-    pce = load_all_dataframes_dict()["pan-cancer-expression.csv"]
+    from pirlygenes import pan_cancer_expression
+    pce = pan_cancer_expression()
 
     cols = [f"nTPM_{t}" for t in tissues]
     _validate_tissue_cols(pce, cols)
@@ -243,8 +243,8 @@ def tissue_expressed_sequences(tissues, min_ntpm=1.0, release=None):
 def available_tissues():
     """List all available tissue names from PirlyGenes expression data."""
     _check_pirlygenes()
-    from pirlygenes import load_all_dataframes_dict
-    pce = load_all_dataframes_dict()["pan-cancer-expression.csv"]
+    from pirlygenes import pan_cancer_expression
+    pce = pan_cancer_expression()
     return sorted(c.replace("nTPM_", "") for c in pce.columns if c.startswith("nTPM_"))
 
 
@@ -298,14 +298,24 @@ def _validate_tissue_cols(pce, cols):
         )
 
 
+_PIRLYGENES_MIN = (5, 1, 0)
+
+
 def _check_pirlygenes():
     try:
-        import pirlygenes  # noqa: F401
+        import pirlygenes
     except ImportError:
         raise ImportError(
             "pirlygenes is required for CTA/tissue gene lists. "
-            "Install with: pip install pirlygenes"
+            "Install with: pip install 'pirlygenes>=5.1.0'"
         ) from None
+    version = getattr(pirlygenes, "__version__", "0.0.0")
+    parts = tuple(int(p) for p in version.split(".")[:3] if p.isdigit())
+    if parts < _PIRLYGENES_MIN:
+        raise ImportError(
+            f"pirlygenes>=5.1.0 required for tissue-expression access; "
+            f"found {version}. Upgrade with: pip install -U 'pirlygenes>=5.1.0'"
+        )
 
 
 def _pirlygenes_cta_gene_ids():


### PR DESCRIPTION
## Summary

Anticipates pirlygenes 5.1.0, now live on PyPI via pirl-unc/pirlygenes#249, by switching topiary's tissue-expression call sites to the new typed accessor and enforcing the minimum version:

- tissue_expressed_gene_ids and available_tissues in topiary/sources.py now call pirlygenes.pan_cancer_expression() instead of indexing load_all_dataframes_dict()[pan-cancer-expression.csv]. Same DataFrame, ergonomic typed handle.
- _check_pirlygenes enforces pirlygenes>=5.1.0 for CTA / tissue gene-list paths and surfaces a clean upgrade message if a stale install is present, instead of a downstream AttributeError on the new accessor name.
- pirlygenes remains an optional dependency. Only the CTA / tissue-exclusion paths require it, so it is still not pinned in requirements.txt.
- Release version bumped to 5.16.1.

## Why now

pirlygenes 5.0.x stripped the expression CSVs from the package entirely, with data moved into trufflepig, which broke topiary's load_all_dataframes_dict()[pan-cancer-expression.csv] path with a KeyError. pirlygenes #246 / #247 / #248 walked that boundary back: the expression matrices belong next to the curated gene lists, with mechanical normalization primitives in the same package. PR #249 shipped all three as 5.1.0.

This PR is the topiary side of that fix. The dict-lookup pattern was awkward anyway, and the new pan_cancer_expression() accessor is the canonical reader.

## Test plan

- [x] pytest tests/test_sources.py tests/test_validation_and_edge_cases.py tests/test_self_proteome.py tests/test_coverage_gaps.py -> 117 passed, 1 skipped
- [x] tissue_expressed_gene_ids([heart_muscle], min_ntpm=10.0) returns 7,993 gene IDs, same as before
- [x] available_tissues() returns 50 tissues
- [x] pytest tests/test_sources_optional.py tests/test_sources.py::test_check_pirlygenes_rejects_old_version tests/test_sources.py::test_pirlygenes_version_check -> 10 passed
- [x] ./lint.sh
- [x] ./test.sh -> 1445 passed, 3 skipped
- [x] CI green