### PR TITLE
Resolve peptide_view's allele mode from the rows it reads (5.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 5.18.1
+
+**`peptide_view()` resolves the allele mode from the rows it reads (#181
+follow-up):**
+
+5.18.0 decided a kind's `mhc_dependence` from `kind_support` plus a scan
+of the whole frame, which let three things go wrong silently:
+
+- A `default_methods` entry naming a model absent from the frame — the
+  normal case for a pipeline-wide default that covers another kind —
+  filtered every model out of the metadata lookup, so the projection
+  fell back to guessing from the rows. A haplotype frame with two rows
+  for one peptide became a silent `max()` instead of an error.
+- One model's allele-stamped rows reclassified another model's
+  allele-free rows: adding an unrelated per-allele processing row made
+  an explicitly method-qualified `peptide_view(processing['netchop'].score)`
+  silently `max()` away a conflict it had correctly rejected before.
+- Models that contributed no rows still triggered "models disagree", and
+  the remedy the message suggested then failed with "no predictions from
+  method matching ...".
+
+The mode is now resolved from the already-selected rows — the ones the
+expression will actually read, after kind, method and version filtering
+— and `kind_support` is consulted only for models those rows came from.
+That also removes the duplicate per-kind scan each evaluation did.
+
+**The one-value-per-peptide check no longer depends on the grouping.**
+With `allele` absent from `group_keys`, `peptide_view` returned a plain
+field read, so the same node on the same data raised for one grouping
+and silently returned `.first()` for another.
+
+**`peptide_view(kind.best_X)` on a field with no defined best direction**
+(e.g. `processing.best_value`) silently read the plain `value` column
+instead. It now says what is wrong, as the equivalent mistake on a
+peptide-level kind already did. The related error message no longer
+claims `mhc_dependence='single_allele'` "means one row per peptide" when
+the real cause is the missing direction.
+
+**Unknown `mhc_dependence` values** are reported as version skew even
+when another model reports a known value; previously the conflict check
+ran first and offered a remedy that cannot resolve an uninterpretable
+value.
+
+**`kind_support` now reaches the DSL from the object API.**
+`TopiaryPredictor(filter_by=..., sort_by=...)` and
+`TopiaryResult.filter_by` / `.sort_by` forwarded no metadata, so every
+guard that depends on `mhc_dependence` — telling `haplotype` from
+`single_allele`, the inconsistent-value error, the version-skew error,
+the `single_allele` warning — was inert on exactly the path the docs
+advertise for `--filter-by` / `--sort-by`. `TopiaryPredictor.kind_support`
+now also skips models that don't report it (older mhctools predictors,
+test doubles) instead of raising `AttributeError`.
+
+The `single_allele` warning names the expression that was written —
+`peptide_view(affinity.value)` rather than a `best_score` the user never
+typed — and points at the caller's frame.
+
+**Breaking (unannounced in 5.18.0):** the scoped-field filter guard now
+covers `BestAlleleField`, so `wt.Affinity.best_value <= 500` raises
+`TypeError` in a filter like the bare `wt.Affinity.value` always did.
+Use scoped fields in sort or score expressions instead.
+
 ## 5.18.0
 
 **`peptide_view()` — per-`mhc_dependence` peptide-level projection (#169):**

--- a/tests/test_kind_support.py
+++ b/tests/test_kind_support.py
@@ -2,6 +2,7 @@
 and CachedPredictor (mhctools >=3.13.7 metadata API)."""
 
 import pandas as pd
+import pytest
 from mhctools import (
     Kind,
     MHC_CLASS_VALUES,
@@ -262,3 +263,105 @@ class TestCachedPredictorKindSupport:
             "mhc_dependence": "none",
             "mhc_class": "none",
         }
+
+
+class TestKindSupportReachesTheDSL:
+    """The metadata is only useful if it gets to the nodes that need it.
+
+    ``peptide_view`` and ``best_*`` dispatch on ``mhc_dependence``; the
+    object API (``TopiaryPredictor(filter_by=...)``, ``result.filter_by``)
+    is the path most callers take, so it has to forward what it holds.
+    """
+
+    def test_predictor_forwards_kind_support_to_filter_and_sort(self):
+        import topiary.predictor as predictor_module
+
+        captured = {}
+
+        def spy_filter(df, node, **kwargs):
+            captured["filter"] = kwargs.get("kind_support")
+            return df
+
+        def spy_sort(df, nodes, **kwargs):
+            captured["sort"] = kwargs.get("kind_support")
+            return df
+
+        predictor = TopiaryPredictor(
+            models=[RandomBindingPredictor(["HLA-A*02:01"])],
+            filter_by=_affinity_under_500(),
+            sort_by=[_affinity_under_500()],
+        )
+        df = pd.DataFrame([{
+            "source_sequence_name": "s", "peptide": "SIINFEKLA",
+            "peptide_offset": 0, "allele": "HLA-A*02:01",
+            "kind": "pMHC_affinity", "value": 100.0, "score": 0.5,
+            "percentile_rank": 1.0, "prediction_method_name": "random",
+        }])
+
+        original = (predictor_module.apply_filter, predictor_module.apply_sort)
+        predictor_module.apply_filter = spy_filter
+        predictor_module.apply_sort = spy_sort
+        try:
+            predictor._apply_filter(df)
+        finally:
+            (predictor_module.apply_filter,
+             predictor_module.apply_sort) = original
+
+        assert captured["filter"] == predictor.kind_support
+        assert captured["sort"] == predictor.kind_support
+        assert captured["filter"], "expected non-empty metadata"
+
+    def test_kind_support_skips_models_that_do_not_report_it(self):
+        class BareModel:
+            prediction_method_name = "bare"
+            predictor_version = "0"
+            default_peptide_lengths = [9]
+            alleles = []
+            supported_kinds = (Kind.pMHC_affinity,)
+
+        predictor = TopiaryPredictor(
+            models=[RandomBindingPredictor(["HLA-A*02:01"]), BareModel()],
+        )
+
+        support = predictor.kind_support
+
+        # The reporting model is present; the bare one is simply absent
+        # rather than raising AttributeError.
+        assert len(support) == 1
+
+    def test_result_forwards_kind_support_from_extra(self):
+        from topiary import TopiaryResult
+
+        support = {"netmhcpan": {"pMHC_presentation": {
+            "mhc_dependence": "single_allele", "mhc_class": "I",
+        }}}
+        df = pd.DataFrame([{
+            "source_sequence_name": "s", "peptide": "SIINFEKLA",
+            "peptide_offset": 0, "allele": allele,
+            "kind": "pMHC_presentation", "value": None, "score": score,
+            "percentile_rank": 1.0, "prediction_method_name": "netmhcpan",
+        } for allele, score in (("HLA-A*02:01", 0.9), ("HLA-B*07:02", 0.1))])
+        result = TopiaryResult(df, extra={"kind_support": support})
+
+        # best_* warns only when the metadata reaches the node.
+        with pytest.warns(UserWarning, match="not a joint multi-allele"):
+            result.filter_by("presentation.best_score >= 0.5")
+
+    def test_result_ignores_non_mapping_kind_support(self):
+        from topiary import TopiaryResult
+
+        df = pd.DataFrame([{
+            "source_sequence_name": "s", "peptide": "SIINFEKLA",
+            "peptide_offset": 0, "allele": "HLA-A*02:01",
+            "kind": "pMHC_affinity", "value": 100.0, "score": 0.5,
+            "percentile_rank": 1.0, "prediction_method_name": "netmhcpan",
+        }])
+        result = TopiaryResult(df, extra={"kind_support": "not a mapping"})
+
+        assert len(result.filter_by("affinity <= 500").df) == 1
+
+
+def _affinity_under_500():
+    from topiary import Affinity
+
+    return Affinity.value <= 500

--- a/tests/test_peptide_view.py
+++ b/tests/test_peptide_view.py
@@ -196,7 +196,7 @@ def test_kind_support_overrides_what_the_rows_look_like():
     support = _kind_support("mhcflurry", "pMHC_presentation", "haplotype")
 
     # Two haplotype rows for one peptide is a data error, not a max().
-    with pytest.raises(ValueError, match="expects one score per peptide"):
+    with pytest.raises(ValueError, match="means one row per peptide"):
         evaluate_scores(
             df, peptide_view(Presentation.score), kind_support=support,
         )
@@ -206,7 +206,17 @@ def test_kind_support_overrides_what_the_rows_look_like():
 
 
 def test_models_disagreeing_about_dependence_is_an_error():
-    df = pd.DataFrame(_affinity_rows())
+    """Both models are read here, so neither mode can be assumed.
+
+    One method per allele group, so nothing narrows the read to a single
+    model the way an ambiguity default would.
+    """
+    df = pd.DataFrame([
+        _row(allele=ALLELES[0], kind="pMHC_affinity", value=50.0,
+             prediction_method_name="netmhcpan"),
+        _row(allele=ALLELES[1], kind="pMHC_affinity", value=90.0,
+             prediction_method_name="mhcflurry"),
+    ])
     support = {
         "netmhcpan": {"pMHC_affinity": {"mhc_dependence": "single_allele"}},
         "mhcflurry": {"pMHC_affinity": {"mhc_dependence": "haplotype"}},
@@ -243,7 +253,7 @@ def test_conflicting_peptide_level_values_are_rejected():
         _processing_row(score=0.77), _processing_row(score=0.11),
     ])
 
-    with pytest.raises(ValueError, match="carry several different values"):
+    with pytest.raises(ValueError, match="carry several different score"):
         evaluate_scores(df, peptide_view(Processing.score))
 
 
@@ -324,11 +334,17 @@ def test_dependence_inference_ignores_other_kinds():
     df = _mixed_df()
 
     ctx = EvalContext(df)
-    from topiary.ranking.nodes import _resolve_mhc_dependence
+    from topiary.ranking.nodes import (
+        _filter_kind_method_version, _resolve_mhc_dependence,
+    )
     from mhctools import Kind
 
-    assert _resolve_mhc_dependence(ctx, Kind.pMHC_affinity) == "single_allele"
-    assert _resolve_mhc_dependence(ctx, Kind.antigen_processing) == "none"
+    for kind, expected in (
+        (Kind.pMHC_affinity, "single_allele"),
+        (Kind.antigen_processing, "none"),
+    ):
+        sub = _filter_kind_method_version(ctx, kind, None, None)
+        assert _resolve_mhc_dependence(ctx, kind, sub) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -626,5 +642,153 @@ def test_values_that_really_differ_are_still_rejected():
         _processing_row(score=0.30), _processing_row(score=0.31),
     ])
 
-    with pytest.raises(ValueError, match="carry several different values"):
+    with pytest.raises(ValueError, match="carry several different score"):
         evaluate_scores(df, peptide_view(Processing.score))
+
+
+# ---------------------------------------------------------------------------
+# The mode is resolved from the rows the expression actually reads
+# ---------------------------------------------------------------------------
+
+
+def test_default_methods_naming_an_absent_model_keeps_kind_support():
+    """A pipeline-wide default for another kind must not void the metadata."""
+    df = pd.DataFrame([
+        _row(allele=ALLELES[0], kind="pMHC_presentation", score=0.8,
+             prediction_method_name="mhcflurry"),
+        _row(allele=ALLELES[1], kind="pMHC_presentation", score=0.2,
+             prediction_method_name="mhcflurry"),
+    ])
+    support = _kind_support("mhcflurry", "pMHC_presentation", "haplotype")
+
+    # Two haplotype rows for one peptide is a data error either way — the
+    # default naming a model absent from this frame must not turn it into
+    # a silent max() across alleles.
+    with pytest.raises(ValueError, match="means one row per peptide"):
+        evaluate_scores(
+            df, peptide_view(Presentation.score), kind_support=support,
+            default_methods={"pMHC_presentation": "netmhcpan"},
+        )
+
+
+def test_another_models_alleles_do_not_reclassify_this_one():
+    """Row-based inference must look at the selected rows, not the kind."""
+    conflicting = [
+        _row(kind="antigen_processing", score=score,
+             prediction_method_name="netchop")
+        for score in (0.30, 0.31)
+    ]
+    unrelated = _row(kind="antigen_processing", score=0.5,
+                     allele=ALLELES[0], prediction_method_name="otherpred")
+
+    for rows in (conflicting, conflicting + [unrelated]):
+        with pytest.raises(ValueError, match="carry several different score"):
+            evaluate_scores(
+                pd.DataFrame(rows), peptide_view(Processing["netchop"].score),
+            )
+
+
+def test_a_model_with_no_rows_here_does_not_conflict():
+    """Metadata for a model that produced nothing must not veto the frame."""
+    df = pd.DataFrame([
+        _row(allele=ALLELES[0], kind="pMHC_presentation", score=0.9,
+             prediction_method_name="netmhcpan"),
+        _row(allele=ALLELES[1], kind="pMHC_presentation", score=0.4,
+             prediction_method_name="netmhcpan"),
+    ])
+    support = {
+        "netmhcpan": {"pMHC_presentation": {"mhc_dependence": "single_allele"}},
+        "mhcflurry": {"pMHC_presentation": {"mhc_dependence": "haplotype"}},
+    }
+
+    with pytest.warns(UserWarning, match="not a joint multi-allele aggregate"):
+        scores = evaluate_scores(
+            df, peptide_view(Presentation.score), kind_support=support,
+        )
+
+    assert scores.tolist() == [0.9, 0.9]
+
+
+def test_unknown_dependence_is_named_even_alongside_a_known_one():
+    """Version skew can't be resolved by picking the other model's mode."""
+    df = pd.DataFrame([
+        _row(kind="antigen_processing", score=0.5,
+             prediction_method_name="netchop"),
+        _row(allele=ALLELES[0], kind="antigen_processing", score=0.6,
+             prediction_method_name="otherpred"),
+    ])
+    support = {
+        "netchop": {"antigen_processing": {"mhc_dependence": "none"}},
+        "otherpred": {"antigen_processing": {"mhc_dependence": "supertype"}},
+    }
+
+    with pytest.raises(ValueError, match="unknown mhc_dependence 'supertype'"):
+        evaluate_scores(
+            df, peptide_view(Processing.score), kind_support=support,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The one-value-per-peptide check runs on every peptide-level path
+# ---------------------------------------------------------------------------
+
+
+def test_disagreeing_values_are_rejected_without_an_allele_group_key():
+    """Same data, same node: the grouping must not decide whether it raises."""
+    df = pd.DataFrame([
+        _row(kind="antigen_processing", value=value,
+             prediction_method_name="mhcflurry")
+        for value in (0.9, 0.1)
+    ])
+
+    with pytest.raises(ValueError, match="carry several different value"):
+        evaluate_scores(df, peptide_view(Processing.value))
+
+    with pytest.raises(ValueError, match="carry several different value"):
+        evaluate_scores(
+            df, peptide_view(Processing.value),
+            group_keys=["source_sequence_name", "peptide", "peptide_offset"],
+        )
+
+
+def test_best_field_without_a_direction_is_rejected_not_downgraded():
+    """peptide_view(processing.best_value) must not quietly read `value`."""
+    df = pd.DataFrame([
+        _row(allele=allele, kind="antigen_processing", value=0.77,
+             prediction_method_name="mhcflurry")
+        for allele in ALLELES
+    ])
+
+    with pytest.raises(ValueError, match="no defined best direction"):
+        evaluate_scores(df, peptide_view(Processing.best_value))
+
+
+def test_no_direction_error_explains_the_real_cause():
+    """Not 'mhc_dependence=single_allele means one row per peptide'."""
+    df = pd.DataFrame([
+        _row(allele=allele, kind="antigen_processing", value=value,
+             prediction_method_name="mhcflurry")
+        for allele, value in zip(ALLELES, (0.9, 0.1))
+    ])
+
+    with pytest.raises(ValueError, match="no defined best direction"):
+        evaluate_scores(df, peptide_view(Processing.value))
+
+
+# ---------------------------------------------------------------------------
+# The warning names what the user wrote
+# ---------------------------------------------------------------------------
+
+
+def test_single_allele_warning_names_the_wrapping_expression():
+    df = pd.DataFrame(_affinity_rows())
+    support = _kind_support("netmhcpan", "pMHC_affinity", "single_allele")
+
+    with pytest.warns(UserWarning, match=r"peptide_view\(affinity\.value\)"):
+        evaluate_scores(
+            df, peptide_view(Affinity.value), kind_support=support,
+        )
+
+    # A bare best_* still names itself.
+    with pytest.warns(UserWarning, match="best_value on"):
+        evaluate_scores(df, Affinity.best_value, kind_support=support)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -77,7 +77,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.18.0"
+__version__ = "5.18.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -574,11 +574,19 @@ class TopiaryPredictor(object):
         per-(model, kind), not per-kind alone — e.g. MHCflurry reports
         ``pMHC_presentation`` as ``single_allele`` or ``haplotype`` depending
         on its configured ``presentation_allele_mode``.
+
+        Models that don't report it — mhctools predictors older than
+        3.13.7, and hand-rolled ones — are omitted rather than raising,
+        so a mixed set still reports what is known. Consumers treat a
+        missing model as "no metadata" and fall back to reading the rows.
         """
-        return {
-            key: dict(model.kind_support())
-            for key, model in zip(self._model_keys, self.models)
-        }
+        support = {}
+        for key, model in zip(self._model_keys, self.models):
+            reported = getattr(model, "kind_support", None)
+            if not callable(reported):
+                continue
+            support[key] = dict(reported())
+        return support
 
     @property
     def supported_kinds(self):
@@ -788,10 +796,18 @@ class TopiaryPredictor(object):
         if df.empty:
             return df
         df = self._maybe_attach_self_nearest(df)
+        # Forward the allele-mode metadata this predictor already owns:
+        # without it, DSL nodes that dispatch on ``mhc_dependence``
+        # (``peptide_view``, ``best_*``) fall back to guessing from the
+        # rows on exactly the path ``filter_by`` / ``sort_by`` drive.
+        kind_support = self.kind_support
         if self.filter_by is not None:
-            df = apply_filter(df, self.filter_by)
+            df = apply_filter(df, self.filter_by, kind_support=kind_support)
         if self.sort_by:
-            df = apply_sort(df, self.sort_by, sort_direction=self.sort_direction)
+            df = apply_sort(
+                df, self.sort_by, sort_direction=self.sort_direction,
+                kind_support=kind_support,
+            )
         return df
 
     def _maybe_attach_self_nearest(self, df):

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -12,10 +12,10 @@ from .nodes import (
     BestAlleleField,
     EvalContext,
     Field,
-    PeptideView,
     _kind_matches,
     _missing_column_error,
     _normalize_group_keys,
+    _unwrap_peptide_view,
 )
 
 
@@ -103,8 +103,7 @@ def _infer_sort_direction(node):
     large is better, so ``peptide_view(Affinity.value)`` and
     ``Affinity.best_value`` sort ascending like the bare field.
     """
-    while isinstance(node, PeptideView):
-        node = node.inner
+    node = _unwrap_peptide_view(node)
     if isinstance(node, (Field, BestAlleleField)):
         if node.field == "percentile_rank":
             return "asc"

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1114,33 +1114,45 @@ class BestAlleleField(DSLNode):
             return pd.Series(np.nan, index=ctx.group_index, dtype=object)
         return ctx.empty_series(fill=np.nan)
 
-    def _maybe_warn_dependence(self, ctx):
+    def _maybe_warn_dependence(self, ctx, label=None, stacklevel=3):
         """Warn if any matching (model, kind) reports
         ``mhc_dependence='single_allele'``: the result is the best
-        per-allele score, not a true joint multi-allele aggregate."""
-        reported = _reported_dependences(ctx, self.kind, self.method)
+        per-allele score, not a true joint multi-allele aggregate.
+
+        *label* names the expression the user actually wrote — when this
+        aggregation was reached through ``peptide_view``, saying
+        ``best_score`` would name a node they never typed.
+        """
+        method = self.method.lower() if self.method else None
+        reported = _reported_dependences(
+            ctx, self.kind, {method} if method else None,
+        )
         for model_key, dep in reported.items():
             if dep == "single_allele":
                 import warnings
-                warnings.warn(
+                default_label = (
                     f"best_{_field_short(self.field)}"
-                    f"{'_allele' if self.return_allele else ''} on "
+                    f"{'_allele' if self.return_allele else ''}"
+                )
+                warnings.warn(
+                    f"{label or default_label} on "
                     f"({_kind_short_name(self.kind)}, model={model_key!r}) "
                     f"where mhc_dependence='single_allele': returns the "
                     f"best per-allele score, not a joint multi-allele "
                     f"aggregate. Use a haplotype-mode predictor (e.g. "
                     f"MHCflurry presentation in haplotype mode) for a "
                     f"true joint aggregate.",
-                    UserWarning, stacklevel=3,
+                    UserWarning, stacklevel=stacklevel,
                 )
                 return  # one warning per eval is enough
 
-    def eval(self, ctx: EvalContext) -> pd.Series:
+    def eval(self, ctx: EvalContext, warn_label=None,
+             stacklevel: int = 3) -> pd.Series:
         # Validate (kind, field) direction up front: an undefined
         # combination is a structural error and should fail loudly even
         # when the frame happens to lack matching rows.
         direction = _best_direction(self.kind, self.field)
-        self._maybe_warn_dependence(ctx)
+        self._maybe_warn_dependence(ctx, warn_label, stacklevel)
 
         sub = _filter_kind_method_version(
             ctx, self.kind, self.method, self.version,
@@ -1184,13 +1196,7 @@ class BestAlleleField(DSLNode):
         target = "allele" if self.return_allele else "__best_value"
         per_peptide = valid.loc[best_idx].set_index(peptide_keys)[target]
 
-        # Broadcast: ctx.group_index has [peptide_keys..., allele].
-        # Dropping the ``allele`` level yields an index aligned with
-        # ``per_peptide``; reindex maps each entry to its per-peptide
-        # value/allele, and we re-attach the full multi-index.
-        peptide_index = ctx.group_index.droplevel("allele")
-        aligned = per_peptide.reindex(peptide_index)
-        result = pd.Series(aligned.to_numpy(), index=ctx.group_index)
+        result = _broadcast_per_peptide(ctx, per_peptide, peptide_keys)
         if self.return_allele:
             return result.astype(object)
         return pd.to_numeric(result, errors="coerce")
@@ -1231,23 +1237,50 @@ class BestAlleleField(DSLNode):
 _MHC_DEPENDENCE_VALUES = frozenset({"none", "single_allele", "haplotype"})
 
 
-def _reported_dependences(ctx, kind, method=None):
+def _model_base_name(model_key):
+    """``mhcflurry__2`` -> ``mhcflurry``.
+
+    ``TopiaryPredictor`` disambiguates same-named models with a ``__N``
+    suffix, but rows only ever carry the shared
+    ``prediction_method_name``.
+    """
+    return str(model_key).split("__")[0]
+
+
+def _methods_present(sub):
+    """Lower-cased ``prediction_method_name`` values in *sub*.
+
+    ``None`` when the frame can't say — no rows, or no such column — in
+    which case every reported model stays in play.
+    """
+    if sub is None or sub.empty or "prediction_method_name" not in sub.columns:
+        return None
+    return {
+        str(m).lower() for m in sub["prediction_method_name"].dropna().unique()
+    }
+
+
+def _reported_dependences(ctx, kind, methods=None):
     """``{model_key: mhc_dependence}`` from ``ctx.kind_support`` for *kind*.
 
     The one place that walks mhctools' per-(model, kind) metadata.
-    *method* is a case-insensitive substring filter on the model key,
-    matching how the DSL selects a model everywhere else.
+    *methods* is the set of lower-cased method names to keep, normally
+    the ones the frame actually contains: metadata for a model that
+    produced no rows here must not decide — or veto — this frame's
+    projection.
     """
     kind_support = getattr(ctx, "kind_support", None)
     if not kind_support:
         return {}
     kind_val = _kind_value(kind)
-    method_filter = method.lower() if method else None
     reported = {}
     for model_key, kind_map in kind_support.items():
         if kind_val not in kind_map:
             continue
-        if method_filter and method_filter not in str(model_key).lower():
+        if (
+            methods is not None
+            and _model_base_name(model_key).lower() not in methods
+        ):
             continue
         dep = kind_map[kind_val].get("mhc_dependence")
         if dep:
@@ -1255,41 +1288,27 @@ def _reported_dependences(ctx, kind, method=None):
     return reported
 
 
-def _effective_method(ctx, kind, method=None):
-    """The method the DSL will actually read for *kind*.
+def _resolve_mhc_dependence(ctx, kind, sub):
+    """How *kind* relates to alleles for the rows in *sub*.
 
-    Mirrors :func:`_filter_kind_method_version`: an explicit method
-    wins, then the per-iteration binding a ``Comparison`` sets while
-    auto-aggregating, then ``default_methods``.
-    """
-    if method is not None:
-        return method
-    kind_val = _kind_value(kind)
-    override = getattr(ctx, "_method_override", None)
-    if override is not None and override[0] == kind_val:
-        return override[1]
-    return ctx.default_methods.get(kind_val)
+    *sub* is the already-selected slice — the rows this expression will
+    read, after kind, method and version filtering.  Resolving from it
+    rather than from the whole frame keeps one model's per-allele rows
+    from reclassifying another model's allele-free ones, and keeps
+    metadata for a model that contributed nothing here out of the
+    decision.
 
-
-def _resolve_mhc_dependence(ctx, kind, method=None):
-    """How *kind* relates to alleles for this frame.
-
-    Prefers ``ctx.kind_support`` — mhctools' per-(model, kind) metadata,
+    Prefers ``ctx.kind_support``, mhctools' per-(model, kind) metadata —
     the only authority that can tell ``haplotype`` from
     ``single_allele``, since both put a real allele on every row.
-    Without it, fall back to what the rows show: a kind whose rows carry
-    no allele at all is allele-independent; anything else is assumed
-    per-allele, which is both the common case and what the DSL already
-    did.
+    Without it, read what the rows show: no allele at all means
+    allele-independent, anything else is per-allele, which is what the
+    DSL already assumed.
     """
-    reported = _reported_dependences(
-        ctx, kind, _effective_method(ctx, kind, method),
-    )
-    found = set(reported.values())
-    if len(found) > 1:
-        raise _dependence_conflict_error(kind, reported)
-    if found:
-        dependence = found.pop()
+    reported = _reported_dependences(ctx, kind, _methods_present(sub))
+    # Validate before comparing: an unknown value can't be resolved by
+    # picking one of the others, so say what it actually is.
+    for dependence in set(reported.values()):
         if dependence not in _MHC_DEPENDENCE_VALUES:
             raise ValueError(
                 f"peptide_view on {_kind_short_name(kind)}: unknown "
@@ -1298,23 +1317,24 @@ def _resolve_mhc_dependence(ctx, kind, method=None):
                 f"than the mhctools that produced the metadata; upgrade "
                 f"topiary rather than guessing the projection."
             )
-        return dependence
+    found = set(reported.values())
+    if len(found) > 1:
+        raise _dependence_conflict_error(kind, reported)
+    if found:
+        return found.pop()
 
-    df = ctx.df
-    if "kind" not in df.columns or "allele" not in df.columns:
-        # No allele column at all: nothing in this frame is per-allele.
+    if sub is None or sub.empty or "allele" not in sub.columns:
+        # Nothing to read, or no allele column at all: nothing here is
+        # per-allele.
         return "none"
-    rows = df[df["kind"] == _kind_value(kind)]
-    if rows.empty:
-        return "single_allele"
-    return "single_allele" if _has_real_values(rows["allele"]) else "none"
+    return "single_allele" if _has_real_values(sub["allele"]) else "none"
 
 
 def _dependence_conflict_error(kind, reported):
     """Explain disagreeing models — and whether method can separate them."""
     kind_name = _kind_short_name(kind)
     modes = sorted(set(reported.values()))
-    base_names = {str(k).split("__")[0] for k in reported}
+    base_names = {_model_base_name(k) for k in reported}
     if len(base_names) == 1:
         # TopiaryPredictor disambiguates same-named models as name__1 /
         # name__2, but rows only carry the shared prediction_method_name,
@@ -1332,6 +1352,35 @@ def _dependence_conflict_error(kind, reported):
         f"({modes}). Qualify the kind with a method, e.g. "
         f"{kind_name}[{sorted(base_names)[0]!r}], so one projection applies."
     )
+
+
+def _broadcast_per_peptide(ctx, per_peptide, peptide_keys):
+    """Spread one value per peptide across that peptide's groups.
+
+    ``per_peptide`` is indexed by *peptide_keys*; the result is indexed
+    by ``ctx.group_index``.  Shared by every node that reduces to the
+    peptide level, so index shape and null-key handling have one
+    definition.
+    """
+    if "allele" in ctx.group_keys:
+        peptide_index = ctx.group_index.droplevel("allele")
+    else:
+        # Groups are already peptide-level: the "broadcast" is identity.
+        peptide_index = ctx.group_index
+    aligned = per_peptide.reindex(peptide_index)
+    result = pd.Series(aligned.to_numpy(), index=ctx.group_index)
+    return result
+
+
+def _unwrap_peptide_view(node):
+    """The field a projection wrapper reads.
+
+    ``peptide_view`` changes which row is read, not which column, so
+    guards and direction inference look through it.
+    """
+    if isinstance(node, PeptideView):
+        return node.inner
+    return node
 
 
 class PeptideView(DSLNode):
@@ -1389,42 +1438,8 @@ class PeptideView(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         inner = self.inner
-        dependence = _resolve_mhc_dependence(ctx, inner.kind, inner.method)
-
-        if dependence == "single_allele":
-            if not _has_best_direction(inner.kind, inner.field):
-                # No ordering is defined for this (kind, field), so there
-                # is no "best" to pick — the value has to be one per
-                # peptide already, and _eval_peptide_level says so loudly
-                # if it isn't.
-                return self._eval_peptide_level(ctx, dependence)
-            if isinstance(inner, BestAlleleField):
-                return inner.eval(ctx)
-            return BestAlleleField(
-                inner.kind, inner.field, method=inner.method,
-                version=inner.version, scope=inner.scope,
-            ).eval(ctx)
-
-        if isinstance(inner, BestAlleleField):
-            raise ValueError(
-                f"peptide_view(best_{_field_short(inner.field)}) on "
-                f"{_kind_short_name(inner.kind)} where "
-                f"mhc_dependence={dependence!r}: there is one row per "
-                f"peptide, so there is nothing to aggregate across "
-                f"alleles. Use peptide_view("
-                f"{_kind_short_name(inner.kind)}."
-                f"{_field_short(inner.field)}) instead."
-            )
-        return self._eval_peptide_level(ctx, dependence)
-
-    def _eval_peptide_level(self, ctx, dependence):
-        """Read the one row per peptide and broadcast it to its groups."""
-        inner = self.inner
         peptide_keys = [k for k in ctx.group_keys if k != "allele"]
-        if "allele" not in ctx.group_keys:
-            # Groups are already peptide-level; nothing to broadcast.
-            return inner.eval(ctx)
-        if not peptide_keys:
+        if "allele" in ctx.group_keys and not peptide_keys:
             # Grouping by allele alone has no peptide to project onto, so
             # the contract ("one value per peptide") can't be honored —
             # and a plain read would leave every allele group but the
@@ -1435,9 +1450,52 @@ class PeptideView(DSLNode):
                 f"identity columns, e.g. group_keys=['peptide', 'allele']."
             )
 
+        # Select once: the rows read here are also the rows the mode is
+        # resolved from, so metadata and data can't disagree about which
+        # model this expression is about.
         sub = _filter_kind_method_version(
             ctx, inner.kind, inner.method, inner.version,
         )
+        dependence = _resolve_mhc_dependence(ctx, inner.kind, sub)
+        aggregable = _has_best_direction(inner.kind, inner.field)
+
+        if dependence == "single_allele" and aggregable:
+            if isinstance(inner, BestAlleleField):
+                return inner.eval(ctx, warn_label=repr(self), stacklevel=5)
+            return BestAlleleField(
+                inner.kind, inner.field, method=inner.method,
+                version=inner.version, scope=inner.scope,
+            ).eval(ctx, warn_label=repr(self), stacklevel=5)
+
+        if isinstance(inner, BestAlleleField):
+            raise self._nothing_to_aggregate_error(dependence, aggregable)
+        return self._eval_peptide_level(ctx, sub, peptide_keys, dependence,
+                                        aggregable)
+
+    def _nothing_to_aggregate_error(self, dependence, aggregable):
+        """Explain a best_* field that cannot be aggregated here."""
+        inner = self.inner
+        kind_name = _kind_short_name(inner.kind)
+        best_label = f"best_{_field_short(inner.field)}"
+        plain = f"peptide_view({kind_name}.{_field_short(inner.field)})"
+        if not aggregable:
+            return ValueError(
+                f"peptide_view({best_label}) on {kind_name}: "
+                f"{_kind_short_name(inner.kind)}.{inner.field} has no "
+                f"defined best direction, so there is no best row to pick "
+                f"across alleles. Use {plain} to read the peptide's value."
+            )
+        return ValueError(
+            f"peptide_view({best_label}) on {kind_name} where "
+            f"mhc_dependence={dependence!r}: there is one row per "
+            f"peptide, so there is nothing to aggregate across alleles. "
+            f"Use {plain} instead."
+        )
+
+    def _eval_peptide_level(self, ctx, sub, peptide_keys, dependence,
+                            aggregable):
+        """Read the one row per peptide and broadcast it to its groups."""
+        inner = self.inner
         if sub is None:
             return ctx.empty_series()
         col_name = inner.scope + inner.field
@@ -1455,16 +1513,11 @@ class PeptideView(DSLNode):
         stats = valid.groupby(peptide_keys, sort=False, dropna=False)[
             "__peptide_value"
         ].agg(["first", "min", "max"])
-        self._check_one_value_per_peptide(stats, dependence)
-        per_peptide = stats["first"]
+        self._check_one_value_per_peptide(stats, dependence, aggregable)
+        return _broadcast_per_peptide(ctx, stats["first"], peptide_keys)
 
-        peptide_index = ctx.group_index.droplevel("allele")
-        aligned = per_peptide.reindex(peptide_index)
-        result = pd.Series(aligned.to_numpy(), index=ctx.group_index)
-        return pd.to_numeric(result, errors="coerce")
-
-    def _check_one_value_per_peptide(self, stats, dependence):
-        """A peptide-level kind must not disagree with itself.
+    def _check_one_value_per_peptide(self, stats, dependence, aggregable):
+        """A peptide-level read must not find the peptide disagreeing.
 
         Compared with a tolerance: one row round-tripped through a CSV
         and one computed in-process can differ in the last bit and still
@@ -1476,13 +1529,25 @@ class PeptideView(DSLNode):
         if conflicting.empty:
             return
         inner = self.inner
+        kind_name = _kind_short_name(inner.kind)
+        if not aggregable:
+            # We are reading per peptide because the field has no
+            # ordering, not because the kind is peptide-level — say that,
+            # rather than blaming a mode the rows may not be in.
+            reason = (
+                f"{kind_name}.{inner.field} has no defined best direction, "
+                f"so its value must already be one per peptide"
+            )
+        else:
+            reason = (
+                f"mhc_dependence={dependence!r} means one row per peptide"
+            )
         raise ValueError(
-            f"peptide_view on {_kind_short_name(inner.kind)} where "
-            f"mhc_dependence={dependence!r} expects one "
-            f"{inner.field} per peptide, but {len(conflicting)} "
-            f"peptide(s) carry several different values (first: "
-            f"{conflicting.index[0]!r}). Filter to one row per peptide "
-            f"first, or qualify the kind by method/version."
+            f"peptide_view on {kind_name}: {reason}, but "
+            f"{len(conflicting)} peptide(s) carry several different "
+            f"{inner.field} values (first: {conflicting.index[0]!r}). "
+            f"Filter to one row per peptide first, or qualify the kind by "
+            f"method/version."
         )
 
     def __repr__(self):
@@ -2077,8 +2142,7 @@ class Comparison(DSLNode):
             # Look through peptide_view(): it changes which row is read,
             # not which columns, so a scoped field stays off-limits in a
             # filter however it is wrapped.
-            while isinstance(side, PeptideView):
-                side = side.inner
+            side = _unwrap_peptide_view(side)
             if isinstance(side, (Field, BestAlleleField)) and side.scope:
                 scope_name = side.scope.rstrip("_")
                 raise TypeError(

--- a/topiary/result.py
+++ b/topiary/result.py
@@ -7,6 +7,7 @@ AST form (for programmatic use without re-parsing).
 
 import warnings
 from collections import OrderedDict
+from collections.abc import Mapping
 
 import pandas as pd
 
@@ -319,6 +320,17 @@ class TopiaryResult:
 
     # -- DSL operations ---------------------------------------------------
 
+    def _kind_support(self):
+        """Per-(model, kind) metadata for the DSL, when this result has it.
+
+        Readers (``read_pvacseq``, ``read_lens``) and predictor runs
+        stash it in ``extra``; nodes that dispatch on ``mhc_dependence``
+        need it to tell ``haplotype`` from ``single_allele``.  Anything
+        that isn't a mapping is ignored rather than passed on.
+        """
+        kind_support = self.extra.get("kind_support")
+        return kind_support if isinstance(kind_support, Mapping) else None
+
     def filter_by(self, expr):
         """Apply a filter expression. ANDs with any existing filter.
 
@@ -355,7 +367,9 @@ class TopiaryResult:
         if df.empty:
             filtered_df = df
         else:
-            filtered_df = apply_filter(df, new_ast)
+            filtered_df = apply_filter(
+                df, new_ast, kind_support=self._kind_support(),
+            )
 
         if self.filter_by_ast is not None:
             combined_ast = self.filter_by_ast & new_ast
@@ -420,7 +434,9 @@ class TopiaryResult:
         if df.empty:
             sorted_df = df
         else:
-            sorted_df = apply_sort(df, sort_nodes)
+            sorted_df = apply_sort(
+                df, sort_nodes, kind_support=self._kind_support(),
+            )
 
         kwargs = self._field_kwargs()
         kwargs["form"] = "long"


### PR DESCRIPTION
Follow-up to #181, from a review of the released 5.18.0.

## The main defect

`peptide_view` decided a kind's `mhc_dependence` from `kind_support` plus a scan
of the *whole frame*, rather than from the rows the expression actually reads.
Three silent failures followed, all verified before fixing:

**1. A `default_methods` entry naming a model absent from the frame voided the
metadata.** That's the normal case for a pipeline-wide default covering another
kind:

```python
# frame: two MHCflurry haplotype rows for one peptide (a data error)
evaluate_scores(df, peptide_view(Presentation.score), kind_support=sup)
# → ValueError: means one row per peptide            ✓

evaluate_scores(df, peptide_view(Presentation.score), kind_support=sup,
                default_methods={"pMHC_presentation": "netmhcpan"})
# → [0.8, 0.8]   silent max() across a conflict      ✗
```

**2. One model's allele-stamped rows reclassified another's allele-free rows.**
Adding an unrelated per-allele processing row made an explicitly
method-qualified expression stop rejecting a conflict:

```python
evaluate_scores(df, peptide_view(Processing["netchop"].score))
# netchop rows only        → ValueError: carry several different score values  ✓
# + one unrelated row      → [0.31, 0.31, 0.31]                                ✗
```

**3. Models with no rows in the frame still triggered "models disagree"** — and
following the remedy it printed (`presentation['mhcflurry']`) then failed with
"No pMHC_presentation predictions from method matching 'mhcflurry'".

The mode is now resolved from the already-selected rows, after kind/method/
version filtering, with `kind_support` consulted only for models those rows came
from. That also removes the duplicate per-kind scan every evaluation did.

## Also fixed

- **The one-value-per-peptide check was skipped** when `allele` wasn't a group
  key — the same node on the same data raised for one grouping and silently
  returned `.first()` for another, contradicting the 5.18.0 note that
  "inconsistent input raises rather than picking silently".
- **`peptide_view(processing.best_value)`** silently read the plain `value`
  column, discarding the `best_` the caller asked for. It now explains that the
  field has no defined best direction — and the related error stops blaming
  `mhc_dependence='single_allele'` for what is a missing direction. (The
  5.18.0 docstring rationale for that guard was also wrong: `best_direction`
  resolves `score` and `percentile_rank` kind-independently, so the guard only
  ever fires for `value` on kinds with no entry.)
- **Unknown `mhc_dependence`** is reported as version skew even when another
  model reports a known value; the conflict check ran first and suggested a
  remedy that cannot resolve an uninterpretable value.
- **`kind_support` never reached the DSL from the object API.**
  `TopiaryPredictor(filter_by=..., sort_by=...)` and `TopiaryResult.filter_by` /
  `.sort_by` forwarded none, so every `mhc_dependence` guard was inert on
  exactly the `--filter-by` / `--sort-by` path the docs advertise. Both now
  forward it, and `TopiaryPredictor.kind_support` skips models that don't
  report it (older mhctools predictors, test doubles) instead of raising
  `AttributeError`. This closes the concrete half of #178.
- **The `single_allele` warning** named a `best_score` node the user never
  wrote and pointed `stacklevel` inside topiary; it now names the wrapping
  expression and the caller's frame.
- Shared the reduce-and-broadcast tail with `BestAlleleField` and the
  `peptide_view` unwrap with `apply.py`, instead of two copies of each.

## Breaking, and unannounced in 5.18.0

The scoped-field filter guard was widened from `Field` to `BestAlleleField` in
#181, so `wt.Affinity.best_value <= 500` now raises `TypeError` in a filter as
the bare `wt.Affinity.value` always did. That was attributed only to
`peptide_view` in the 5.18.0 notes; it's called out properly in this
CHANGELOG.

## Tests

53 in `tests/test_peptide_view.py` (+8), plus a `TestKindSupportReachesTheDSL`
class in `tests/test_kind_support.py` pinning the object-API wiring and the
`AttributeError` fix.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1664 passed, 3 skipped

Version 5.18.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG