### PR TITLE
Project a bare allele-free kind instead of reading NaN (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 5.20.0
+
+**A bare allele-free kind is projected instead of reading NaN (#186):**
+
+Referencing an allele-free kind without `peptide_view()` in a grouping
+keyed by allele returned NaN for every allele group, silently — the row
+carries no allele, so it is in none of those groups and the plain read
+can never find it:
+
+```python
+evaluate_scores(df, Processing.score)   # 5.19.0: [nan, nan, 0.77]
+                                        # 5.20.0: [0.77, 0.77, 0.77] + UserWarning
+```
+
+That reading has no useful meaning, so the reference now means the one
+thing it can: the peptide's value, projected across its groups, exactly
+as `peptide_view()` does. A `UserWarning` names the explicit form, so
+the implicit behavior is greppable and migration is optional rather than
+urgent.
+
+This matters most for user-facing config: `score_expr` / `filter_expr`
+strings that read a processing kind used to work only because producers
+duplicated the allele-free row across a patient's alleles before
+evaluation. Removing that duplication — the point of #182 and #183 —
+would otherwise have left the same string parsing, validating, and
+scoring zero.
+
+**Only `mhc_dependence='none'` is treated this way.** A per-allele kind
+read plainly returns a real row, and choosing *which* row is a genuine
+decision that stays with the caller and `best_*` / `peptide_view()`.
+Explicit `peptide_view(...)` never warns, and the one-value-per-peptide
+rule is unchanged: an allele-free kind carrying two different values for
+one peptide still raises.
+
 ## 5.19.0
 
 **Allele-free predictions reach a genotype (#182), and survive a filter

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -107,12 +107,14 @@ from topiary import peptide_view, Affinity, Processing
 0.5 * peptide_view(Processing.score) + 0.5 * peptide_view(Affinity.score)
 ```
 
-The allele-free case is the one that couldn't be written before. An antigen-processing row carries no allele, so it forms its own group and every per-allele group reads `NaN`:
+The allele-free case is the one that couldn't be written before. An antigen-processing row carries no allele, so it forms its own group, and a plain read leaves every per-allele group `NaN` — the row is in none of them. Since that reading has no useful meaning, a bare reference to an allele-free kind in an allele-keyed grouping is projected anyway, with a warning naming the explicit form:
 
 ```python
-evaluate_scores(df, Processing.score)               # [nan, nan, 0.77]
-evaluate_scores(df, peptide_view(Processing.score)) # [0.77, 0.77, 0.77]
+evaluate_scores(df, Processing.score)                # [0.77, 0.77, 0.77] + UserWarning
+evaluate_scores(df, peptide_view(Processing.score))  # [0.77, 0.77, 0.77], silent
 ```
+
+Per-allele kinds are left alone: a plain read there returns a real row, and choosing *which* row is a genuine decision that stays with `best_*` / `peptide_view`. Writing the wrapper explicitly is still the right thing — it silences the warning and says what the expression means:
 
 That is why producers duplicated the processing row across the patient's alleles before handing topiary a frame. With `peptide_view` the frame keeps one canonical row and the value is broadcast at evaluation time:
 

--- a/tests/test_allele_free_kinds.py
+++ b/tests/test_allele_free_kinds.py
@@ -11,6 +11,8 @@ consequences the DSL has to handle explicitly:
   at all, so a consumer keyed by patient allele can't read it (#182).
 """
 
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -277,3 +279,119 @@ def test_alleles_are_ignored_without_an_allele_group_key():
     )
 
     assert len(ctx.group_index) == 1
+
+
+# ---------------------------------------------------------------------------
+# #186 — an unwrapped allele-free kind means the same thing, and says so
+# ---------------------------------------------------------------------------
+
+
+def test_unwrapped_allele_free_kind_is_projected():
+    """The config strings users have already written keep working."""
+    df = _affinity_and_processing()
+    ctx = EvalContext(df, group_keys=GROUP_KEYS)
+
+    with pytest.warns(UserWarning, match="carries no allele"):
+        scores = parse("processing[mhcflurry].score").eval(ctx)
+
+    assert scores.reindex(ctx.group_index).tolist() == [0.77, 0.77, 0.77]
+
+
+def test_unwrapped_and_wrapped_agree():
+    df = _affinity_and_processing()
+
+    with pytest.warns(UserWarning):
+        bare = _scores(df, parse("processing[mhcflurry].score"))
+
+    assert bare == _scores(df, PROCESSING)
+
+
+def test_the_warning_names_the_explicit_form():
+    df = _affinity_and_processing()
+    ctx = EvalContext(df, group_keys=GROUP_KEYS)
+
+    with pytest.warns(UserWarning) as caught:
+        parse("processing[mhcflurry].score").eval(ctx)
+
+    message = str(caught[0].message)
+    assert "peptide_view(" in message
+
+
+def test_explicit_peptide_view_does_not_warn():
+    df = _affinity_and_processing()
+    ctx = EvalContext(df, group_keys=GROUP_KEYS)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert PROCESSING.eval(ctx).reindex(ctx.group_index).tolist() == [
+            0.77, 0.77, 0.77,
+        ]
+
+
+def test_per_allele_kinds_are_left_alone():
+    """Choosing which allele's row to read stays the caller's decision."""
+    df = _affinity_and_processing()
+    ctx = EvalContext(df, group_keys=GROUP_KEYS)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        affinity = parse("affinity.value").eval(ctx).reindex(ctx.group_index)
+
+    assert affinity.tolist()[:2] == [50.0, 60.0]
+    assert pd.isna(affinity.tolist()[2])
+
+
+def test_no_projection_without_an_allele_group_key():
+    """Nothing to project onto; the plain read is already right."""
+    df = _affinity_and_processing()
+    keys = ["prediction_id", "peptide", "peptide_offset"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ctx = EvalContext(df, group_keys=keys)
+        scores = parse("processing[mhcflurry].score").eval(ctx)
+
+    assert scores.reindex(ctx.group_index).tolist() == [0.77]
+
+
+def test_unwrapped_reference_works_in_a_filter():
+    df = _affinity_and_processing()
+
+    with pytest.warns(UserWarning, match="carries no allele"):
+        kept = apply_filter(
+            df, parse("processing[mhcflurry].score >= 0.5"),
+            group_keys=GROUP_KEYS,
+        )
+
+    assert len(kept) == 3
+
+
+def test_unwrapped_reference_reaches_declared_alleles():
+    """Auto-projection composes with a declared genotype."""
+    df = pd.DataFrame([_row("", "antigen_processing", None, 0.77)])
+    ctx = EvalContext(df, group_keys=GROUP_KEYS, alleles=PATIENT_ALLELES)
+
+    with pytest.warns(UserWarning, match="carries no allele"):
+        scores = parse("processing[mhcflurry].score").eval(ctx)
+
+    per_allele = {
+        key[-1]: value
+        for key, value in scores.reindex(ctx.group_index).items()
+        if key[-1]
+    }
+    assert per_allele == {"HLA-A*02:01": 0.77, "HLA-B*07:02": 0.77}
+
+
+def test_inconsistent_values_still_raise_when_unwrapped():
+    """Auto-projection doesn't soften the one-value-per-peptide rule."""
+    df = pd.DataFrame([
+        _row("HLA-A*02:01", "pMHC_affinity", 50.0),
+        _row("", "antigen_processing", None, 0.30),
+        _row("", "antigen_processing", None, 0.90),
+    ])
+    ctx = EvalContext(df, group_keys=GROUP_KEYS)
+
+    with pytest.warns(UserWarning), pytest.raises(
+        ValueError, match="carry several different score",
+    ):
+        parse("processing[mhcflurry].score").eval(ctx)

--- a/tests/test_peptide_view.py
+++ b/tests/test_peptide_view.py
@@ -57,16 +57,19 @@ def _mixed_df():
 # ---------------------------------------------------------------------------
 
 
-def test_allele_free_kind_is_nan_without_peptide_view():
-    """The motivating gap: a processing row is in nobody's allele group."""
+def test_allele_free_kind_projects_even_unwrapped():
+    """A bare reference means the same thing — and says so once.
+
+    A plain read can only ever leave the allele groups NaN, since the
+    row is in none of them, so the reference is projected and warns
+    rather than quietly returning nothing (topiary #186).
+    """
     df = _mixed_df()
 
-    scores = evaluate_scores(df, Processing.score)
+    with pytest.warns(UserWarning, match="carries no allele"):
+        scores = evaluate_scores(df, Processing.score)
 
-    # Two per-allele groups read NaN; only the processing row's own group
-    # sees the value.
-    assert scores.tolist()[:2] == [pytest.approx(float("nan"), nan_ok=True)] * 2
-    assert scores.isna().tolist() == [True, True, False]
+    assert scores.tolist() == [0.77, 0.77, 0.77]
 
 
 def test_peptide_view_broadcasts_allele_free_value_to_every_group():
@@ -87,9 +90,12 @@ def test_peptide_view_composes_with_per_allele_clauses():
     # Only the A*02:01 affinity row clears both clauses.
     assert kept["allele"].tolist() == ["HLA-A*02:01"]
 
-    # Without the projection, the processing clause is NaN everywhere the
-    # affinity clause is true, so nothing survives.
-    assert len(apply_filter(df, parse("affinity <= 500 & processing.score >= 0.5"))) == 0
+    # The unwrapped form means the same thing, with a warning.
+    with pytest.warns(UserWarning, match="carries no allele"):
+        unwrapped = apply_filter(
+            df, parse("affinity <= 500 & processing.score >= 0.5"),
+        )
+    assert unwrapped["allele"].tolist() == kept["allele"].tolist()
 
 
 def test_peptide_view_processing_gate_can_reject_every_allele():

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -77,7 +77,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.19.0"
+__version__ = "5.20.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1065,11 +1065,53 @@ class Field(DSLNode):
         if col_name not in sub.columns:
             return ctx.empty_series()
 
+        projected = self._maybe_project_allele_free(ctx, sub)
+        if projected is not None:
+            return projected
+
         vals = sub.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[col_name].first()
         vals = vals.reindex(ctx.group_index)
         return pd.to_numeric(vals, errors="coerce")
+
+    def _maybe_project_allele_free(self, ctx, sub):
+        """Read an allele-free kind as the peptide-level fact it is.
+
+        Grouping by allele puts a prediction that has no allele in a
+        group of its own, so a plain read leaves every allele group NaN
+        — not a different answer to the question, but no answer at all,
+        since the row can never be in those groups.  There is exactly
+        one thing the reference can sensibly mean here, so mean it:
+        project the peptide's value across its groups, the same as
+        :func:`peptide_view`.
+
+        Only ``mhc_dependence='none'`` is treated this way.  A
+        per-allele kind read plainly returns a real row, and choosing
+        *which* row is a genuine decision — that stays with the caller
+        and ``best_*`` / ``peptide_view``.
+
+        Returns ``None`` when no projection applies, so the caller falls
+        through to the plain read.
+        """
+        if "allele" not in ctx.group_keys:
+            return None
+        if not [k for k in ctx.group_keys if k != "allele"]:
+            return None
+        if _resolve_mhc_dependence(ctx, self.kind, sub) != "none":
+            return None
+
+        import warnings
+        warnings.warn(
+            f"{self!r} reads {_kind_short_name(self.kind)}, which carries "
+            f"no allele, in a grouping keyed by allele. Reading it "
+            f"directly would leave every allele group NaN, so its "
+            f"peptide-level value is projected across them — write "
+            f"peptide_view({self!r}) to say so explicitly and silence "
+            f"this warning.",
+            UserWarning, stacklevel=4,
+        )
+        return PeptideView(self).eval(ctx)
 
     def __repr__(self):
         kind_name = _kind_short_name(self.kind)


### PR DESCRIPTION
Closes #186.

## What I did, and why not just the warning

The issue offered three options; I took **(2) auto-wrap plus (1) the warning**,
not (1) alone.

The reasoning is that the unwrapped reading isn't a *different answer* to the
question — it's no answer at all. An allele-free row carries no allele, so it is
in none of the peptide's allele groups, and a plain read can never find it. NaN
there isn't a semantic anyone chose; it's a structural miss:

```python
evaluate_scores(df, Processing.score)   # before: [nan, nan, 0.77]
                                        # after:  [0.77, 0.77, 0.77] + UserWarning
```

So the reference now means the one thing it can mean, and the warning names the
explicit form — implicit behavior stays greppable, and migration to
`peptide_view(...)` is optional rather than urgent. Warning alone would have
left every existing `score_expr` scoring zero the moment the downstream
projection comes out, which is the hazard the issue is about.

Not (3) — rejecting the unwrapped form would break those same configs
immediately, at the layer where users, not developers, wrote them.

## The line this draws

**Only `mhc_dependence='none'` is projected.** A per-allele kind read plainly
returns a real row; choosing *which* row is a genuine decision, and that stays
with the caller via `best_*` / `peptide_view()`. This is deliberately narrower
than the "accessors auto-reduce" option that #169 considered and deferred — that
one changes what a well-defined expression means, whereas this one gives meaning
to an expression that had none.

Consequences pinned by tests:

| expression | behavior |
|---|---|
| `processing.score`, allele in group keys | projected, warns once |
| `peptide_view(processing.score)` | projected, silent |
| `affinity.value` (per-allele kind) | untouched, silent |
| `processing.score`, no allele group key | untouched, silent — plain read is already right |
| allele-free kind with two values for one peptide | still raises |

The projection also composes with `alleles=` from #182, so a processing-only
peptide reaches a declared genotype through the bare reference too.

## Tests

9 added to `tests/test_allele_free_kinds.py` (77 in that file plus
`test_peptide_view.py` together). Two existing tests that pinned the old
NaN behavior are rewritten — that behavior is what this changes, and both now
assert the projection plus the warning.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1688 passed, 3 skipped

Version 5.20.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG