### PR TITLE
Read pirlygenes tissue columns under either naming form (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 5.17.1
+
+**Fixed: tissue expression lookups against current pirlygenes (#177):**
+
+`topiary.sources` built its per-tissue column names as `nTPM_<tissue>`,
+but pirlygenes now emits the suffix form (`<tissue>_nTPM`), matching the
+convention its own FPKM/TPM helpers accept. `available_tissues()`
+returned `[]` and `tissue_expressed_gene_ids(["heart_muscle"])` raised
+`ValueError: Unknown tissue column(s)`, taking
+`tissue_expressed_sequences` and the `--tissue` CLI paths with them.
+
+Tissue names are now read under either spelling, so topiary works
+across pirlygenes releases rather than pinning to one of them. Unknown
+tissue names are also reported as tissue names rather than as column
+names.
+
 ## 5.17.0
 
 **Explicit group keys everywhere (#175):**
@@ -91,6 +107,7 @@ still name `sample_name` explicitly.
   Consumers that materialize a group tuple and index a per-group Series
   with it must drop the leading `sample_name` element (or pass
   `group_keys=` explicitly to keep it).
+
 
 ## 5.16.2
 

--- a/tests/test_sources_optional.py
+++ b/tests/test_sources_optional.py
@@ -17,3 +17,53 @@ def test_check_pirlygenes_raises_clear_error(monkeypatch):
 
     with pytest.raises(ImportError, match="pirlygenes>=5.1.0"):
         sources._check_pirlygenes()
+
+
+# PirlyGenes has shipped per-tissue normalized-TPM columns under two
+# spellings; topiary must read tissue names from either without pinning to
+# whichever release happens to be installed.
+
+
+def _fake_expression(naming):
+    import pandas as pd
+
+    def column(tissue):
+        return f"nTPM_{tissue}" if naming == "prefix" else f"{tissue}_nTPM"
+
+    return pd.DataFrame({
+        "Ensembl_Gene_ID": ["ENSG1", "ENSG2"],
+        "Symbol": ["A", "B"],
+        column("lung"): [50.0, 0.1],
+        column("testis"): [0.2, 80.0],
+    })
+
+
+@pytest.mark.parametrize("naming", ["prefix", "suffix"])
+def test_available_tissues_reads_either_naming_form(naming):
+    tissues = sources._tissue_column_map(_fake_expression(naming))
+
+    assert sorted(tissues) == ["lung", "testis"]
+
+
+@pytest.mark.parametrize("naming", ["prefix", "suffix"])
+def test_tissue_columns_resolve_under_either_naming_form(naming):
+    pce = _fake_expression(naming)
+
+    cols = sources._tissue_columns(pce, ["testis"])
+
+    assert pce[cols].iloc[1, 0] == 80.0
+
+
+@pytest.mark.parametrize("naming", ["prefix", "suffix"])
+def test_unknown_tissue_names_the_tissue_not_the_column(naming):
+    pce = _fake_expression(naming)
+
+    with pytest.raises(ValueError, match=r"Unknown tissue\(s\): \['brain'\]"):
+        sources._tissue_columns(pce, ["brain"])
+
+
+def test_non_string_columns_are_ignored():
+    pce = _fake_expression("suffix")
+    pce[7] = 1
+
+    assert sorted(sources._tissue_column_map(pce)) == ["lung", "testis"]

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -75,7 +75,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.17.0"
+__version__ = "5.17.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/sources.py
+++ b/topiary/sources.py
@@ -216,8 +216,7 @@ def tissue_expressed_gene_ids(tissues, min_ntpm=1.0):
     from pirlygenes import pan_cancer_expression
     pce = pan_cancer_expression()
 
-    cols = [f"nTPM_{t}" for t in tissues]
-    _validate_tissue_cols(pce, cols)
+    cols = _tissue_columns(pce, tissues)
 
     mask = pce[cols].max(axis=1) >= min_ntpm
     return set(pce.loc[mask, "Ensembl_Gene_ID"])
@@ -245,8 +244,7 @@ def available_tissues():
     """List all available tissue names from PirlyGenes expression data."""
     _check_pirlygenes()
     from pirlygenes import pan_cancer_expression
-    pce = pan_cancer_expression()
-    return sorted(c.replace("nTPM_", "") for c in pce.columns if c.startswith("nTPM_"))
+    return sorted(_tissue_column_map(pan_cancer_expression()))
 
 
 # ---------------------------------------------------------------------------
@@ -288,15 +286,38 @@ def _sequences_for_genes(genome, identifiers, by="name"):
     return sequences
 
 
-def _validate_tissue_cols(pce, cols):
-    available = {c for c in pce.columns if c.startswith("nTPM_")}
-    bad = [c for c in cols if c not in available]
+# PirlyGenes has named its per-tissue normalized-TPM columns both ways:
+# the prefix form (nTPM_lung) through 5.1, and the suffix form
+# (lung_nTPM) in current releases, matching the suffix convention its
+# own FPKM/TPM helpers accept.  Read tissue names under either spelling
+# rather than pinning topiary to one of them.
+_NTPM_PREFIX = "nTPM_"
+_NTPM_SUFFIX = "_nTPM"
+
+
+def _tissue_column_map(pce):
+    """Map tissue name -> expression column, under either naming form."""
+    columns = {}
+    for col in pce.columns:
+        if not isinstance(col, str):
+            continue
+        if col.endswith(_NTPM_SUFFIX):
+            columns.setdefault(col[:-len(_NTPM_SUFFIX)], col)
+        elif col.startswith(_NTPM_PREFIX):
+            columns.setdefault(col[len(_NTPM_PREFIX):], col)
+    return columns
+
+
+def _tissue_columns(pce, tissues):
+    """Resolve tissue names to expression columns, or explain what's there."""
+    columns = _tissue_column_map(pce)
+    bad = [t for t in tissues if t not in columns]
     if bad:
-        tissues = sorted(c.replace("nTPM_", "") for c in available)
         raise ValueError(
-            "Unknown tissue column(s): %s. Available: %s"
-            % ([c.replace("nTPM_", "") for c in bad], tissues)
+            "Unknown tissue(s): %s. Available: %s"
+            % (bad, sorted(columns))
         )
+    return [columns[t] for t in tissues]
 
 
 _PIRLYGENES_MIN = (5, 1, 0)


### PR DESCRIPTION
Closes #177.

## Problem

`topiary/sources.py` builds per-tissue expression column names as
`nTPM_<tissue>`, but current pirlygenes emits the suffix form
(`<tissue>_nTPM`) — the same convention its own FPKM/TPM helpers accept via
`source_suffix` / `target_suffix`:

```python
>>> pirlygenes.__version__
'5.23.55'
>>> list(pirlygenes.pan_cancer_expression().columns)[:4]
['Ensembl_Gene_ID', 'Symbol', 'adipose_tissue_nTPM', 'adrenal_gland_nTPM']
>>> topiary.sources.available_tissues()
[]
```

So `available_tissues()` returned `[]` and
`tissue_expressed_gene_ids(["heart_muscle"])` raised
`ValueError: Unknown tissue column(s)`, taking `tissue_expressed_sequences`
and the `--tissue` CLI paths with them. Seven tests failed on master for
anyone with pirlygenes installed:

```
tests/test_sources.py::test_available_tissues
tests/test_sources.py::test_tissue_expressed_gene_ids
tests/test_sources.py::test_tissue_expressed_gene_ids_strict
tests/test_coverage_gaps.py::test_available_tissues_has_testis
tests/test_integration.py::test_tissue_restricted_predict
tests/test_integration.py::test_tissue_exclusion_reduces_predictions
tests/test_integration.py::test_first_principles_workflow
```

CI never caught this: pirlygenes isn't a CI dependency, so those tests
`importorskip` away. It does block `./deploy.sh`, which runs the suite locally.

## Fix

Resolve tissue names to columns under either spelling rather than pinning
topiary to one pirlygenes release. `_tissue_column_map` builds
`tissue -> column` from whichever form the frame uses, `available_tissues`
lists its keys, and `_tissue_columns` resolves a requested list — reporting
unknown *tissue names* rather than unknown column names, which is what the
caller passed in.

The `_check_pirlygenes` min-version gate is untouched: the accessor exists at
>=5.1.0, only its column naming moved, so gating harder would reject working
installs.

## Tests

Four new parametrized tests in `tests/test_sources_optional.py` run both
naming forms against a synthetic frame, so the behavior is pinned regardless
of which pirlygenes happens to be installed, plus one for non-string column
labels.

## Verification

- `./lint.sh` — passes
- `./test.sh` — **1607 passed, 3 skipped, 0 failed** (first fully green run;
  master currently fails the seven tests above with pirlygenes installed)

Version bumped to 5.17.1 so the release that carries #176 also carries this.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG