### PR TITLE
Let allele-free predictions reach a genotype and survive a filter (#182, #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 5.19.0
+
+**Allele-free predictions reach a genotype (#182), and survive a filter
+(#183):**
+
+An antigen-processing prediction carries no allele, so it lands in a
+group of its own rather than in any of the peptide's per-allele groups.
+`peptide_view()` (5.18.0) broadcasts its value, but two things still
+stopped it from replacing the row duplication producers do by hand.
+
+**A filter on an allele-scoped kind no longer drops it.** That group
+holds no rows of the kind being filtered on, so the predicate evaluated
+to NaN — which pandas turns into False, which dropped the row and took
+the evidence out of the frame before the score expression could read it:
+
+```python
+apply_filter(df, parse("affinity.value <= 500"), group_keys=keys)
+# 5.18.0: the processing row is gone, and a later
+#         peptide_view(processing.score) reads NaN
+```
+
+An allele-free group holding none of the kinds a filter reads is now
+kept whenever the filter kept at least one of that peptide's allele
+groups. A filter that *does* read that kind still decides it, and a
+peptide excluded entirely takes its evidence with it.
+
+**`alleles=` declares the alleles to evaluate against.** Groups come
+from the rows, so a peptide whose only evidence is allele-free has no
+per-allele group for a consumer keyed by patient allele to read — and
+the genotype is not something the frame contains:
+
+```python
+evaluate_scores(df, peptide_view(Processing.score),
+                group_keys=keys, alleles=["HLA-A*02:01", "HLA-B*07:02"])
+```
+
+`alleles` is the fourth shared context option, accepted by
+`apply_filter`, `apply_sort`, `evaluate_scores` and `EvalContext`. It
+adds one group per peptide per declared allele; those groups hold no
+rows, so allele-scoped fields read NaN there — that allele has no
+prediction of its own. The frame is untouched: only the group index
+grows, so row counts out of every entry point are unchanged.
+
+Together these let a producer keep one canonical allele-free row instead
+of duplicating it across a patient's alleles.
+
 ## 5.18.1
 
 **`peptide_view()` resolves the allele mode from the rows it reads (#181

--- a/docs/api.md
+++ b/docs/api.md
@@ -270,7 +270,7 @@ Apply with `apply_filter(df, node)` and `apply_sort(df, [nodes])`.
 
 ### Context options
 
-`apply_filter`, `apply_sort` and `evaluate_scores` share three keyword-only
+`apply_filter`, `apply_sort` and `evaluate_scores` share four keyword-only
 options, all forwarded to `EvalContext`:
 
 | Option | Meaning |
@@ -278,6 +278,7 @@ options, all forwarded to `EvalContext`:
 | `group_keys` | Explicit group identity columns; default infers them from the DataFrame |
 | `default_methods` | Per-kind default `prediction_method_name` for unqualified references |
 | `kind_support` | Per-(model, kind) metadata from `TopiaryPredictor.kind_support` |
+| `alleles` | Alleles every peptide is evaluated against, so allele-free evidence reaches a genotype |
 
 See [Group identity](ranking.md#group-identity) for when to pass `group_keys`.
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -48,7 +48,7 @@ kept = apply_sort(kept, [Affinity.score], group_keys=group_keys)
 scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
 ```
 
-`apply_filter`, `apply_sort` and `evaluate_scores` accept the same three keyword-only context options — `group_keys`, `default_methods` and `kind_support` — so filtering, sorting and scoring can share one grouping and one method resolution.
+`apply_filter`, `apply_sort` and `evaluate_scores` accept the same keyword-only context options — `group_keys`, `default_methods`, `kind_support` and `alleles` — so filtering, sorting and scoring can share one grouping and one method resolution.
 
 One thing is deliberately *not* shared: on a frame where several methods produce the same kind, `apply_filter` auto-aggregates an unqualified reference across them (`nanmin` for `<`/`<=`, `nanmax` for `>`/`>=`), while `apply_sort` and `evaluate_scores` stay strict and raise on the ambiguity. Pass `default_methods={"affinity": "mhcflurry"}` (or qualify the reference, `Affinity["mhcflurry"]`) to get one answer from all three.
 
@@ -120,7 +120,21 @@ That is why producers duplicated the processing row across the patient's alleles
 apply_filter(df, parse("affinity <= 500 & peptide_view(processing.score) >= 0.5"))
 ```
 
-Note that the allele-free row is still its own group, so a per-allele filter clause drops that row from the *output* frame — the projection is about reading its value, not about relocating it.
+The allele-free row is still its own group. A filter on an allele-scoped kind has nothing to say about that group, so rather than dropping it — which would take the evidence out of the frame before the score expression reads it — topiary keeps it whenever the filter kept at least one of that peptide's allele groups. A filter that *does* read the allele-free kind (`peptide_view(processing.score) >= 0.9`) still decides it, and a peptide excluded entirely takes its evidence with it.
+
+### Declaring the alleles to evaluate against
+
+Groups come from the rows, so a peptide whose *only* evidence is allele-free has no per-allele group at all — and a consumer keyed by patient allele has nothing to read. The genotype isn't in the frame, so pass it:
+
+```python
+scores = evaluate_scores(
+    df, peptide_view(Processing.score),
+    group_keys=group_keys,
+    alleles=["HLA-A*02:01", "HLA-B*07:02"],
+)
+```
+
+`alleles` adds one group per peptide per declared allele, giving `peptide_view` somewhere to broadcast into. The added groups hold no rows, so allele-scoped fields read `NaN` there — which is the truth: that allele has no prediction of its own. The frame itself is untouched; only the group index grows.
 
 The mode comes from `EvalContext(kind_support=...)` — mhctools' per-(model, kind) metadata, available as `TopiaryPredictor.kind_support` — which is the only thing that can tell `haplotype` from `single_allele`, since both put a real allele on every row. Without it, a kind whose rows carry no allele is treated as allele-free and everything else as per-allele. Inconsistent data is an error, not a silent pick: a peptide-level kind with two different values for one peptide, or models that disagree about `mhc_dependence`, both raise.
 

--- a/tests/test_allele_free_kinds.py
+++ b/tests/test_allele_free_kinds.py
@@ -1,0 +1,279 @@
+"""Allele-free predictions in an allele-keyed frame (topiary #182, #183).
+
+An antigen-processing prediction carries no allele, so it lands in a group
+of its own rather than in any of the peptide's per-allele groups. Two
+consequences the DSL has to handle explicitly:
+
+* a filter on an allele-scoped kind has nothing to say about that group,
+  and dropping it silently removes evidence a later ``peptide_view()``
+  would read (#183);
+* a peptide whose *only* evidence is allele-free has no per-allele group
+  at all, so a consumer keyed by patient allele can't read it (#182).
+"""
+
+import pandas as pd
+import pytest
+
+from topiary.ranking import (
+    EvalContext,
+    apply_filter,
+    apply_sort,
+    evaluate_scores,
+    parse,
+)
+
+GROUP_KEYS = ["prediction_id", "peptide", "peptide_offset", "allele"]
+PATIENT_ALLELES = ["HLA-A*02:01", "HLA-B*07:02"]
+
+PROCESSING = parse("peptide_view(processing[mhcflurry].score)")
+
+
+def _row(allele, kind, value=None, score=0.0, peptide="SIINFEKL",
+         prediction_id="p1"):
+    return {
+        "prediction_id": prediction_id, "source_sequence_name": "ctx",
+        "peptide": peptide, "peptide_offset": 2, "peptide_length": 8,
+        "allele": allele, "n_flank": "", "c_flank": "",
+        "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
+        "kind": kind, "value": value, "affinity": value,
+        "percentile_rank": None, "score": score,
+    }
+
+
+def _affinity_and_processing(processing_score=0.77):
+    return pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0),
+        _row("HLA-B*07:02", "pMHC_affinity", 60.0),
+        _row("", "antigen_processing", None, processing_score),
+    ])
+
+
+def _scores(df, node=PROCESSING, **kwargs):
+    ctx = EvalContext(df, group_keys=GROUP_KEYS, **kwargs)
+    return node.eval(ctx).reindex(ctx.group_index).tolist()
+
+
+# ---------------------------------------------------------------------------
+# #183 — a filter on an allele-scoped kind must not drop allele-free evidence
+# ---------------------------------------------------------------------------
+
+
+def test_allele_scoped_filter_keeps_allele_free_evidence():
+    df = _affinity_and_processing()
+
+    kept = apply_filter(
+        df, parse("affinity.value <= 500"), group_keys=GROUP_KEYS,
+    )
+
+    assert sorted(kept["kind"].unique()) == [
+        "antigen_processing", "pMHC_affinity",
+    ]
+    # The whole point: the value is still there to broadcast afterwards.
+    assert _scores(kept) == [0.77, 0.77, 0.77]
+
+
+def test_filter_that_reads_the_allele_free_kind_still_decides_it():
+    """Riding along is for predicates that say nothing, not for exemption."""
+    df = _affinity_and_processing(processing_score=0.4)
+
+    rejected = apply_filter(
+        df, parse("peptide_view(processing[mhcflurry].score) >= 0.9"),
+        group_keys=GROUP_KEYS,
+    )
+    accepted = apply_filter(
+        df, parse("peptide_view(processing[mhcflurry].score) >= 0.3"),
+        group_keys=GROUP_KEYS,
+    )
+
+    assert len(rejected) == 0
+    assert "antigen_processing" in set(accepted["kind"])
+
+
+def test_excluded_peptide_takes_its_allele_free_evidence_with_it():
+    df = _affinity_and_processing()
+
+    kept = apply_filter(
+        df, parse("affinity.value <= 10"), group_keys=GROUP_KEYS,
+    )
+
+    assert len(kept) == 0
+
+
+def test_evidence_rides_along_only_with_its_own_peptide():
+    df = pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0, peptide="AAA",
+             prediction_id="p1"),
+        _row("", "antigen_processing", None, 0.9, peptide="AAA",
+             prediction_id="p1"),
+        _row("HLA-A*02:01", "pMHC_affinity", 9000.0, peptide="BBB",
+             prediction_id="p2"),
+        _row("", "antigen_processing", None, 0.2, peptide="BBB",
+             prediction_id="p2"),
+    ])
+
+    kept = apply_filter(
+        df, parse("affinity.value <= 500"), group_keys=GROUP_KEYS,
+    )
+
+    assert set(kept["peptide"]) == {"AAA"}
+    assert sorted(kept["kind"].unique()) == [
+        "antigen_processing", "pMHC_affinity",
+    ]
+
+
+def test_filter_then_score_matches_scoring_the_unfiltered_frame():
+    """The pipeline shape that made this silent: filter, then score."""
+    df = _affinity_and_processing()
+
+    before = _scores(df)
+    after = _scores(
+        apply_filter(df, parse("affinity.value <= 500"), group_keys=GROUP_KEYS)
+    )
+
+    assert before == after == [0.77, 0.77, 0.77]
+
+
+def test_allele_free_rows_are_not_kept_when_the_filter_is_boolean_false():
+    """A False answer about the peptide is still a False answer."""
+    df = _affinity_and_processing()
+
+    kept = apply_filter(
+        df, parse("affinity.value <= 500 & affinity.value >= 1000"),
+        group_keys=GROUP_KEYS,
+    )
+
+    assert len(kept) == 0
+
+
+# ---------------------------------------------------------------------------
+# #182 — declaring the alleles a peptide should be evaluated against
+# ---------------------------------------------------------------------------
+
+
+def test_processing_only_peptide_reaches_the_patient_alleles():
+    """No allele-scoped rows at all: the genotype has to come from outside."""
+    df = pd.DataFrame([_row("", "antigen_processing", None, 0.77)])
+
+    without = _scores(df)
+    with_genotype = EvalContext(
+        df, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+    )
+    scores = PROCESSING.eval(with_genotype).reindex(with_genotype.group_index)
+
+    # Without the genotype there is one group, and it names no allele.
+    assert without == [0.77]
+    per_allele = {
+        key[-1]: value for key, value in scores.items() if key[-1]
+    }
+    assert per_allele == {
+        "HLA-A*02:01": 0.77, "HLA-B*07:02": 0.77,
+    }
+
+
+def test_declared_alleles_union_with_observed_ones():
+    df = pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0),
+        _row("", "antigen_processing", None, 0.9),
+    ])
+
+    ctx = EvalContext(df, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES)
+
+    assert [key[-1] for key in ctx.group_index] == [
+        "HLA-A*02:01", "", "HLA-B*07:02",
+    ]
+
+
+def test_declared_groups_have_no_rows_so_allele_scoped_fields_are_nan():
+    """An allele with no prediction of its own reads NaN, which is true."""
+    df = pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0),
+        _row("", "antigen_processing", None, 0.9),
+    ])
+
+    ctx = EvalContext(df, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES)
+    affinity = parse("affinity.value").eval(ctx).reindex(ctx.group_index)
+
+    assert affinity.tolist()[0] == 50.0
+    assert pd.isna(affinity.tolist()[2])
+    assert PROCESSING.eval(ctx).reindex(ctx.group_index).tolist() == [
+        0.9, 0.9, 0.9,
+    ]
+
+
+def test_declared_alleles_do_not_invent_rows():
+    """Group keys grow; the frame does not."""
+    df = pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0),
+        _row("", "antigen_processing", None, 0.9),
+    ])
+
+    scores = evaluate_scores(
+        df, PROCESSING, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+    )
+    kept = apply_filter(
+        df, parse("affinity.value <= 500"), group_keys=GROUP_KEYS,
+        alleles=PATIENT_ALLELES,
+    )
+    ordered = apply_sort(
+        df, [PROCESSING], group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+    )
+
+    assert len(scores) == len(df)
+    assert len(kept) == len(df)
+    assert len(ordered) == len(df)
+
+
+def test_alleles_forwarded_by_every_entry_point():
+    df = pd.DataFrame([_row("", "antigen_processing", None, 0.77)])
+
+    for call in (
+        lambda: apply_filter(
+            df, parse("peptide_view(processing[mhcflurry].score) >= 0.5"),
+            group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+        ),
+        lambda: apply_sort(
+            df, [PROCESSING], group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+        ),
+        lambda: evaluate_scores(
+            df, PROCESSING, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES,
+        ),
+    ):
+        assert len(call()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Rejected declarations
+# ---------------------------------------------------------------------------
+
+
+def test_bare_string_allele_set_is_rejected():
+    df = _affinity_and_processing()
+
+    with pytest.raises(ValueError, match="not the string 'HLA-A"):
+        EvalContext(df, group_keys=GROUP_KEYS, alleles="HLA-A*02:01")
+
+
+def test_empty_allele_set_is_rejected():
+    df = _affinity_and_processing()
+
+    with pytest.raises(ValueError, match="non-empty sequence"):
+        EvalContext(df, group_keys=GROUP_KEYS, alleles=[])
+
+
+def test_blank_allele_entry_is_rejected():
+    """Allele-free is a property of a row, not an allele you can declare."""
+    df = _affinity_and_processing()
+
+    with pytest.raises(ValueError, match="must all name an allele"):
+        EvalContext(df, group_keys=GROUP_KEYS, alleles=["HLA-A*02:01", ""])
+
+
+def test_alleles_are_ignored_without_an_allele_group_key():
+    df = _affinity_and_processing()
+
+    ctx = EvalContext(
+        df, group_keys=["prediction_id", "peptide", "peptide_offset"],
+        alleles=PATIENT_ALLELES,
+    )
+
+    assert len(ctx.group_index) == 1

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -77,7 +77,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.18.1"
+__version__ = "5.19.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -12,6 +12,7 @@ from .nodes import (
     BestAlleleField,
     EvalContext,
     Field,
+    _kind_value,
     _kind_matches,
     _missing_column_error,
     _normalize_group_keys,
@@ -95,6 +96,75 @@ def _validate_columns(df, node):
     raise _missing_column_error(missing, df.columns)
 
 
+def _allele_free_groups(ctx):
+    """Boolean array: which groups carry no allele at all.
+
+    An allele-free prediction — antigen processing, say — has nothing in
+    its ``allele`` column, so it lands in a group of its own rather than
+    in any of the peptide's per-allele groups.
+    """
+    alleles = pd.Series(ctx.group_index.get_level_values("allele"))
+    return (alleles.isna() | (alleles.astype(str).str.strip() == "")).to_numpy()
+
+
+def _collect_kinds(node):
+    """Every prediction kind a DSL tree reads."""
+    kinds = set()
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n is None:
+            continue
+        kind = getattr(n, "kind", None)
+        if kind is not None:
+            kinds.add(_kind_value(kind))
+        stack.extend(n.child_nodes())
+    return kinds
+
+
+def _keep_allele_free_evidence(ctx, node, mask):
+    """Let allele-free evidence ride along with its peptide.
+
+    An allele-free prediction lands in a group of its own, and a filter
+    on an allele-scoped kind has nothing to say about it — that group
+    holds no rows of the kind being filtered on, so it evaluates to NaN,
+    which pandas turns into False, which drops the row.  The evidence a
+    later ``peptide_view()`` would have read is then simply gone, and
+    the peptide scores as if the prediction had never been made.
+
+    So an allele-free group holding none of the kinds the filter reads
+    is kept whenever the filter kept at least one of that peptide's
+    allele groups: it is peptide-level evidence and the peptide
+    survived.  A group the filter *does* read — ``processing.score >=
+    0.9`` against the processing row itself — keeps its own answer, and
+    a peptide excluded entirely takes its evidence with it.
+    """
+    peptide_keys = [k for k in ctx.group_keys if k != "allele"]
+    if "allele" not in ctx.group_keys or not peptide_keys:
+        return mask
+    if "kind" not in ctx.df.columns:
+        return mask
+    node_kinds = _collect_kinds(node)
+    if not node_kinds:
+        return mask
+
+    # Groups holding at least one row of a kind this filter reads.
+    read = np.zeros(len(ctx.group_index), dtype=bool)
+    codes = ctx.row_group_codes()
+    read[codes[ctx.df["kind"].isin(node_kinds).to_numpy()]] = True
+
+    candidates = _allele_free_groups(ctx) & ~read & ~mask
+    if not candidates.any():
+        return mask
+
+    groups = ctx.group_index.to_frame(index=False)
+    groups["_kept"] = mask
+    peptide_kept = groups.groupby(
+        peptide_keys, sort=False, dropna=False,
+    )["_kept"].transform("any").to_numpy()
+    return mask | (candidates & peptide_kept)
+
+
 def _infer_sort_direction(node):
     """Natural sort direction for a node (asc = smaller is better).
 
@@ -119,7 +189,7 @@ def _resolve_sort_direction(node, sort_direction):
 
 
 def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
-                    kind_support=None, fill=np.nan):
+                    kind_support=None, alleles=None, fill=np.nan):
     """Evaluate a DSL *node* against *df* and align the result to ``df.index``.
 
     ``DSLNode.eval`` returns a Series indexed by the peptide-allele
@@ -137,9 +207,9 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
     callers pick semantics — ``.fillna(0.0)`` for additive scoring,
     ``.fillna(-inf)`` for ranking.
 
-    *group_keys*, *default_methods* and *kind_support* are the shared
-    context options, forwarded to :class:`EvalContext` — see its
-    docstring.
+    *group_keys*, *default_methods*, *kind_support* and *alleles* are
+    the shared context options, forwarded to :class:`EvalContext` — see
+    its docstring.
 
     Returns a ``pd.Series`` with ``df.index`` and a numeric dtype.
     """
@@ -153,7 +223,7 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
 
     ctx = EvalContext(
         df, group_keys=group_keys, default_methods=default_methods,
-        kind_support=kind_support,
+        kind_support=kind_support, alleles=alleles,
     )
     scored = node.eval(ctx).reindex(ctx.group_index)
     aligned = pd.Series(
@@ -167,15 +237,15 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
 
 
 def apply_filter(df, node, *, group_keys=None, default_methods=None,
-                 kind_support=None):
+                 kind_support=None, alleles=None):
     """Apply a boolean-valued DSL node to *df*.
 
     Keeps all rows for peptide-allele groups whose evaluated value is
     truthy.  ``None`` for *node* is a no-op.
 
-    *group_keys*, *default_methods* and *kind_support* are the shared
-    context options, forwarded to :class:`EvalContext` — see its
-    docstring.
+    *group_keys*, *default_methods*, *kind_support* and *alleles* are
+    the shared context options, forwarded to :class:`EvalContext` — see
+    its docstring.
     """
     if node is None or df.empty:
         _check_group_keys(df, group_keys)
@@ -185,6 +255,7 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     ctx = EvalContext(
         df, group_keys=group_keys, filter_context=True,
         default_methods=default_methods, kind_support=kind_support,
+        alleles=alleles,
     )
     # Reindex defensively so a misbehaving node (index mismatch) surfaces
     # as NaN → False rather than silently picking up rows from a
@@ -192,13 +263,14 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     values = node.eval(ctx).reindex(ctx.group_index)
     _check_boolean_like(values)
     mask = values.fillna(False).astype(bool).to_numpy()
+    mask = _keep_allele_free_evidence(ctx, node, mask)
 
     keep = mask[ctx.row_group_codes()]
     return df[keep].reset_index(drop=True)
 
 
 def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
-               default_methods=None, kind_support=None):
+               default_methods=None, kind_support=None, alleles=None):
     """Sort groups by one or more DSL nodes (lexicographic fallthrough).
 
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
@@ -207,9 +279,9 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     value is used for all nodes.  NaN values do not force an ordering —
     they fall through to the next tiebreaker.
 
-    *group_keys*, *default_methods* and *kind_support* are the shared
-    context options, forwarded to :class:`EvalContext` — see its
-    docstring.
+    *group_keys*, *default_methods*, *kind_support* and *alleles* are
+    the shared context options, forwarded to :class:`EvalContext` — see
+    its docstring.
     """
     if not sort_nodes or df.empty:
         _check_group_keys(df, group_keys)
@@ -220,7 +292,7 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
 
     ctx = EvalContext(df, group_keys=group_keys,
                       default_methods=default_methods,
-                      kind_support=kind_support)
+                      kind_support=kind_support, alleles=alleles)
     n_groups = len(ctx.group_index)
     n_keys = len(sort_nodes)
     values_matrix = np.empty((n_groups, n_keys), dtype=float)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -264,6 +264,31 @@ def _normalize_group_keys(df, group_keys):
     return keys
 
 
+def _normalize_alleles(alleles):
+    """Validate a declared allele set and return it as a list (or None)."""
+    if alleles is None:
+        return None
+    if isinstance(alleles, str):
+        raise ValueError(
+            f"alleles must be a sequence of allele names, not the string "
+            f"{alleles!r}; pass [{alleles!r}] for a single allele."
+        )
+    declared = list(alleles)
+    if not declared:
+        raise ValueError(
+            "alleles must be a non-empty sequence of allele names; pass "
+            "alleles=None to use only the alleles present in the DataFrame."
+        )
+    blank = [a for a in declared if pd.isna(a) or str(a).strip() == ""]
+    if blank:
+        raise ValueError(
+            "alleles must all name an allele; got a blank entry. An "
+            "allele-free prediction is expressed by leaving the row's "
+            "allele empty, not by declaring a blank allele."
+        )
+    return declared
+
+
 def _normalize_default_methods(mapping):
     """Canonicalize ``default_methods`` keys to DataFrame ``kind`` values.
 
@@ -311,6 +336,14 @@ class EvalContext:
     ----------
     df : pandas.DataFrame
         Prediction rows, long-form.
+    alleles : list of str, optional
+        Alleles to evaluate every peptide against — a patient's
+        genotype, typically.  Group keys otherwise come only from the
+        rows, so a peptide whose evidence is allele-free has no
+        per-allele group to read; declaring the set adds one group per
+        peptide per allele for :func:`peptide_view` to broadcast into.
+        Added groups carry no rows, so allele-scoped fields read NaN
+        there.
     group_keys : list of str, optional
         Override the auto-detected peptide-allele group keys.  Use this
         when the frame carries a stable provenance identity (e.g. a
@@ -351,14 +384,14 @@ class EvalContext:
 
     __slots__ = (
         "df", "group_keys", "default_methods", "filter_context",
-        "kind_support",
+        "kind_support", "alleles",
         "_group_index", "_key_frame", "_group_tuples_cache",
         "_group_codes_cache", "_method_override",
     )
 
     def __init__(
         self, df, group_keys=None, default_methods=None, filter_context=False,
-        kind_support=None,
+        kind_support=None, alleles=None,
     ):
         self.df = df
         if group_keys is None:
@@ -375,6 +408,7 @@ class EvalContext:
         # :class:`BestAlleleField`) can warn or branch on it. Shape:
         # ``{model_key: {kind_value: {"mhc_dependence", "mhc_class"}}}``.
         self.kind_support = kind_support
+        self.alleles = _normalize_alleles(alleles)
         self._group_index = None
         self._key_frame = None
         self._group_tuples_cache = None
@@ -431,13 +465,41 @@ class EvalContext:
                         names=self.group_keys,
                     )
             else:
-                key_df = self.key_frame.drop_duplicates()
+                key_df = self._declared_key_frame()
                 if single_key:
                     key = self.group_keys[0]
                     self._group_index = pd.Index(key_df[key], name=key)
                 else:
                     self._group_index = pd.MultiIndex.from_frame(key_df)
         return self._group_index
+
+    def _declared_key_frame(self):
+        """Unique group keys, extended by any declared allele set.
+
+        Rows only ever produce the groups they name, so a peptide whose
+        evidence is allele-free — an antigen-processing prediction, with
+        nothing in its ``allele`` column — has no per-allele group for a
+        consumer to read.  Declaring ``alleles`` (a patient's genotype,
+        say) adds a group per peptide per allele, so
+        :class:`PeptideView` has somewhere to broadcast the peptide's
+        value to.  The added groups hold no rows: allele-scoped fields
+        read NaN for them, which is the truth — that allele has no
+        prediction of its own.
+        """
+        key_df = self.key_frame.drop_duplicates()
+        peptide_keys = [k for k in self.group_keys if k != "allele"]
+        if not self.alleles or "allele" not in self.group_keys:
+            return key_df
+        if not peptide_keys:
+            return pd.DataFrame({"allele": self.alleles}).drop_duplicates()
+        declared = key_df[peptide_keys].drop_duplicates().merge(
+            pd.DataFrame({"allele": list(self.alleles)}), how="cross",
+        )
+        # Observed groups first so row order is preserved; the declared
+        # extras follow, and duplicates of observed ones fall away.
+        return pd.concat(
+            [key_df, declared[self.group_keys]], ignore_index=True,
+        ).drop_duplicates()
 
     def row_group_codes(self) -> np.ndarray:
         """Position within :attr:`group_index` of each row's group.


### PR DESCRIPTION
Closes #182 and #183.

Both were filed while adopting `peptide_view()` downstream, and both are why
the allele-free fan-out couldn't be deleted yet. `peptide_view` solved the
*broadcast*; these are the two things around it.

## #183 — a filter on an allele-scoped kind silently dropped the evidence

An allele-free group holds no rows of the kind being filtered on, so the
predicate evaluates to NaN — and pandas turns NaN comparisons into `False`, so
the row was dropped:

```python
before filter: [0.77, 0.77, 0.77]
rows 3 -> 2, kinds left ['pMHC_affinity']
after filter:  [nan, nan]      # the row holding the value is gone
```

Filter-then-score is the normal pipeline, so any config pairing an affinity
filter with a processing term in the score silently scored 0, with nothing
raised at either step.

An allele-free group holding **none of the kinds the filter reads** is now kept
whenever the filter kept at least one of that peptide's allele groups. The rule
is deliberately narrow:

| case | behavior |
|---|---|
| filter reads only allele-scoped kinds, peptide survives | evidence rides along ✓ |
| filter reads the allele-free kind itself | its own True/False decides it |
| peptide excluded entirely | evidence goes with it |
| no allele-free groups | untouched (early return) |

I first tried keying this off `values.isna()`, which never fires — pandas
comparisons against NaN yield `False`, not NA. The kind-membership test is what
actually distinguishes "the predicate said nothing" from "the predicate said no".

## #182 — declaring the alleles to evaluate against

Groups come from the rows, so a peptide whose *only* evidence is allele-free has
no per-allele group at all, and a consumer keyed by patient allele can't read
it. The genotype isn't in the frame, so it has to be passed:

```python
evaluate_scores(df, peptide_view(Processing.score),
                group_keys=keys, alleles=["HLA-A*02:01", "HLA-B*07:02"])
```

```
('p1', 'SIINFEKL', 2, '')            -> 0.77
('p1', 'SIINFEKL', 2, 'HLA-A*02:01') -> 0.77
('p1', 'SIINFEKL', 2, 'HLA-B*07:02') -> 0.77
```

`alleles` is the fourth shared context option (`apply_filter`, `apply_sort`,
`evaluate_scores`, `EvalContext`). It adds one group per peptide per declared
allele — a union with the observed ones, so nothing existing disappears.

The design point worth flagging: **the added groups hold no rows.** That keeps
the row-per-group model intact, so row counts out of every entry point are
unchanged (pinned by a test), and allele-scoped fields read `NaN` in a declared
group — which is the truth, that allele has no prediction of its own. This is
the issue's first suggested shape rather than the third; expanding rows would
have meant one row belonging to N groups, which `row_group_codes` and
`evaluate_scores`' per-row contract can't express.

Blank entries in `alleles` are rejected: allele-free is a property of a row, not
an allele you can declare.

## Tests

15 in `tests/test_allele_free_kinds.py`, including both issues' reproducers
verbatim, the four filter cases in the table above, the union ordering, NaN in
declared groups, and that no entry point invents rows.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1679 passed, 3 skipped

Version 5.19.0 (new option plus a filter behavior change).

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG