### PR TITLE
Accept explicit group keys in apply_filter / apply_sort / evaluate_scores (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 5.17.0
+
+**Explicit group keys everywhere (#175):**
+
+`apply_filter`, `apply_sort`, and `evaluate_scores` now accept the same
+three keyword-only context options — `group_keys`, `default_methods`,
+and `kind_support` — and forward all of them to `EvalContext`. Filtering,
+sorting, and scoring can therefore share one grouping and one method
+resolution instead of each entry point supporting a different subset.
+
+```python
+group_keys = ["prediction_id", "source_sequence_name", "peptide",
+              "peptide_offset", "allele"]
+
+kept = apply_filter(df, Affinity <= 500, group_keys=group_keys)
+scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
+```
+
+This matters when a frame carries a stable provenance identity: the
+inferred group keys are sequence-oriented, so two rows sharing peptide,
+source sequence, and offset are one group even when they came from
+different variants, transcripts, or genes — and one row's filter decision
+then applies to the other. Callers that previously reimplemented
+`apply_filter` on top of `EvalContext` just to supply `group_keys` (e.g.
+vaxrank's LENS/pVACseq path) can now call `apply_filter` directly.
+
+Explicit `group_keys` are validated when the context is built: an empty
+sequence, duplicate entries, and names that aren't columns all raise
+immediately, with a near-match suggestion, instead of failing deep
+inside a node.
+
+**Blank `sample_name` is no longer an inferred group key:**
+
+`mhctools` stamps `sample_name=""` on every row of a single-sample run,
+which made group key inference prepend a constant `sample_name` level to
+every group tuple of ordinary predictor output. A `sample_name` column
+that is entirely null or blank is now ignored by inference (null-only
+columns already were). Frames that mix real names with blanks keep the
+key — there the blank is a distinguishing value — and `group_keys=` can
+still name `sample_name` explicitly.
+
+**Breaking:** the context options are now keyword-only. Calls that passed
+them positionally — `apply_filter(df, node, default_methods)`,
+`evaluate_scores(df, node, group_keys, fill)` — must use keywords.
+Positional `df`, `node` / `sort_nodes`, and `sort_direction` are
+unchanged.
+
 ## 5.16.2
 
 **Combine separate predictor runs (#170):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ identity columns it expects — now raise a `ValueError` naming the
 missing columns and pointing at `group_keys=`, rather than a bare
 `KeyError` from inside pandas.
 
+**Fixed: null group keys silently dropped rows and scores.** `None`,
+`NaN` and `pd.NA` in an identity column are one group under
+`groupby(dropna=False)` — which every node evaluates through — but the
+group index was built from raw values, which keeps them apart, and rows
+were matched to groups by key lookup, which never matches a null key
+(`NaN != NaN`, and since Python 3.10 it hashes by identity). A frame
+mixing `None` and `NaN` in `source_sequence_name` — which
+`TopiaryPredictor` produces, since it writes `source_sequence_name =
+None` — could lose rows from `apply_filter` that its own scores said
+should pass, while `apply_sort` kept them. Null spellings are now
+collapsed once, and rows map to groups by position via the new
+`EvalContext.row_group_codes()`.
+
 **Fixed: a single group key produced empty or all-NaN results.**
 `EvalContext.group_index` built a 1-level `MultiIndex` for a single
 group key, while `DataFrame.groupby` on one key produces a flat `Index`.
@@ -73,6 +86,11 @@ still name `sample_name` explicitly.
   `MultiIndex` when there is a single group key (see the fix above).
   Code that indexed single-key results with 1-tuples must use bare
   values.
+- Inferred group keys drop a blank-only `sample_name`, so group tuples
+  for single-sample `mhctools` output are 4-wide rather than 5-wide.
+  Consumers that materialize a group tuple and index a per-group Series
+  with it must drop the leading `sample_name` element (or pass
+  `group_keys=` explicitly to keep it).
 
 ## 5.16.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,29 @@ then applies to the other. Callers that previously reimplemented
 `apply_filter` on top of `EvalContext` just to supply `group_keys` (e.g.
 vaxrank's LENS/pVACseq path) can now call `apply_filter` directly.
 
-Explicit `group_keys` are validated when the context is built: an empty
-sequence, duplicate entries, and names that aren't columns all raise
-immediately, with a near-match suggestion, instead of failing deep
-inside a node.
+Explicit `group_keys` are validated before anything is evaluated: a bare
+string instead of a sequence, an empty sequence, duplicate entries, and
+names that aren't columns all raise immediately, with a near-match
+suggestion, instead of failing deep inside a node. Validation also runs
+on the paths that return early (empty frame, `node=None`, no sort
+nodes), so a typo can't pass silently just because a pipeline has
+degenerated to zero rows.
+
+Frames that group key *inference* can't handle — missing one of the
+identity columns it expects — now raise a `ValueError` naming the
+missing columns and pointing at `group_keys=`, rather than a bare
+`KeyError` from inside pandas.
+
+**Fixed: a single group key produced empty or all-NaN results.**
+`EvalContext.group_index` built a 1-level `MultiIndex` for a single
+group key, while `DataFrame.groupby` on one key produces a flat `Index`.
+Every node result therefore reindexed to all-NaN: `apply_filter` dropped
+every row, `evaluate_scores` returned all-NaN, and `apply_sort` silently
+no-opped. `group_index` is now a flat `Index` (and `row_group_tuples`
+yields bare values) when there is one group key, matching pandas.
+Multi-key grouping is unchanged. This was reachable before via
+`EvalContext(df, group_keys=["peptide"])`; the new kwarg makes it
+reachable from all three entry points.
 
 **Blank `sample_name` is no longer an inferred group key:**
 
@@ -41,11 +60,19 @@ columns already were). Frames that mix real names with blanks keep the
 key — there the blank is a distinguishing value — and `group_keys=` can
 still name `sample_name` explicitly.
 
-**Breaking:** the context options are now keyword-only. Calls that passed
-them positionally — `apply_filter(df, node, default_methods)`,
-`evaluate_scores(df, node, group_keys, fill)` — must use keywords.
-Positional `df`, `node` / `sort_nodes`, and `sort_direction` are
-unchanged.
+**Breaking:**
+
+- The context options are now keyword-only. Calls that passed them
+  positionally — `apply_filter(df, node, default_methods)`,
+  `evaluate_scores(df, node, group_keys, fill)` — must use keywords.
+  Positional `df`, `node` / `sort_nodes`, and `sort_direction` are
+  unchanged.
+- An empty `group_keys` sequence now raises instead of falling back to
+  inferred keys. Pass `group_keys=None` to infer.
+- `EvalContext.group_index` is a flat `Index` rather than a 1-level
+  `MultiIndex` when there is a single group key (see the fix above).
+  Code that indexed single-key results with 1-tuples must use bare
+  values.
 
 ## 5.16.2
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -268,6 +268,19 @@ minimum(Affinity["netmhcpan"].value, Affinity["mhcflurry"].value)
 
 Apply with `apply_filter(df, node)` and `apply_sort(df, [nodes])`.
 
+### Context options
+
+`apply_filter`, `apply_sort` and `evaluate_scores` share three keyword-only
+options, all forwarded to `EvalContext`:
+
+| Option | Meaning |
+|--------|---------|
+| `group_keys` | Explicit group identity columns; default infers them from the DataFrame |
+| `default_methods` | Per-kind default `prediction_method_name` for unqualified references |
+| `kind_support` | Per-(model, kind) metadata from `TopiaryPredictor.kind_support` |
+
+See [Group identity](ranking.md#group-identity) for when to pass `group_keys`.
+
 ## String parsing
 
 ### Kind aliases

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -19,6 +19,46 @@ df = apply_sort(df, [Presentation.score, Affinity.score])
 
 `TopiaryPredictor(filter_by=..., sort_by=[...])` applies them automatically during prediction.
 
+## Group identity
+
+Expressions evaluate per *group*, not per row: one peptide-allele group can span several rows (one per predictor and kind). `apply_filter` keeps or drops whole groups, `apply_sort` orders groups, and `evaluate_scores` gives every row its group's score.
+
+By default the group keys are inferred from the columns present:
+
+| Columns present | Inferred group keys |
+|---|---|
+| `fragment_id` | `fragment_id, peptide, peptide_offset, allele` |
+| `variant` | `variant, peptide, peptide_offset, allele` |
+| neither | `source_sequence_name, peptide, peptide_offset, allele` |
+
+A `sample_name` column is prepended when it holds real values. Blank or null-only `sample_name` columns are ignored — `mhctools` stamps `sample_name=""` on every row of a single-sample run, and a constant level carries no identity.
+
+### Explicit group keys
+
+Inferred keys are sequence-oriented, so two rows that share peptide, source sequence and offset land in the same group even when they came from different variants, transcripts or genes — one row's filter decision then applies to the other. When your frame carries a stable provenance identity, pass it explicitly:
+
+```python
+from topiary import apply_filter, apply_sort, evaluate_scores, Affinity
+
+group_keys = ["prediction_id", "source_sequence_name", "peptide",
+              "peptide_offset", "allele"]
+
+kept = apply_filter(df, Affinity <= 500, group_keys=group_keys)
+kept = apply_sort(kept, [Affinity.score], group_keys=group_keys)
+scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
+```
+
+`apply_filter`, `apply_sort` and `evaluate_scores` accept the same three keyword-only context options — `group_keys`, `default_methods` and `kind_support` — so filtering, sorting and scoring can share one grouping and one method resolution. All three are forwarded to `EvalContext`, which you can also build directly when you need the raw per-group Series:
+
+```python
+from topiary.ranking import EvalContext
+
+ctx = EvalContext(df, group_keys=group_keys)
+per_group = (Affinity <= 500).eval(ctx)   # indexed by ctx.group_index
+```
+
+Group key names are validated against the DataFrame when the context is built, so a typo fails immediately with a suggestion rather than deep inside a node.
+
 ## Prediction kinds
 
 Each MHC prediction model produces one or more *kinds* of output. The built-in accessors are:

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -57,7 +57,9 @@ ctx = EvalContext(df, group_keys=group_keys)
 per_group = (Affinity <= 500).eval(ctx)   # indexed by ctx.group_index
 ```
 
-Group key names are validated against the DataFrame when the context is built, so a typo fails immediately with a suggestion rather than deep inside a node.
+Group key names are validated before anything is evaluated, so a typo fails immediately with a suggestion rather than deep inside a node — including on empty frames, where there is otherwise nothing to fail on.
+
+With a single group key, `ctx.group_index` is a flat `Index` of bare values (matching `DataFrame.groupby` on one column); with several it is a `MultiIndex` of key tuples.
 
 ## Prediction kinds
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -48,7 +48,11 @@ kept = apply_sort(kept, [Affinity.score], group_keys=group_keys)
 scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
 ```
 
-`apply_filter`, `apply_sort` and `evaluate_scores` accept the same three keyword-only context options — `group_keys`, `default_methods` and `kind_support` — so filtering, sorting and scoring can share one grouping and one method resolution. All three are forwarded to `EvalContext`, which you can also build directly when you need the raw per-group Series:
+`apply_filter`, `apply_sort` and `evaluate_scores` accept the same three keyword-only context options — `group_keys`, `default_methods` and `kind_support` — so filtering, sorting and scoring can share one grouping and one method resolution.
+
+One thing is deliberately *not* shared: on a frame where several methods produce the same kind, `apply_filter` auto-aggregates an unqualified reference across them (`nanmin` for `<`/`<=`, `nanmax` for `>`/`>=`), while `apply_sort` and `evaluate_scores` stay strict and raise on the ambiguity. Pass `default_methods={"affinity": "mhcflurry"}` (or qualify the reference, `Affinity["mhcflurry"]`) to get one answer from all three.
+
+All three options are forwarded to `EvalContext`, which you can also build directly when you need the raw per-group Series:
 
 ```python
 from topiary.ranking import EvalContext
@@ -59,7 +63,9 @@ per_group = (Affinity <= 500).eval(ctx)   # indexed by ctx.group_index
 
 Group key names are validated before anything is evaluated, so a typo fails immediately with a suggestion rather than deep inside a node — including on empty frames, where there is otherwise nothing to fail on.
 
-With a single group key, `ctx.group_index` is a flat `Index` of bare values (matching `DataFrame.groupby` on one column); with several it is a `MultiIndex` of key tuples.
+With a single group key, `ctx.group_index` is a flat `Index` of bare values (matching `DataFrame.groupby` on one column); with several it is a `MultiIndex` of key tuples. Null keys are collapsed to one group per spelling — `None`, `NaN` and `pd.NA` in an identity column name the same group, as they do under `groupby(dropna=False)`.
+
+To map a per-group result back onto rows, use `ctx.row_group_codes()`, which gives each row the position of its group in `group_index`. Looking group keys up by value is unreliable when a key is null: `NaN` never equals itself.
 
 ## Prediction kinds
 

--- a/tests/test_group_keys.py
+++ b/tests/test_group_keys.py
@@ -1,0 +1,317 @@
+"""Group identity for DSL evaluation: explicit ``group_keys`` and inference.
+
+Covers the two halves of grouping:
+
+* **Explicit** — ``group_keys=`` is accepted by ``apply_filter``,
+  ``apply_sort`` and ``evaluate_scores`` alike, so a caller with a stable
+  provenance identity can use one grouping everywhere (topiary #175).
+* **Inferred** — what topiary picks when the caller says nothing.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary.ranking import (
+    Affinity,
+    EvalContext,
+    apply_filter,
+    apply_sort,
+    evaluate_scores,
+)
+from topiary.ranking.nodes import _pick_group_keys
+
+# Peptide, context and offset are identical across the two rows; only the
+# provenance ID differs.  This is the vaxrank case from openvax/vaxrank#345:
+# two distinct variants that happen to produce the same 9mer in the same
+# flanking context.
+PROVENANCE_ROWS = [
+    dict(
+        prediction_id="variant-1", source_sequence_name="ctx",
+        peptide="SIINFEKL", peptide_offset=10, allele="HLA-A*02:01",
+        n_flank="AAA", c_flank="CCC", kind="pMHC_affinity",
+        score=0.9, value=50.0, percentile_rank=0.2,
+        prediction_method_name="netmhcpan",
+    ),
+    dict(
+        prediction_id="variant-2", source_sequence_name="ctx",
+        peptide="SIINFEKL", peptide_offset=10, allele="HLA-A*02:01",
+        n_flank="AAA", c_flank="CCC", kind="pMHC_affinity",
+        score=0.1, value=5000.0, percentile_rank=20.0,
+        prediction_method_name="netmhcpan",
+    ),
+]
+
+PROVENANCE_GROUP_KEYS = [
+    "prediction_id", "source_sequence_name", "peptide", "peptide_offset",
+    "allele",
+]
+
+
+def _provenance_df():
+    return pd.DataFrame(PROVENANCE_ROWS)
+
+
+# ---------------------------------------------------------------------------
+# Explicit group_keys on apply_filter (topiary #175)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_filter_group_keys_keep_distinct_provenance_apart():
+    """One variant's passing decision must not leak into another's."""
+    df = _provenance_df()
+
+    kept = apply_filter(
+        df, Affinity.value <= 500, group_keys=PROVENANCE_GROUP_KEYS,
+    )
+
+    assert kept["prediction_id"].tolist() == ["variant-1"]
+
+
+def test_apply_filter_without_group_keys_merges_identical_sequences():
+    """The inferred, sequence-oriented grouping collapses the two rows.
+
+    Not a bug — it is what the sequence-keyed default means, and it is
+    exactly why an explicit identity has to be passable.
+    """
+    df = _provenance_df()
+
+    kept = apply_filter(df, Affinity.value <= 500)
+
+    # One group holding both rows: nanmin over the group passes, so the
+    # 5000 nM row rides along on the 50 nM row's decision.
+    assert kept["prediction_id"].tolist() == ["variant-1", "variant-2"]
+
+
+def test_apply_filter_group_keys_match_direct_eval_context():
+    """Filtering and direct EvalContext scoring share one group index."""
+    df = _provenance_df()
+    node = Affinity.value <= 500
+
+    ctx = EvalContext(
+        df, group_keys=PROVENANCE_GROUP_KEYS, filter_context=True,
+    )
+    manual = node.eval(ctx).reindex(ctx.group_index)
+    passing = set(manual[manual.fillna(False).astype(bool)].index)
+    manual_keep = df[ctx.row_group_tuples().isin(passing)].reset_index(drop=True)
+
+    via_api = apply_filter(df, node, group_keys=PROVENANCE_GROUP_KEYS)
+
+    assert list(ctx.group_index.names) == PROVENANCE_GROUP_KEYS
+    pd.testing.assert_frame_equal(via_api, manual_keep)
+
+
+def test_apply_filter_none_group_keys_is_inferred_grouping():
+    """Omitting group_keys is identical to passing the inferred ones."""
+    df = _provenance_df()
+    node = Affinity.value <= 500
+
+    implicit = apply_filter(df, node)
+    explicit = apply_filter(df, node, group_keys=_pick_group_keys(df))
+
+    pd.testing.assert_frame_equal(implicit, explicit)
+
+
+# ---------------------------------------------------------------------------
+# The same kwarg on apply_sort and evaluate_scores
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sort_group_keys_sort_distinct_provenance_separately():
+    df = _provenance_df()
+
+    ordered = apply_sort(
+        df, [Affinity.value], group_keys=PROVENANCE_GROUP_KEYS,
+    )
+
+    # Ascending by affinity value: the 50 nM variant first.
+    assert ordered["prediction_id"].tolist() == ["variant-1", "variant-2"]
+
+    reverse = apply_sort(
+        df, [Affinity.value], sort_direction="desc",
+        group_keys=PROVENANCE_GROUP_KEYS,
+    )
+    assert reverse["prediction_id"].tolist() == ["variant-2", "variant-1"]
+
+
+def test_evaluate_scores_group_keys_score_each_provenance_row():
+    df = _provenance_df()
+
+    scores = evaluate_scores(
+        df, Affinity.value, group_keys=PROVENANCE_GROUP_KEYS,
+    )
+
+    assert scores.tolist() == [50.0, 5000.0]
+
+
+def test_evaluate_scores_and_apply_filter_agree_on_group_keys():
+    """Scores and the filter decision line up row-for-row."""
+    df = _provenance_df()
+
+    scores = evaluate_scores(
+        df, Affinity.value, group_keys=PROVENANCE_GROUP_KEYS,
+    )
+    kept = apply_filter(
+        df, Affinity.value <= 500, group_keys=PROVENANCE_GROUP_KEYS,
+    )
+
+    expected = df.loc[scores <= 500, "prediction_id"].tolist()
+    assert kept["prediction_id"].tolist() == expected
+
+
+def test_evaluate_scores_accepts_default_methods():
+    """The context trio is uniform: evaluate_scores takes default_methods too."""
+    rows = []
+    for method, value in (("netmhcpan", 50.0), ("mhcflurry", 900.0)):
+        rows.append(dict(
+            source_sequence_name="ctx", peptide="SIINFEKL", peptide_offset=10,
+            allele="HLA-A*02:01", kind="pMHC_affinity",
+            score=0.5, value=value, percentile_rank=1.0,
+            prediction_method_name=method,
+        ))
+    df = pd.DataFrame(rows)
+
+    # Ambiguous without a default: two methods produce the same kind.
+    with pytest.raises(ValueError):
+        evaluate_scores(df, Affinity.value)
+
+    scores = evaluate_scores(
+        df, Affinity.value, default_methods={"affinity": "mhcflurry"},
+    )
+    assert scores.tolist() == [900.0, 900.0]
+
+
+@pytest.mark.parametrize("call", [
+    lambda df, node: apply_filter(df, node, ["peptide"]),
+    lambda df, node: apply_sort(df, [node], "auto", ["peptide"]),
+    lambda df, node: evaluate_scores(df, node, ["peptide"]),
+])
+def test_context_options_are_keyword_only(call):
+    """Context knobs are keyword-only so their order can keep growing."""
+    df = _provenance_df()
+    with pytest.raises(TypeError):
+        call(df, Affinity.value)
+
+
+# ---------------------------------------------------------------------------
+# Validation of explicit group_keys
+# ---------------------------------------------------------------------------
+
+
+def test_group_keys_unknown_column_suggests_near_match():
+    df = _provenance_df()
+    with pytest.raises(ValueError, match="group_keys column 'peptid'"):
+        apply_filter(df, Affinity.value <= 500, group_keys=["peptid"])
+
+
+def test_group_keys_unknown_column_lists_columns_when_nothing_is_close():
+    df = _provenance_df()
+    with pytest.raises(ValueError, match="Available columns"):
+        EvalContext(df, group_keys=["zzzzzz"])
+
+
+def test_group_keys_empty_sequence_rejected():
+    df = _provenance_df()
+    with pytest.raises(ValueError, match="non-empty sequence"):
+        EvalContext(df, group_keys=[])
+
+
+def test_group_keys_duplicates_rejected():
+    df = _provenance_df()
+    with pytest.raises(ValueError, match="duplicate entries"):
+        EvalContext(df, group_keys=["peptide", "allele", "peptide"])
+
+
+def test_group_keys_validated_before_any_evaluation():
+    """The error comes from constructing the context, not from a node."""
+    df = _provenance_df()
+    with pytest.raises(ValueError, match="group_keys column"):
+        EvalContext(df, group_keys=["prediction_id", "not_a_column"])
+
+
+def test_group_keys_accept_any_sequence():
+    df = _provenance_df()
+    ctx = EvalContext(df, group_keys=tuple(PROVENANCE_GROUP_KEYS))
+    assert ctx.group_keys == PROVENANCE_GROUP_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Inferred group keys: sample_name
+# ---------------------------------------------------------------------------
+
+
+def _sample_df(sample_names):
+    rows = []
+    for i, sample_name in enumerate(sample_names):
+        rows.append(dict(
+            sample_name=sample_name, source_sequence_name="ctx",
+            peptide="SIINFEKL", peptide_offset=10, allele="HLA-A*02:01",
+            kind="pMHC_affinity", score=0.9, value=50.0 * (i + 1),
+            percentile_rank=0.2, prediction_method_name="netmhcpan",
+        ))
+    return pd.DataFrame(rows)
+
+
+def test_blank_sample_name_is_not_inferred_as_a_group_key():
+    """mhctools stamps sample_name='' on every single-sample row.
+
+    A constant blank column carries no identity; grouping by it would
+    widen every group tuple for nothing.
+    """
+    df = _sample_df(["", ""])
+
+    assert "sample_name" not in EvalContext(df).group_keys
+
+
+def test_whitespace_only_sample_name_is_not_inferred_as_a_group_key():
+    df = _sample_df(["   ", ""])
+
+    assert "sample_name" not in EvalContext(df).group_keys
+
+
+def test_null_sample_name_is_not_inferred_as_a_group_key():
+    df = _sample_df([np.nan, None])
+
+    assert "sample_name" not in EvalContext(df).group_keys
+
+
+def test_real_sample_names_are_inferred_as_a_group_key():
+    df = _sample_df(["tumor", "normal"])
+
+    ctx = EvalContext(df)
+
+    assert ctx.group_keys[0] == "sample_name"
+    assert len(ctx.group_index) == 2
+
+
+def test_sample_name_kept_when_blanks_mix_with_real_names():
+    """A blank alongside a real name *is* a distinguishing value."""
+    df = _sample_df(["", "tumor"])
+
+    ctx = EvalContext(df)
+
+    assert ctx.group_keys[0] == "sample_name"
+    assert len(ctx.group_index) == 2
+
+
+def test_blank_sample_name_does_not_change_filter_results():
+    df = _sample_df(["", ""])
+    df.loc[1, "value"] = 5000.0
+
+    kept = apply_filter(df, Affinity.value <= 500)
+
+    # Both rows share the same peptide/offset/allele group either way;
+    # the point is that group tuples stay 4-wide.
+    assert list(EvalContext(df).group_index.names) == [
+        "source_sequence_name", "peptide", "peptide_offset", "allele",
+    ]
+    assert len(kept) == 2
+
+
+def test_blank_sample_name_still_usable_as_an_explicit_group_key():
+    """Inference skips it; an explicit request still honors it."""
+    df = _sample_df(["", ""])
+
+    ctx = EvalContext(df, group_keys=["sample_name", "peptide", "allele"])
+
+    assert ctx.group_keys[0] == "sample_name"

--- a/tests/test_group_keys.py
+++ b/tests/test_group_keys.py
@@ -462,3 +462,147 @@ def test_uninferable_frame_still_works_with_explicit_keys():
 def test_empty_frame_without_identity_columns_is_not_rejected():
     """Nothing to group; inference stays quiet rather than erroring."""
     assert EvalContext(pd.DataFrame()).group_keys
+
+
+# ---------------------------------------------------------------------------
+# Null keys: None / NaN / pd.NA must name the same group
+# ---------------------------------------------------------------------------
+
+
+def _null_key_df(column, keys):
+    """Three rows whose *column* holds the given (possibly null) keys."""
+    rows = []
+    for key, value, peptide in zip(keys, (50.0, 100.0, 150.0), "abc"):
+        rows.append({
+            column: key, "peptide": peptide, "peptide_offset": 0,
+            "allele": "HLA-A*02:01", "kind": "pMHC_affinity", "score": 0.5,
+            "value": value, "percentile_rank": 1.0,
+            "prediction_method_name": "netmhcpan",
+        })
+    return pd.DataFrame(rows)
+
+
+@pytest.mark.parametrize("nulls", [
+    (None, np.nan),
+    (np.nan, None),
+    (pd.NA, np.nan),
+    (None, pd.NA),
+])
+def test_null_spellings_collapse_into_one_group(nulls):
+    """groupby(dropna=False) merges them, so group_index must too.
+
+    Otherwise the group index holds keys no node result can carry and
+    every row in the extra group scores NaN.
+    """
+    df = _null_key_df("gid", [*nulls, "x"])
+
+    ctx = EvalContext(df, group_keys=["gid"])
+
+    assert len(ctx.group_index) == 2
+    assert ctx.row_group_codes().tolist() == [0, 0, 1]
+
+
+def test_null_keys_score_their_group_not_nan():
+    df = _null_key_df("gid", [None, np.nan, "x"])
+
+    scores = evaluate_scores(df, Affinity.value, group_keys=["gid"])
+
+    # Both null rows are one group; nanmin over it is 50.
+    assert scores.tolist() == [50.0, 50.0, 150.0]
+
+
+def test_null_keys_are_not_dropped_by_filter():
+    df = _null_key_df("gid", [None, np.nan, "x"])
+
+    kept = apply_filter(df, Affinity.value <= 60, group_keys=["gid"])
+
+    assert kept["peptide"].tolist() == ["a", "b"]
+
+
+def test_inferred_keys_do_not_drop_rows_with_none_identity():
+    """Regression: None in an identity column silently lost the row.
+
+    `TopiaryPredictor` writes `source_sequence_name = None`, so this is
+    reachable without passing group_keys at all.
+    """
+    df = _null_key_df("source_sequence_name", [None, np.nan, "x"])
+
+    kept = apply_filter(df, Affinity.value <= 60)
+    ordered = apply_sort(df, [Affinity.value])
+    scores = evaluate_scores(df, Affinity.value)
+
+    # Distinct peptides, so one group per row: only the 50 nM row passes.
+    assert kept["peptide"].tolist() == ["a"]
+    assert ordered["peptide"].tolist() == ["a", "b", "c"]
+    assert scores.tolist() == [50.0, 100.0, 150.0]
+
+
+def test_row_group_codes_index_group_index():
+    df = _provenance_df()
+
+    ctx = EvalContext(df, group_keys=PROVENANCE_GROUP_KEYS)
+    codes = ctx.row_group_codes()
+
+    assert codes.tolist() == [0, 1]
+    assert [ctx.group_index[c] for c in codes] == list(ctx.group_index)
+
+
+def test_row_group_codes_empty_frame():
+    ctx = EvalContext(_provenance_df().iloc[0:0])
+
+    assert ctx.row_group_codes().tolist() == []
+
+
+# ---------------------------------------------------------------------------
+# Remaining validation edges
+# ---------------------------------------------------------------------------
+
+
+def test_group_keys_shape_checked_even_without_a_frame():
+    with pytest.raises(ValueError, match="not the string 'peptide'"):
+        evaluate_scores(None, Affinity.value, group_keys="peptide")
+    with pytest.raises(ValueError, match="non-empty sequence"):
+        evaluate_scores(None, Affinity.value, group_keys=[])
+
+
+def test_uninferable_empty_frame_with_columns_is_rejected():
+    """An empty frame still has columns to be wrong about."""
+    df = pd.DataFrame(columns=["peptide", "allele"])
+
+    with pytest.raises(ValueError, match="Cannot infer group keys"):
+        EvalContext(df)
+
+
+def test_array_like_group_key_gets_a_readable_error():
+    """Otherwise: 'truth value of an array is ambiguous', or unhashable."""
+    df = _provenance_df()
+
+    with pytest.raises(ValueError, match="must be column names, got a ndarray"):
+        EvalContext(df, group_keys=[np.array(["peptide", "allele"])])
+
+
+def test_close_matches_never_suggest_a_stringified_label():
+    """An int label 7 must not be offered as the string '7'."""
+    df = _provenance_df()
+    df[7] = 1
+
+    with pytest.raises(ValueError) as excinfo:
+        EvalContext(df, group_keys=["7"])
+
+    assert "Did you mean" not in str(excinfo.value)
+
+
+def test_all_missing_columns_are_named_at_once():
+    from topiary.ranking import Column
+
+    df = _provenance_df()
+    node = Column("zscore") >= 1
+
+    with pytest.raises(ValueError, match="zscore"):
+        apply_filter(df, node)
+
+    node = (Column("zscore") >= 1) & (Column("vaff") >= 0.1)
+    with pytest.raises(ValueError) as excinfo:
+        apply_filter(df, node)
+    message = str(excinfo.value)
+    assert "zscore" in message and "vaff" in message

--- a/tests/test_group_keys.py
+++ b/tests/test_group_keys.py
@@ -315,3 +315,150 @@ def test_blank_sample_name_still_usable_as_an_explicit_group_key():
     ctx = EvalContext(df, group_keys=["sample_name", "peptide", "allele"])
 
     assert ctx.group_keys[0] == "sample_name"
+
+
+# ---------------------------------------------------------------------------
+# Single group key: group_index must match what groupby produces
+# ---------------------------------------------------------------------------
+
+
+def test_single_group_key_index_is_flat():
+    """A 1-level MultiIndex would reindex to all-NaN against a groupby."""
+    df = _provenance_df()
+
+    index = EvalContext(df, group_keys=["prediction_id"]).group_index
+
+    assert not isinstance(index, pd.MultiIndex)
+    assert index.name == "prediction_id"
+    assert index.tolist() == ["variant-1", "variant-2"]
+
+
+def test_single_group_key_empty_frame_index_is_flat():
+    df = _provenance_df().iloc[0:0]
+
+    index = EvalContext(df, group_keys=["prediction_id"]).group_index
+
+    assert not isinstance(index, pd.MultiIndex)
+    assert index.name == "prediction_id"
+    assert len(index) == 0
+
+
+def test_single_group_key_row_group_tuples_are_bare_values():
+    df = _provenance_df()
+
+    ctx = EvalContext(df, group_keys=["prediction_id"])
+
+    assert ctx.row_group_tuples().tolist() == ["variant-1", "variant-2"]
+
+
+def test_single_group_key_filters_scores_and_sorts():
+    df = _provenance_df()
+
+    kept = apply_filter(df, Affinity.value <= 500, group_keys=["prediction_id"])
+    scores = evaluate_scores(df, Affinity.value, group_keys=["prediction_id"])
+    ordered = apply_sort(df, [Affinity.value], group_keys=["prediction_id"])
+
+    assert kept["prediction_id"].tolist() == ["variant-1"]
+    assert scores.tolist() == [50.0, 5000.0]
+    assert ordered["prediction_id"].tolist() == ["variant-1", "variant-2"]
+
+
+def test_single_group_key_column_and_isin_nodes():
+    """Column-backed nodes group the same way as Field nodes."""
+    from topiary.ranking import Column
+
+    df = _provenance_df()
+    df["peptide_length"] = df["peptide"].str.len()
+
+    lengths = evaluate_scores(
+        df, Column("peptide_length"), group_keys=["prediction_id"],
+    )
+    kept = apply_filter(
+        df, Column("prediction_id").isin(["variant-2"]),
+        group_keys=["prediction_id"],
+    )
+
+    assert lengths.tolist() == [8.0, 8.0]
+    assert kept["prediction_id"].tolist() == ["variant-2"]
+
+
+# ---------------------------------------------------------------------------
+# Validation reaches the early-return paths
+# ---------------------------------------------------------------------------
+
+
+def test_group_keys_validated_on_empty_frame():
+    """A typo must not pass just because the frame has no rows."""
+    empty = _provenance_df().iloc[0:0]
+
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        apply_filter(empty, Affinity.value <= 500, group_keys=["nope"])
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        evaluate_scores(empty, Affinity.value, group_keys=["nope"])
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        apply_sort(empty, [Affinity.value], group_keys=["nope"])
+
+
+def test_group_keys_validated_when_node_is_a_no_op():
+    df = _provenance_df()
+
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        apply_filter(df, None, group_keys=["nope"])
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        apply_sort(df, [], group_keys=["nope"])
+
+
+def test_group_keys_bare_string_names_the_mistake():
+    df = _provenance_df()
+
+    with pytest.raises(ValueError, match="not the string 'peptide'"):
+        apply_filter(df, Affinity.value <= 500, group_keys="peptide")
+
+
+def test_group_keys_non_string_entry_raises_value_error():
+    """difflib must not be handed a non-string key."""
+    df = _provenance_df()
+
+    with pytest.raises(ValueError, match="group_keys column 123"):
+        EvalContext(df, group_keys=["peptide", 123])
+    with pytest.raises(ValueError, match="group_keys column None"):
+        EvalContext(df, group_keys=["peptide", None])
+
+
+def test_missing_column_error_survives_mixed_type_column_labels():
+    df = _provenance_df()
+    df[7] = 1
+
+    with pytest.raises(ValueError, match="group_keys column 'nope'"):
+        EvalContext(df, group_keys=["nope"])
+
+
+# ---------------------------------------------------------------------------
+# Inferred keys that aren't in the frame
+# ---------------------------------------------------------------------------
+
+
+def test_uninferable_frame_explains_itself():
+    """Missing identity columns get an explanation, not a KeyError."""
+    df = _provenance_df().drop(columns=["peptide_offset"])
+
+    with pytest.raises(ValueError, match="Cannot infer group keys"):
+        EvalContext(df)
+    with pytest.raises(ValueError, match="group_keys="):
+        apply_filter(df, Affinity.value <= 500)
+
+
+def test_uninferable_frame_still_works_with_explicit_keys():
+    df = _provenance_df().drop(columns=["peptide_offset"])
+
+    kept = apply_filter(
+        df, Affinity.value <= 500,
+        group_keys=["prediction_id", "peptide", "allele"],
+    )
+
+    assert kept["prediction_id"].tolist() == ["variant-1"]
+
+
+def test_empty_frame_without_identity_columns_is_not_rejected():
+    """Nothing to group; inference stays quiet rather than erroring."""
+    assert EvalContext(pd.DataFrame()).group_keys

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -75,7 +75,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.16.2"
+__version__ = "5.17.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -13,19 +13,23 @@ from .nodes import (
     Field,
     _kind_matches,
     _missing_column_error,
-    normalize_group_keys,
+    _normalize_group_keys,
 )
 
 
 def _check_group_keys(df, group_keys):
-    """Validate explicit *group_keys* ahead of the early-return paths.
+    """Validate explicit *group_keys* on a path that returns early.
 
-    ``EvalContext`` validates them too, but an empty frame or a no-op
-    node returns before a context is ever built — a typo must not pass
-    silently just because a pipeline has degenerated to zero rows.
+    The normal path validates inside :class:`EvalContext`, but an empty
+    frame or a no-op node returns before a context is ever built — a
+    typo must not pass silently just because a pipeline has degenerated
+    to zero rows or dropped its expression.
     """
-    if group_keys is not None and df is not None:
-        normalize_group_keys(df, group_keys)
+    if group_keys is None:
+        return
+    # With no frame there are no columns to check against, but the shape
+    # of the argument is still wrong or right on its own terms.
+    _normalize_group_keys(pd.DataFrame() if df is None else df, group_keys)
 
 
 def _check_boolean_like(values: pd.Series):
@@ -83,10 +87,10 @@ def _validate_columns(df, node):
     needed = _collect_column_names(node)
     if not needed:
         return
-    missing = needed - set(df.columns)
+    missing = sorted(needed - set(df.columns))
     if not missing:
         return
-    raise _missing_column_error(min(missing), df.columns)
+    raise _missing_column_error(missing, df.columns)
 
 
 def _infer_sort_direction(node):
@@ -125,29 +129,27 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
     ``.fillna(-inf)`` for ranking.
 
     *group_keys*, *default_methods* and *kind_support* are the shared
-    context options: :func:`apply_filter`, :func:`apply_sort` and
-    :func:`evaluate_scores` all accept them and forward them to
-    :class:`EvalContext`, so one grouping and one method resolution can
-    be shared across filtering, sorting and scoring.  See
-    :class:`EvalContext` for what each one means.
+    context options, forwarded to :class:`EvalContext` — see its
+    docstring.
 
     Returns a ``pd.Series`` with ``df.index`` and a numeric dtype.
     """
     if node is None:
         raise ValueError("evaluate_scores requires a DSL node")
-    _check_group_keys(df, group_keys)
     if df is None or df.empty:
+        _check_group_keys(df, group_keys)
         return pd.Series([], index=df.index if df is not None else None,
                          dtype=float)
+
 
     ctx = EvalContext(
         df, group_keys=group_keys, default_methods=default_methods,
         kind_support=kind_support,
     )
-    scored = node.eval(ctx)
-    row_tuples = ctx.row_group_tuples()
-    aligned = row_tuples.map(scored.to_dict())
-    aligned.index = df.index
+    scored = node.eval(ctx).reindex(ctx.group_index)
+    aligned = pd.Series(
+        scored.to_numpy()[ctx.row_group_codes()], index=df.index,
+    )
     aligned = pd.to_numeric(aligned, errors="coerce")
     if not (isinstance(fill, float) and np.isnan(fill)):
         aligned = aligned.fillna(fill)
@@ -163,17 +165,12 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     truthy.  ``None`` for *node* is a no-op.
 
     *group_keys*, *default_methods* and *kind_support* are the shared
-    context options: :func:`apply_filter`, :func:`apply_sort` and
-    :func:`evaluate_scores` all accept them and forward them to
-    :class:`EvalContext`, so one grouping and one method resolution can
-    be shared across filtering, sorting and scoring.  See
-    :class:`EvalContext` for what each one means.
+    context options, forwarded to :class:`EvalContext` — see its
+    docstring.
     """
-    _check_group_keys(df, group_keys)
-    if node is None:
-        return df
-    if df.empty:
-        return df.reset_index(drop=True)
+    if node is None or df.empty:
+        _check_group_keys(df, group_keys)
+        return df if node is None else df.reset_index(drop=True)
 
     _validate_columns(df, node)
     ctx = EvalContext(
@@ -185,11 +182,9 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     # different MultiIndex alignment.
     values = node.eval(ctx).reindex(ctx.group_index)
     _check_boolean_like(values)
-    mask = values.fillna(False).astype(bool)
+    mask = values.fillna(False).astype(bool).to_numpy()
 
-    passing = set(mask[mask].index)
-    row_keys = ctx.row_group_tuples()
-    keep = row_keys.isin(passing)
+    keep = mask[ctx.row_group_codes()]
     return df[keep].reset_index(drop=True)
 
 
@@ -204,17 +199,12 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     they fall through to the next tiebreaker.
 
     *group_keys*, *default_methods* and *kind_support* are the shared
-    context options: :func:`apply_filter`, :func:`apply_sort` and
-    :func:`evaluate_scores` all accept them and forward them to
-    :class:`EvalContext`, so one grouping and one method resolution can
-    be shared across filtering, sorting and scoring.  See
-    :class:`EvalContext` for what each one means.
+    context options, forwarded to :class:`EvalContext` — see its
+    docstring.
     """
-    _check_group_keys(df, group_keys)
-    if not sort_nodes:
-        return df
-    if df.empty:
-        return df.reset_index(drop=True)
+    if not sort_nodes or df.empty:
+        _check_group_keys(df, group_keys)
+        return df if not sort_nodes else df.reset_index(drop=True)
 
     for node in sort_nodes:
         _validate_columns(df, node)
@@ -248,13 +238,11 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
         return 0
 
     sorted_idx = sorted(range(n_groups), key=cmp_to_key(_cmp))
-    sorted_keys = [ctx.group_index[i] for i in sorted_idx]
+    rank_of_group = np.empty(n_groups, dtype=int)
+    rank_of_group[sorted_idx] = np.arange(n_groups)
 
-    key_pos = {k: i for i, k in enumerate(sorted_keys)}
-    row_keys = ctx.row_group_tuples()
-    positions = row_keys.map(key_pos)
-    assert positions.notna().all(), "internal: row group tuple not found in sort keys"
-    ordered = df.assign(_sort_pos=positions.values).sort_values(
+    positions = rank_of_group[ctx.row_group_codes()]
+    ordered = df.assign(_sort_pos=positions).sort_values(
         "_sort_pos", kind="mergesort",
     )
     return ordered.drop(columns=["_sort_pos"]).reset_index(drop=True)

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -13,7 +13,19 @@ from .nodes import (
     Field,
     _kind_matches,
     _missing_column_error,
+    normalize_group_keys,
 )
+
+
+def _check_group_keys(df, group_keys):
+    """Validate explicit *group_keys* ahead of the early-return paths.
+
+    ``EvalContext`` validates them too, but an empty frame or a no-op
+    node returns before a context is ever built — a typo must not pass
+    silently just because a pipeline has degenerated to zero rows.
+    """
+    if group_keys is not None and df is not None:
+        normalize_group_keys(df, group_keys)
 
 
 def _check_boolean_like(values: pd.Series):
@@ -123,6 +135,7 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
     """
     if node is None:
         raise ValueError("evaluate_scores requires a DSL node")
+    _check_group_keys(df, group_keys)
     if df is None or df.empty:
         return pd.Series([], index=df.index if df is not None else None,
                          dtype=float)
@@ -156,6 +169,7 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     be shared across filtering, sorting and scoring.  See
     :class:`EvalContext` for what each one means.
     """
+    _check_group_keys(df, group_keys)
     if node is None:
         return df
     if df.empty:
@@ -196,6 +210,7 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     be shared across filtering, sorting and scoring.  See
     :class:`EvalContext` for what each one means.
     """
+    _check_group_keys(df, group_keys)
     if not sort_nodes:
         return df
     if df.empty:

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from difflib import get_close_matches
 from functools import cmp_to_key
 
 import numpy as np
@@ -13,6 +12,7 @@ from .nodes import (
     EvalContext,
     Field,
     _kind_matches,
+    _missing_column_error,
 )
 
 
@@ -71,18 +71,10 @@ def _validate_columns(df, node):
     needed = _collect_column_names(node)
     if not needed:
         return
-    available = set(df.columns)
-    missing = needed - available
+    missing = needed - set(df.columns)
     if not missing:
         return
-    for col_name in sorted(missing):
-        close = get_close_matches(col_name, sorted(available), n=3, cutoff=0.6)
-        msg = f"Column {col_name!r} not found in DataFrame."
-        if close:
-            msg += f" Did you mean: {close}?"
-        else:
-            msg += f" Available columns: {sorted(available)}"
-        raise ValueError(msg)
+    raise _missing_column_error(min(missing), df.columns)
 
 
 def _infer_sort_direction(node):
@@ -101,7 +93,8 @@ def _resolve_sort_direction(node, sort_direction):
     return sort_direction
 
 
-def evaluate_scores(df, node, group_keys=None, fill=np.nan, kind_support=None):
+def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
+                    kind_support=None, fill=np.nan):
     """Evaluate a DSL *node* against *df* and align the result to ``df.index``.
 
     ``DSLNode.eval`` returns a Series indexed by the peptide-allele
@@ -109,8 +102,7 @@ def evaluate_scores(df, node, group_keys=None, fill=np.nan, kind_support=None):
     This helper wraps the group→row mapping every consumer ends up
     writing by hand:
 
-    1. Build an :class:`EvalContext` (with optional *group_keys* and
-       *kind_support*).
+    1. Build an :class:`EvalContext`.
     2. Call ``node.eval(ctx)``.
     3. Map each of ``df``'s rows to its group's value via
        :meth:`EvalContext.row_group_tuples`.
@@ -120,11 +112,12 @@ def evaluate_scores(df, node, group_keys=None, fill=np.nan, kind_support=None):
     callers pick semantics — ``.fillna(0.0)`` for additive scoring,
     ``.fillna(-inf)`` for ranking.
 
-    *kind_support* is the per-(model, kind) metadata dict produced by
-    :attr:`TopiaryPredictor.kind_support`. Forwarded to
-    :class:`EvalContext` so allele-aware nodes (e.g.
-    :class:`BestAlleleField`) can warn or branch on
-    ``mhc_dependence``.
+    *group_keys*, *default_methods* and *kind_support* are the shared
+    context options: :func:`apply_filter`, :func:`apply_sort` and
+    :func:`evaluate_scores` all accept them and forward them to
+    :class:`EvalContext`, so one grouping and one method resolution can
+    be shared across filtering, sorting and scoring.  See
+    :class:`EvalContext` for what each one means.
 
     Returns a ``pd.Series`` with ``df.index`` and a numeric dtype.
     """
@@ -134,7 +127,10 @@ def evaluate_scores(df, node, group_keys=None, fill=np.nan, kind_support=None):
         return pd.Series([], index=df.index if df is not None else None,
                          dtype=float)
 
-    ctx = EvalContext(df, group_keys=group_keys, kind_support=kind_support)
+    ctx = EvalContext(
+        df, group_keys=group_keys, default_methods=default_methods,
+        kind_support=kind_support,
+    )
     scored = node.eval(ctx)
     row_tuples = ctx.row_group_tuples()
     aligned = row_tuples.map(scored.to_dict())
@@ -146,20 +142,19 @@ def evaluate_scores(df, node, group_keys=None, fill=np.nan, kind_support=None):
     return aligned
 
 
-def apply_filter(df, node, default_methods=None, kind_support=None):
+def apply_filter(df, node, *, group_keys=None, default_methods=None,
+                 kind_support=None):
     """Apply a boolean-valued DSL node to *df*.
 
     Keeps all rows for peptide-allele groups whose evaluated value is
     truthy.  ``None`` for *node* is a no-op.
 
-    *default_methods* is forwarded to :class:`EvalContext` — see its
-    docstring for the per-kind default ``prediction_method_name`` kwarg
-    used to resolve unqualified Field references on multi-method inputs.
-
-    *kind_support* (optional) is the per-(model, kind) metadata dict
-    from :attr:`TopiaryPredictor.kind_support`. Forwarded to
-    :class:`EvalContext` so :class:`BestAlleleField` can warn when
-    invoked against ``mhc_dependence='single_allele'`` rows.
+    *group_keys*, *default_methods* and *kind_support* are the shared
+    context options: :func:`apply_filter`, :func:`apply_sort` and
+    :func:`evaluate_scores` all accept them and forward them to
+    :class:`EvalContext`, so one grouping and one method resolution can
+    be shared across filtering, sorting and scoring.  See
+    :class:`EvalContext` for what each one means.
     """
     if node is None:
         return df
@@ -168,8 +163,8 @@ def apply_filter(df, node, default_methods=None, kind_support=None):
 
     _validate_columns(df, node)
     ctx = EvalContext(
-        df, filter_context=True, default_methods=default_methods,
-        kind_support=kind_support,
+        df, group_keys=group_keys, filter_context=True,
+        default_methods=default_methods, kind_support=kind_support,
     )
     # Reindex defensively so a misbehaving node (index mismatch) surfaces
     # as NaN → False rather than silently picking up rows from a
@@ -184,8 +179,8 @@ def apply_filter(df, node, default_methods=None, kind_support=None):
     return df[keep].reset_index(drop=True)
 
 
-def apply_sort(df, sort_nodes, sort_direction="auto", default_methods=None,
-               kind_support=None):
+def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
+               default_methods=None, kind_support=None):
     """Sort groups by one or more DSL nodes (lexicographic fallthrough).
 
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
@@ -194,8 +189,12 @@ def apply_sort(df, sort_nodes, sort_direction="auto", default_methods=None,
     value is used for all nodes.  NaN values do not force an ordering —
     they fall through to the next tiebreaker.
 
-    *default_methods* and *kind_support* are forwarded to
-    :class:`EvalContext` — see its docstring.
+    *group_keys*, *default_methods* and *kind_support* are the shared
+    context options: :func:`apply_filter`, :func:`apply_sort` and
+    :func:`evaluate_scores` all accept them and forward them to
+    :class:`EvalContext`, so one grouping and one method resolution can
+    be shared across filtering, sorting and scoring.  See
+    :class:`EvalContext` for what each one means.
     """
     if not sort_nodes:
         return df
@@ -205,7 +204,8 @@ def apply_sort(df, sort_nodes, sort_direction="auto", default_methods=None,
     for node in sort_nodes:
         _validate_columns(df, node)
 
-    ctx = EvalContext(df, default_methods=default_methods,
+    ctx = EvalContext(df, group_keys=group_keys,
+                      default_methods=default_methods,
                       kind_support=kind_support)
     n_groups = len(ctx.group_index)
     n_keys = len(sort_nodes)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import math
 import operator
+from collections import Counter
 from difflib import get_close_matches
 from typing import Optional
 
@@ -112,21 +113,42 @@ def _build_kind_aliases(kind_source=Kind):
 # =============================================================================
 
 
-def _missing_column_error(col_name, available, label="Column"):
-    """ValueError for a referenced column that isn't in the DataFrame."""
-    # str() the labels: difflib needs strings, and a frame is allowed
-    # non-string column labels that would otherwise fail to sort.
-    available = sorted(str(c) for c in available)
-    close = (
-        get_close_matches(col_name, available, n=3, cutoff=0.6)
-        if isinstance(col_name, str) else []
+def _missing_column_error(col_names, available, label="Column"):
+    """ValueError for referenced column(s) that aren't in the DataFrame.
+
+    Takes one name or several; naming all of them at once saves the
+    caller a round-trip per typo.
+    """
+    names = (
+        list(col_names) if isinstance(col_names, (list, tuple, set))
+        else [col_names]
     )
-    msg = f"{label} {col_name!r} not found in DataFrame."
-    if close:
-        msg += f" Did you mean: {close}?"
-    else:
-        msg += f" Available columns: {available}"
-    return ValueError(msg)
+    # Suggest only real string labels — a frame is allowed non-string
+    # column labels, and str()ing them would suggest a '7' that isn't a
+    # usable key.  The displayed list is stringified so it can be sorted.
+    string_labels = sorted(c for c in available if isinstance(c, str))
+
+    def suggest(name):
+        if not isinstance(name, str):
+            return []
+        return get_close_matches(name, string_labels, n=3, cutoff=0.6)
+
+    if len(names) == 1:
+        msg = f"{label} {names[0]!r} not found in DataFrame."
+        close = suggest(names[0])
+        if close:
+            return ValueError(msg + f" Did you mean: {close}?")
+        return ValueError(
+            msg + f" Available columns: {sorted(str(c) for c in available)}"
+        )
+
+    msg = f"{label}s {names!r} not found in DataFrame."
+    hints = [f"{n!r} -> {close}" for n in names if (close := suggest(n))]
+    if hints:
+        return ValueError(msg + f" Did you mean: {'; '.join(hints)}?")
+    return ValueError(
+        msg + f" Available columns: {sorted(str(c) for c in available)}"
+    )
 
 
 _SAMPLE_GROUP_KEY = "sample_name"
@@ -147,12 +169,13 @@ def _has_real_sample_names(values) -> bool:
     for no benefit.  A frame that mixes real names with blanks keeps the
     key — there the blank *is* a distinguishing value.
     """
-    non_null = values.dropna()
-    if non_null.empty:
-        return False
-    # Sample names are constant per sample, so the distinct set is tiny —
-    # much cheaper than stringifying and stripping every row.
-    return any(str(v).strip() != "" for v in pd.unique(non_null.to_numpy()))
+    # Sample names are constant per sample, so the distinct set is tiny.
+    # One hashing pass over the column, then the blank test runs over a
+    # couple of values rather than every row.
+    return any(
+        not pd.isna(v) and str(v).strip() != ""
+        for v in pd.unique(values.to_numpy())
+    )
 
 
 def _with_optional_sample_key(df, group_keys):
@@ -187,7 +210,9 @@ def _check_inferred_group_keys(df, keys):
     missing one of them used to reach ``df[self.group_keys]`` and raise
     a bare ``KeyError``; say what's missing and point at the way out.
     """
-    if df.empty:
+    if len(df.columns) == 0:
+        # Nothing to infer from at all (e.g. ``pd.DataFrame()``); there is
+        # no identity to get wrong, so stay quiet.
         return
     missing = [k for k in keys if k not in df.columns]
     if not missing:
@@ -200,7 +225,7 @@ def _check_inferred_group_keys(df, keys):
     )
 
 
-def normalize_group_keys(df, group_keys):
+def _normalize_group_keys(df, group_keys):
     """Validate explicit *group_keys* against *df* and return them as a list.
 
     Fails loudly on a bare string, an empty sequence, duplicate entries,
@@ -219,10 +244,20 @@ def normalize_group_keys(df, group_keys):
             "group_keys must be a non-empty sequence of column names; "
             "pass group_keys=None to infer them from the DataFrame."
         )
-    duplicates = sorted({str(k) for k in keys if keys.count(k) > 1})
+    # Compare by repr, not ==: a key may be array-like, whose __eq__
+    # returns an array and would raise before the real error is reached.
+    counts = Counter(repr(k) for k in keys)
+    duplicates = sorted(k for k, n in counts.items() if n > 1)
     if duplicates:
         raise ValueError(f"group_keys has duplicate entries: {duplicates}")
     for key in keys:
+        try:
+            hash(key)
+        except TypeError:
+            raise ValueError(
+                f"group_keys entries must be column names, got a "
+                f"{type(key).__name__}: {key!r}"
+            ) from None
         if key not in df.columns:
             raise _missing_column_error(
                 key, df.columns, label="group_keys column",
@@ -318,7 +353,8 @@ class EvalContext:
     __slots__ = (
         "df", "group_keys", "default_methods", "filter_context",
         "kind_support",
-        "_group_index", "_group_tuples_cache", "_method_override",
+        "_group_index", "_key_frame", "_group_tuples_cache",
+        "_group_codes_cache", "_method_override",
     )
 
     def __init__(
@@ -329,7 +365,7 @@ class EvalContext:
         if group_keys is None:
             self.group_keys = _pick_group_keys(df)
         else:
-            self.group_keys = normalize_group_keys(df, group_keys)
+            self.group_keys = _normalize_group_keys(df, group_keys)
         self.default_methods = (
             _normalize_default_methods(default_methods) if default_methods else {}
         )
@@ -341,11 +377,37 @@ class EvalContext:
         # ``{model_key: {kind_value: {"mhc_dependence", "mhc_class"}}}``.
         self.kind_support = kind_support
         self._group_index = None
+        self._key_frame = None
         self._group_tuples_cache = None
+        self._group_codes_cache = None
         # Internal: when Comparison auto-aggregates across methods, it
         # binds Field(method=None, kind=K) references to a specific
         # method per iteration by setting (kind_value, method_name) here.
         self._method_override = None
+
+    @property
+    def key_frame(self) -> pd.DataFrame:
+        """The group-key columns, with null spellings collapsed.
+
+        ``groupby(dropna=False)`` — which every node evaluates through —
+        treats ``None``, ``NaN`` and ``pd.NA`` in an object column as one
+        group, but a plain ``drop_duplicates`` keeps them apart.  Building
+        the group index from raw values therefore produces groups no node
+        result can ever key, and rows would silently score NaN.  Collapse
+        them once here so the index, the row mapping and every node agree.
+        """
+        if self._key_frame is None:
+            frame = self.df[self.group_keys]
+            mixed = [
+                k for k in self.group_keys
+                if frame[k].dtype == object and frame[k].isna().any()
+            ]
+            if mixed:
+                frame = frame.assign(**{
+                    k: frame[k].where(frame[k].notna(), np.nan) for k in mixed
+                })
+            self._key_frame = frame
+        return self._key_frame
 
     @property
     def group_index(self) -> pd.Index:
@@ -370,7 +432,7 @@ class EvalContext:
                         names=self.group_keys,
                     )
             else:
-                key_df = self.df[self.group_keys].drop_duplicates()
+                key_df = self.key_frame.drop_duplicates()
                 if single_key:
                     key = self.group_keys[0]
                     self._group_index = pd.Index(key_df[key], name=key)
@@ -378,11 +440,39 @@ class EvalContext:
                     self._group_index = pd.MultiIndex.from_frame(key_df)
         return self._group_index
 
+    def row_group_codes(self) -> np.ndarray:
+        """Position within :attr:`group_index` of each row's group.
+
+        The way to map a per-group Series back onto rows.  Prefer this
+        over matching :meth:`row_group_tuples` against a set of keys:
+        ``NaN`` never equals itself, and since Python 3.10 hashes by
+        identity, so key lookups drop rows whose group key is null.
+        Positions sidestep both.
+        """
+        if self._group_codes_cache is None:
+            if self.df.empty:
+                self._group_codes_cache = np.empty(0, dtype=int)
+            else:
+                if len(self.group_keys) == 1:
+                    key = self.group_keys[0]
+                    row_index = pd.Index(self.key_frame[key], name=key)
+                else:
+                    row_index = pd.MultiIndex.from_frame(self.key_frame)
+                codes = self.group_index.get_indexer(row_index)
+                assert (codes >= 0).all(), (
+                    "internal: row group key missing from group_index"
+                )
+                self._group_codes_cache = codes
+        return self._group_codes_cache
+
     def row_group_tuples(self) -> pd.Series:
         """Per-row group key, aligned to ``self.df.index``.
 
         A tuple of group-key values per row — or the bare value when
         there is a single group key, matching :attr:`group_index`.
+        For mapping group results back onto rows, use
+        :meth:`row_group_codes`: null keys make key-based lookups
+        unreliable.
         """
         if self._group_tuples_cache is None:
             if self.df.empty:
@@ -391,12 +481,12 @@ class EvalContext:
                 )
             elif len(self.group_keys) == 1:
                 self._group_tuples_cache = pd.Series(
-                    self.df[self.group_keys[0]].to_numpy(),
+                    self.key_frame[self.group_keys[0]].to_numpy(),
                     index=self.df.index,
                 )
             else:
                 self._group_tuples_cache = pd.Series(
-                    list(zip(*[self.df[k] for k in self.group_keys])),
+                    list(zip(*[self.key_frame[k] for k in self.group_keys])),
                     index=self.df.index,
                 )
         return self._group_tuples_cache

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -114,8 +114,13 @@ def _build_kind_aliases(kind_source=Kind):
 
 def _missing_column_error(col_name, available, label="Column"):
     """ValueError for a referenced column that isn't in the DataFrame."""
-    available = sorted(available)
-    close = get_close_matches(col_name, available, n=3, cutoff=0.6)
+    # str() the labels: difflib needs strings, and a frame is allowed
+    # non-string column labels that would otherwise fail to sort.
+    available = sorted(str(c) for c in available)
+    close = (
+        get_close_matches(col_name, available, n=3, cutoff=0.6)
+        if isinstance(col_name, str) else []
+    )
     msg = f"{label} {col_name!r} not found in DataFrame."
     if close:
         msg += f" Did you mean: {close}?"
@@ -145,7 +150,9 @@ def _has_real_sample_names(values) -> bool:
     non_null = values.dropna()
     if non_null.empty:
         return False
-    return bool(non_null.astype(str).str.strip().ne("").any())
+    # Sample names are constant per sample, so the distinct set is tiny —
+    # much cheaper than stringifying and stripping every row.
+    return any(str(v).strip() != "" for v in pd.unique(non_null.to_numpy()))
 
 
 def _with_optional_sample_key(df, group_keys):
@@ -164,32 +171,63 @@ def _pick_group_keys(df):
     # variant is for the legacy varcode pipeline; source_sequence_name is the
     # generic fallback.
     if "fragment_id" in df.columns:
-        return _with_optional_sample_key(df, _GROUP_KEYS_FRAGMENT)
-    if "variant" in df.columns:
-        return _with_optional_sample_key(df, _GROUP_KEYS_VARIANT)
-    return _with_optional_sample_key(df, _GROUP_KEYS)
+        keys = _GROUP_KEYS_FRAGMENT
+    elif "variant" in df.columns:
+        keys = _GROUP_KEYS_VARIANT
+    else:
+        keys = _GROUP_KEYS
+    _check_inferred_group_keys(df, keys)
+    return _with_optional_sample_key(df, keys)
 
 
-def _validate_group_keys(df, group_keys):
-    """Check explicit *group_keys* against *df* before any evaluation.
+def _check_inferred_group_keys(df, keys):
+    """Explain a frame that inference can't key, instead of a KeyError.
 
-    Fails loudly on an empty sequence, duplicate entries, or names that
-    aren't columns, so a caller with a stable provenance identity finds
-    out here rather than through a KeyError deep inside a node.
+    Inference works from a fixed set of identity columns.  A frame
+    missing one of them used to reach ``df[self.group_keys]`` and raise
+    a bare ``KeyError``; say what's missing and point at the way out.
     """
-    if not group_keys:
+    if df.empty:
+        return
+    missing = [k for k in keys if k not in df.columns]
+    if not missing:
+        return
+    raise ValueError(
+        f"Cannot infer group keys: this DataFrame is missing "
+        f"{missing!r}, expected alongside "
+        f"{[k for k in keys if k in df.columns]!r}. "
+        f"Pass group_keys=[...] to name the group identity explicitly."
+    )
+
+
+def normalize_group_keys(df, group_keys):
+    """Validate explicit *group_keys* against *df* and return them as a list.
+
+    Fails loudly on a bare string, an empty sequence, duplicate entries,
+    or names that aren't columns, so a caller with a stable provenance
+    identity finds out here rather than through a KeyError deep inside a
+    node.
+    """
+    if isinstance(group_keys, str):
+        raise ValueError(
+            f"group_keys must be a sequence of column names, not the string "
+            f"{group_keys!r}; pass [{group_keys!r}] for a single key."
+        )
+    keys = list(group_keys)
+    if not keys:
         raise ValueError(
             "group_keys must be a non-empty sequence of column names; "
             "pass group_keys=None to infer them from the DataFrame."
         )
-    duplicates = sorted({k for k in group_keys if group_keys.count(k) > 1})
+    duplicates = sorted({str(k) for k in keys if keys.count(k) > 1})
     if duplicates:
         raise ValueError(f"group_keys has duplicate entries: {duplicates}")
-    for key in group_keys:
+    for key in keys:
         if key not in df.columns:
             raise _missing_column_error(
                 key, df.columns, label="group_keys column",
             )
+    return keys
 
 
 def _normalize_default_methods(mapping):
@@ -231,9 +269,9 @@ class EvalContext:
     """Context for vectorized DSL evaluation.
 
     Wraps a prediction DataFrame and exposes the unique group-key
-    MultiIndex.  Every :class:`DSLNode` ``.eval(ctx)`` returns a
-    ``pd.Series`` indexed by this MultiIndex (one value per peptide
-    -allele group).
+    index.  Every :class:`DSLNode` ``.eval(ctx)`` returns a
+    ``pd.Series`` indexed by :attr:`group_index` (one value per
+    peptide-allele group).
 
     Parameters
     ----------
@@ -291,8 +329,7 @@ class EvalContext:
         if group_keys is None:
             self.group_keys = _pick_group_keys(df)
         else:
-            self.group_keys = list(group_keys)
-            _validate_group_keys(df, self.group_keys)
+            self.group_keys = normalize_group_keys(df, group_keys)
         self.default_methods = (
             _normalize_default_methods(default_methods) if default_methods else {}
         )
@@ -311,26 +348,51 @@ class EvalContext:
         self._method_override = None
 
     @property
-    def group_index(self) -> pd.MultiIndex:
-        """MultiIndex of unique group-key tuples (preserving row order)."""
+    def group_index(self) -> pd.Index:
+        """Index of unique group keys, preserving row order.
+
+        A MultiIndex of key tuples, or a flat Index of bare values when
+        there is a single group key.  That mirrors what
+        ``DataFrame.groupby`` produces, so node results — which are all
+        groupby output reindexed onto this — align in both cases.  A
+        1-level MultiIndex here would silently reindex to all-NaN
+        against a groupby's flat Index.
+        """
         if self._group_index is None:
+            single_key = len(self.group_keys) == 1
             if self.df.empty:
-                self._group_index = pd.MultiIndex(
-                    levels=[[] for _ in self.group_keys],
-                    codes=[[] for _ in self.group_keys],
-                    names=self.group_keys,
-                )
+                if single_key:
+                    self._group_index = pd.Index([], name=self.group_keys[0])
+                else:
+                    self._group_index = pd.MultiIndex(
+                        levels=[[] for _ in self.group_keys],
+                        codes=[[] for _ in self.group_keys],
+                        names=self.group_keys,
+                    )
             else:
                 key_df = self.df[self.group_keys].drop_duplicates()
-                self._group_index = pd.MultiIndex.from_frame(key_df)
+                if single_key:
+                    key = self.group_keys[0]
+                    self._group_index = pd.Index(key_df[key], name=key)
+                else:
+                    self._group_index = pd.MultiIndex.from_frame(key_df)
         return self._group_index
 
     def row_group_tuples(self) -> pd.Series:
-        """Per-row tuple of group-key values, aligned to ``self.df.index``."""
+        """Per-row group key, aligned to ``self.df.index``.
+
+        A tuple of group-key values per row — or the bare value when
+        there is a single group key, matching :attr:`group_index`.
+        """
         if self._group_tuples_cache is None:
             if self.df.empty:
                 self._group_tuples_cache = pd.Series(
                     [], index=self.df.index, dtype=object
+                )
+            elif len(self.group_keys) == 1:
+                self._group_tuples_cache = pd.Series(
+                    self.df[self.group_keys[0]].to_numpy(),
+                    index=self.df.index,
                 )
             else:
                 self._group_tuples_cache = pd.Series(

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -111,6 +111,19 @@ def _build_kind_aliases(kind_source=Kind):
 # Group key detection and EvalContext
 # =============================================================================
 
+
+def _missing_column_error(col_name, available, label="Column"):
+    """ValueError for a referenced column that isn't in the DataFrame."""
+    available = sorted(available)
+    close = get_close_matches(col_name, available, n=3, cutoff=0.6)
+    msg = f"{label} {col_name!r} not found in DataFrame."
+    if close:
+        msg += f" Did you mean: {close}?"
+    else:
+        msg += f" Available columns: {available}"
+    return ValueError(msg)
+
+
 _SAMPLE_GROUP_KEY = "sample_name"
 _GROUP_KEYS = ["source_sequence_name", "peptide", "peptide_offset", "allele"]
 _GROUP_KEYS_VARIANT = ["variant", "peptide", "peptide_offset", "allele"]
@@ -119,12 +132,28 @@ _GROUP_KEYS_VARIANT = ["variant", "peptide", "peptide_offset", "allele"]
 _GROUP_KEYS_FRAGMENT = ["fragment_id", "peptide", "peptide_offset", "allele"]
 
 
+def _has_real_sample_names(values) -> bool:
+    """True when *values* holds at least one non-blank sample name.
+
+    ``mhctools`` stamps ``sample_name=""`` on every row of a
+    single-sample run, so the column's presence alone does not mean the
+    frame is multi-sample.  A null-or-blank column carries no identity;
+    grouping by it would widen every group tuple with a constant level
+    for no benefit.  A frame that mixes real names with blanks keeps the
+    key — there the blank *is* a distinguishing value.
+    """
+    non_null = values.dropna()
+    if non_null.empty:
+        return False
+    return bool(non_null.astype(str).str.strip().ne("").any())
+
+
 def _with_optional_sample_key(df, group_keys):
     group_keys = list(group_keys)
     if (
         _SAMPLE_GROUP_KEY in df.columns
         and _SAMPLE_GROUP_KEY not in group_keys
-        and df[_SAMPLE_GROUP_KEY].notna().any()
+        and _has_real_sample_names(df[_SAMPLE_GROUP_KEY])
     ):
         group_keys.insert(0, _SAMPLE_GROUP_KEY)
     return group_keys
@@ -139,6 +168,28 @@ def _pick_group_keys(df):
     if "variant" in df.columns:
         return _with_optional_sample_key(df, _GROUP_KEYS_VARIANT)
     return _with_optional_sample_key(df, _GROUP_KEYS)
+
+
+def _validate_group_keys(df, group_keys):
+    """Check explicit *group_keys* against *df* before any evaluation.
+
+    Fails loudly on an empty sequence, duplicate entries, or names that
+    aren't columns, so a caller with a stable provenance identity finds
+    out here rather than through a KeyError deep inside a node.
+    """
+    if not group_keys:
+        raise ValueError(
+            "group_keys must be a non-empty sequence of column names; "
+            "pass group_keys=None to infer them from the DataFrame."
+        )
+    duplicates = sorted({k for k in group_keys if group_keys.count(k) > 1})
+    if duplicates:
+        raise ValueError(f"group_keys has duplicate entries: {duplicates}")
+    for key in group_keys:
+        if key not in df.columns:
+            raise _missing_column_error(
+                key, df.columns, label="group_keys column",
+            )
 
 
 def _normalize_default_methods(mapping):
@@ -189,7 +240,16 @@ class EvalContext:
     df : pandas.DataFrame
         Prediction rows, long-form.
     group_keys : list of str, optional
-        Override the auto-detected peptide-allele group keys.
+        Override the auto-detected peptide-allele group keys.  Use this
+        when the frame carries a stable provenance identity (e.g. a
+        variant or prediction ID) that inferred sequence-oriented keys
+        would collapse: two rows with the same peptide, context and
+        offset but different origins stay in separate groups.  The names
+        are validated against ``df`` up front.
+        :func:`~topiary.ranking.apply_filter`,
+        :func:`~topiary.ranking.apply_sort` and
+        :func:`~topiary.ranking.evaluate_scores` forward the same kwarg,
+        so filtering, sorting and scoring can share one grouping.
     default_methods : dict, optional
         Per-kind default ``prediction_method_name`` for resolving
         unqualified Field references when multiple methods produce
@@ -228,7 +288,11 @@ class EvalContext:
         kind_support=None,
     ):
         self.df = df
-        self.group_keys = list(group_keys) if group_keys else _pick_group_keys(df)
+        if group_keys is None:
+            self.group_keys = _pick_group_keys(df)
+        else:
+            self.group_keys = list(group_keys)
+            _validate_group_keys(df, self.group_keys)
         self.default_methods = (
             _normalize_default_methods(default_methods) if default_methods else {}
         )
@@ -541,14 +605,7 @@ class Column(DSLNode):
         if ctx.df.empty:
             return ctx.empty_series()
         if self.col_name not in ctx.df.columns:
-            available = sorted(ctx.df.columns)
-            close = get_close_matches(self.col_name, available, n=3, cutoff=0.6)
-            msg = f"Column {self.col_name!r} not found in DataFrame."
-            if close:
-                msg += f" Did you mean: {close}?"
-            else:
-                msg += f" Available: {available}"
-            raise ValueError(msg)
+            raise _missing_column_error(self.col_name, ctx.df.columns)
         vals = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[self.col_name].first()
@@ -633,14 +690,7 @@ class IsIn(DSLNode):
             # to carry a stale non-empty index.
             return ctx.empty_series().astype("boolean")
         if self.col_name not in df.columns:
-            available = sorted(df.columns)
-            close = get_close_matches(self.col_name, available, n=3, cutoff=0.6)
-            msg = f"Column {self.col_name!r} not found in DataFrame."
-            if close:
-                msg += f" Did you mean: {close}?"
-            else:
-                msg += f" Available: {available}"
-            raise ValueError(msg)
+            raise _missing_column_error(self.col_name, df.columns)
         vals = df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[self.col_name].first()


### PR DESCRIPTION
Closes #175.

## What changed

`apply_filter`, `apply_sort` and `evaluate_scores` now accept the same three
keyword-only context options — `group_keys`, `default_methods` and
`kind_support` — and forward all of them to `EvalContext`. Previously each
entry point supported a different subset: `apply_filter`/`apply_sort` took
`default_methods` but not `group_keys`, `evaluate_scores` took `group_keys`
but not `default_methods`.

```python
group_keys = ["prediction_id", "source_sequence_name", "peptide",
              "peptide_offset", "allele"]

kept   = apply_filter(df, Affinity <= 500, group_keys=group_keys)
kept   = apply_sort(kept, [Affinity.score], group_keys=group_keys)
scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
```

The generalization beyond the issue is that one grouping and one method
resolution can now be shared across all three operations, rather than
`group_keys` being bolted onto `apply_filter` alone.

## Why

Inferred group keys are sequence-oriented, so two rows that share peptide,
source sequence and offset land in the same group even when they came from
different variants, transcripts or genes — and then one row's filter decision
applies to the other (openvax/vaxrank#345). Callers with a stable provenance
identity had to reimplement `apply_filter` on top of the public `EvalContext`
to supply their own grouping.

Verified against vaxrank's `filter_prediction_groups` wrapper: for both the
plain and `default_methods` paths, `apply_filter(df, node, group_keys=...)`
returns a frame equal to the wrapper's output, so that wrapper can be deleted
downstream.

## Also in this PR

**Explicit `group_keys` are validated up front.** An empty sequence,
duplicate entries, or names that aren't columns now raise from the
`EvalContext` constructor with a near-match suggestion, instead of a
`KeyError` deep inside a node. This benefits direct `EvalContext` users too.
The three near-identical "column not found" message builders (`Column.eval`,
`IsIn.eval`, `_validate_columns`) collapse into one shared helper.

**Blank `sample_name` is no longer an inferred group key.** `mhctools`
stamps `sample_name=""` on every row of a single-sample run, so group key
inference was prepending a constant `sample_name` level to every group tuple
of ordinary `TopiaryPredictor` output:

```python
>>> EvalContext(predictor.predict_from_named_peptides(...).df).group_keys
['sample_name', 'source_sequence_name', 'peptide', 'peptide_offset', 'allele']
```

A `sample_name` column that is entirely null or blank is now ignored by
inference (null-only columns already were). Frames that mix real names with
blanks keep the key — there the blank *is* a distinguishing value — and
`group_keys=` can still name it explicitly. This removes the need for
vaxrank's `drop_empty_sample_name` workaround.

## Breaking change

The context options are keyword-only, so their order can keep growing without
silently reinterpreting positional arguments. Calls that passed them
positionally — `apply_filter(df, node, default_methods)`,
`evaluate_scores(df, node, group_keys, fill)` — must use keywords. Positional
`df`, `node` / `sort_nodes` and `sort_direction` are unchanged. Per this
repo's version scheme that lands as a minor bump: **5.17.0**.

## Tests

New `tests/test_group_keys.py` (24 tests) covering the issue's list plus the
generalizations: distinct provenance IDs staying separate under explicit
keys, `apply_filter` agreeing with a direct `EvalContext` build, omitted
`group_keys` reproducing inferred grouping exactly, the same kwarg on
`apply_sort`/`evaluate_scores`, `default_methods` on `evaluate_scores`,
keyword-only enforcement, the four validation errors, and the `sample_name`
inference rules.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1566 passed, 3 skipped. The 7 failures in
  `test_sources.py` / `test_integration.py` / `test_coverage_gaps.py` are
  pre-existing on master (confirmed by stashing this branch): the installed
  pirlygenes 5.23.55 names its expression columns `<tissue>_nTPM` while
  `topiary/sources.py` expects `nTPM_<tissue>`, so `available_tissues()`
  returns `[]`. Filed separately as #177.

## Review follow-ups (second commit)

A `/code-review` pass on the first commit surfaced a bug worth calling out, plus
several rough edges around the new kwarg. All verified empirically before fixing:

**Single group key returned nothing.** `EvalContext.group_index` built a 1-level
`MultiIndex` for a single group key, but `DataFrame.groupby` on one key produces
a flat `Index`, so every node result reindexed to all-NaN:

```python
>>> apply_filter(df, Affinity.value <= 500, group_keys=["peptide"])   # before
Empty DataFrame
>>> evaluate_scores(df, Affinity.value, group_keys=["peptide"])       # before
[nan, nan]
```

`apply_sort` silently no-opped (all comparisons NaN). `group_index` is now a
flat `Index`, and `row_group_tuples` yields bare values, when there is one group
key. Multi-key grouping is unchanged, and this is the convention the code
already relied on elsewhere — `BestAlleleField` aligns a single-key
`groupby` against `group_index.droplevel("allele")`, which pandas collapses to
a flat `Index`. Reachable before this PR via `EvalContext` directly; the new
kwarg makes it reachable from all three entry points.

Also fixed:

- Explicit `group_keys` are validated **before** the early-return paths, so a
  typo isn't swallowed when the frame is empty or the node is a no-op.
- A bare string (`group_keys="peptide"`) is rejected by name instead of being
  splatted into characters and reported as `duplicate entries: ['e', 'p']`.
- Non-string keys and mixed-type column labels no longer reach `difflib`, which
  raised `TypeError: 'int' object is not iterable` instead of the intended
  `ValueError`.
- Frames that key *inference* can't handle (missing e.g. `peptide_offset`) get
  a `ValueError` naming what's missing and pointing at `group_keys=`, instead
  of a bare `KeyError` from pandas. Pre-existing, but it's the exact failure the
  new validator claims to prevent.
- `_has_real_sample_names` checks the distinct values rather than stringifying
  every row: measured 0.22s → 0.07s on a 2M-row column, same answers.

13 more tests (37 total in `tests/test_group_keys.py`).

### Deliberately not changed

- **Constant non-blank `sample_name` still widens group tuples.** Suggested as
  the more general rule, but a named single sample is real identity, and making
  the key depend on cardinality means filtering a two-sample frame down to one
  sample would silently change the grouping.
- **Predictor/result plumbing** (`TopiaryPredictor._apply_filter` and
  `TopiaryResult.filter_by` forward none of the three options) → #178.
- **Each entry point still builds its own `EvalContext`**, so the sharing is by
  convention rather than literal, and the grouping is recomputed per call →
  #179.
- `properties.py:303` still hand-rolls a "column not found" message outside the
  consolidated helper — cosmetic, left out to keep the diff scoped.

## Second review pass (third commit)

A second `/code-review` found two more silent-data-loss bugs with a shared root
cause: **group identity was compared by key value, and a null key never equals
itself.**

`None`, `NaN` and `pd.NA` in an identity column are one group under
`groupby(dropna=False)` — which every node evaluates through — but `group_index`
was built from raw values, which keeps them apart, so rows in the extra group
scored `NaN`. And rows were matched to their group with tuple/dict lookups,
which never match a null key (`NaN != NaN`, and since Python 3.10 it hashes by
identity). Verified before the fix:

```python
# source_sequence_name = [None, nan, "x"], values 50 / 100 / 150
>>> apply_filter(df, Affinity.value <= 60)      # before
[]                                              # p0 scored 50 and should pass
>>> apply_sort(df, [Affinity.value])            # before
["p0", "p1", "p2"]                              # sort disagreed with filter
```

Reachable without `group_keys` at all — `TopiaryPredictor` writes
`source_sequence_name = None`, and those frames get concatenated with
NaN-valued ones through `combine_predictions`. `EvalContext` now collapses null
spellings once in a cached `key_frame`, and the new `row_group_codes()` gives
each row the position of its group, which all three entry points use instead of
key lookups. Both bugs predate this PR; they live in the identity code this PR
is about, and one of them is the same index-shape class as the single-key bug.

Also in this commit: every missing column is named in one error rather than one
per round-trip; unhashable and array-like group keys get a real message instead
of "truth value of an array is ambiguous"; close matches never suggest a
stringified int label; `group_keys` shape is validated even with no frame to
check against; key *inference* is held to the same standard as explicit keys on
empty frames that have columns; and the `sample_name` blank check makes one
hashing pass — 0.03s on a 2M-row column, faster than the `notna().any()` it
originally replaced.

The docs now also say that `apply_filter` auto-aggregates an unqualified
multi-method reference while `apply_sort` / `evaluate_scores` stay strict (a
deliberate asymmetry the "shared options" wording glossed over), and the
CHANGELOG lists the group-tuple width change under Breaking, since consumers
that materialize a group tuple are affected.

51 tests in `tests/test_group_keys.py`; suite at 1593 passed.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
