### PR TITLE
Project haplotype kinds too, not just allele-free ones (5.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 5.20.1
+
+**Fixed: a labeled haplotype kind read more quietly than an unlabeled one.**
+
+The auto-projection added in 5.20.0 covered `mhc_dependence='none'` only,
+so supplying correct metadata made the bare read fail *more* silently:
+
+```
+no kind_support          bare read = [0.9, 0.9, 0.9]   warns
+kind_support=haplotype   bare read = [nan, nan, 0.9]   silent
+```
+
+A haplotype prediction scores a whole genotype, and mhctools stamps the
+row with the allele it deconvolved as the best presenter. Reading it
+plainly therefore hands that joint score to one allele and leaves the
+rest of the genotype NaN — the same failure 5.20.0 fixed for
+allele-free kinds, wearing an allele name. Both peptide-level modes
+(`none` and `haplotype`) are now projected, with a warning naming
+`peptide_view(...)`.
+
+This matters on the default path: MHCflurry's
+`presentation_allele_mode="auto"` resolves to haplotype for six alleles
+or fewer, i.e. every ordinary patient genotype, and 5.18.1 made
+`TopiaryPredictor` forward `kind_support` automatically — so a
+`filter_by="presentation.score >= 0.5"` was reading NaN for every allele
+but one.
+
+`single_allele` kinds are unchanged: a plain read there returns a real
+row, and choosing which row stays with the caller.
+
 ## 5.20.0
 
 **A bare allele-free kind is projected instead of reading NaN (#186):**

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -107,14 +107,14 @@ from topiary import peptide_view, Affinity, Processing
 0.5 * peptide_view(Processing.score) + 0.5 * peptide_view(Affinity.score)
 ```
 
-The allele-free case is the one that couldn't be written before. An antigen-processing row carries no allele, so it forms its own group, and a plain read leaves every per-allele group `NaN` — the row is in none of them. Since that reading has no useful meaning, a bare reference to an allele-free kind in an allele-keyed grouping is projected anyway, with a warning naming the explicit form:
+The peptide-level cases are the ones that couldn't be written before. An antigen-processing row carries no allele, so it forms its own group and a plain read leaves every per-allele group `NaN` — the row is in none of them. A haplotype row has the same problem wearing an allele name: it scores a whole genotype, and mhctools stamps it with the deconvolved best allele, so a plain read hands that joint score to one allele and leaves the rest of the genotype `NaN`. Since neither reading has a useful meaning, a bare reference to either kind in an allele-keyed grouping is projected anyway, with a warning naming the explicit form:
 
 ```python
 evaluate_scores(df, Processing.score)                # [0.77, 0.77, 0.77] + UserWarning
 evaluate_scores(df, peptide_view(Processing.score))  # [0.77, 0.77, 0.77], silent
 ```
 
-Per-allele kinds are left alone: a plain read there returns a real row, and choosing *which* row is a genuine decision that stays with `best_*` / `peptide_view`. Writing the wrapper explicitly is still the right thing — it silences the warning and says what the expression means:
+Per-allele (`single_allele`) kinds are left alone: a plain read there returns a real row, and choosing *which* row is a genuine decision that stays with `best_*` / `peptide_view`. Writing the wrapper explicitly is still the right thing — it silences the warning and says what the expression means:
 
 That is why producers duplicated the processing row across the patient's alleles before handing topiary a frame. With `peptide_view` the frame keeps one canonical row and the value is broadcast at evaluation time:
 

--- a/tests/test_peptide_view.py
+++ b/tests/test_peptide_view.py
@@ -6,6 +6,8 @@ for per-allele kinds, a direct read for peptide-level ones — and callers
 had to know which by hand (topiary #169).
 """
 
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -798,3 +800,111 @@ def test_single_allele_warning_names_the_wrapping_expression():
     # A bare best_* still names itself.
     with pytest.warns(UserWarning, match="best_value on"):
         evaluate_scores(df, Affinity.best_value, kind_support=support)
+
+
+# ---------------------------------------------------------------------------
+# A genotype-level score is peptide-level too (auto-projection, haplotype)
+# ---------------------------------------------------------------------------
+
+
+HAPLOTYPE_SUPPORT = {
+    "mhcflurry": {
+        "pMHC_presentation": {"mhc_dependence": "haplotype"},
+        "pMHC_affinity": {"mhc_dependence": "single_allele"},
+    },
+}
+
+
+def _haplotype_df(presentation_allele):
+    """One genotype-level presentation row plus per-allele affinity.
+
+    ``presentation_allele`` is how the row names itself: mhctools stamps
+    the deconvolved best allele today, and a faithful writer might leave
+    it blank.  Neither should decide whether the genotype's score
+    reaches the genotype's alleles.
+    """
+    return pd.DataFrame([
+        _row(allele=ALLELES[0], kind="pMHC_affinity", value=50.0, score=0.5,
+             prediction_method_name="mhcflurry"),
+        _row(allele=ALLELES[1], kind="pMHC_affinity", value=4000.0, score=0.4,
+             prediction_method_name="mhcflurry"),
+        _row(allele=presentation_allele, kind="pMHC_presentation", score=0.9,
+             prediction_method_name="mhcflurry"),
+    ])
+
+
+@pytest.mark.parametrize("presentation_allele", ["", ALLELES[0]])
+def test_haplotype_score_reaches_the_whole_genotype(presentation_allele):
+    df = _haplotype_df(presentation_allele)
+
+    with pytest.warns(UserWarning, match="whole genotype"):
+        scores = evaluate_scores(
+            df, Presentation.score, kind_support=HAPLOTYPE_SUPPORT,
+        )
+
+    # Every row's group carries the genotype's score, not just the one
+    # allele the predictor deconvolved as best.
+    assert scores.tolist() == [0.9] * len(df)
+
+
+def test_labeled_haplotype_is_no_worse_than_an_unlabeled_one():
+    """More metadata must not make the bare read fail more quietly."""
+    df = _haplotype_df("")
+
+    with pytest.warns(UserWarning):
+        labeled = evaluate_scores(
+            df, Presentation.score, kind_support=HAPLOTYPE_SUPPORT,
+        )
+    with pytest.warns(UserWarning):
+        unlabeled = evaluate_scores(df, Presentation.score)
+
+    assert labeled.tolist() == unlabeled.tolist()
+
+
+def test_haplotype_warning_names_the_deconvolution():
+    df = _haplotype_df(ALLELES[0])
+
+    with pytest.warns(UserWarning) as caught:
+        evaluate_scores(df, Presentation.score, kind_support=HAPLOTYPE_SUPPORT)
+
+    message = str(caught[0].message)
+    assert "deconvolved" in message and "peptide_view(" in message
+
+
+def test_explicit_peptide_view_on_a_haplotype_kind_is_silent():
+    df = _haplotype_df(ALLELES[0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        scores = evaluate_scores(
+            df, peptide_view(Presentation.score),
+            kind_support=HAPLOTYPE_SUPPORT,
+        )
+
+    assert scores.tolist() == [0.9] * len(df)
+
+
+def test_single_allele_kinds_are_still_left_alone():
+    """Choosing which allele's row to read remains the caller's decision."""
+    df = _haplotype_df(ALLELES[0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        affinity = evaluate_scores(
+            df, Affinity.value, kind_support=HAPLOTYPE_SUPPORT,
+        )
+
+    assert affinity.tolist()[:2] == [50.0, 4000.0]
+
+
+def test_no_haplotype_projection_without_an_allele_group_key():
+    df = _haplotype_df(ALLELES[0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        scores = evaluate_scores(
+            df, Presentation.score, kind_support=HAPLOTYPE_SUPPORT,
+            group_keys=["source_sequence_name", "peptide", "peptide_offset"],
+        )
+
+    assert scores.tolist() == [0.9] * len(df)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -77,7 +77,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.20.0"
+__version__ = "5.20.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1065,7 +1065,7 @@ class Field(DSLNode):
         if col_name not in sub.columns:
             return ctx.empty_series()
 
-        projected = self._maybe_project_allele_free(ctx, sub)
+        projected = self._maybe_project_peptide_level(ctx, sub)
         if projected is not None:
             return projected
 
@@ -1075,21 +1075,28 @@ class Field(DSLNode):
         vals = vals.reindex(ctx.group_index)
         return pd.to_numeric(vals, errors="coerce")
 
-    def _maybe_project_allele_free(self, ctx, sub):
-        """Read an allele-free kind as the peptide-level fact it is.
+    def _maybe_project_peptide_level(self, ctx, sub):
+        """Read a peptide-level kind as the peptide-level fact it is.
 
-        Grouping by allele puts a prediction that has no allele in a
-        group of its own, so a plain read leaves every allele group NaN
-        — not a different answer to the question, but no answer at all,
-        since the row can never be in those groups.  There is exactly
-        one thing the reference can sensibly mean here, so mean it:
-        project the peptide's value across its groups, the same as
-        :func:`peptide_view`.
+        Grouping by allele puts a prediction that isn't about one allele
+        in a group of its own, so a plain read leaves the peptide's
+        other allele groups NaN — not a different answer to the
+        question, but no answer at all, since the row can never be in
+        those groups.  There is exactly one thing the reference can
+        sensibly mean, so mean it: project the peptide's value across
+        its groups, the same as :func:`peptide_view`.
 
-        Only ``mhc_dependence='none'`` is treated this way.  A
-        per-allele kind read plainly returns a real row, and choosing
-        *which* row is a genuine decision — that stays with the caller
-        and ``best_*`` / ``peptide_view``.
+        Both peptide-level modes qualify.  ``mhc_dependence='none'`` is
+        the processing case — no allele anywhere.  ``'haplotype'`` is a
+        score for a whole genotype, which mhctools stamps with the
+        deconvolved best allele; reading it plainly hands the joint
+        score to that one allele and leaves the rest of the genotype
+        NaN, which is the same failure wearing an allele name.
+
+        ``single_allele`` is untouched: a per-allele kind read plainly
+        returns a real row, and choosing *which* row is a genuine
+        decision that stays with the caller and ``best_*`` /
+        ``peptide_view``.
 
         Returns ``None`` when no projection applies, so the caller falls
         through to the plain read.
@@ -1098,17 +1105,30 @@ class Field(DSLNode):
             return None
         if not [k for k in ctx.group_keys if k != "allele"]:
             return None
-        if _resolve_mhc_dependence(ctx, self.kind, sub) != "none":
+        dependence = _resolve_mhc_dependence(ctx, self.kind, sub)
+        if dependence not in ("none", "haplotype"):
             return None
 
+        kind_name = _kind_short_name(self.kind)
+        if dependence == "none":
+            subject = f"{kind_name}, which carries no allele,"
+            reading = "would leave every allele group NaN"
+        else:
+            subject = (
+                f"{kind_name}, which is predicted for a whole genotype "
+                f"rather than one allele,"
+            )
+            reading = (
+                "would hand that joint score to the single allele "
+                "mhctools deconvolved as the best one, leaving the rest "
+                "of the genotype NaN"
+            )
         import warnings
         warnings.warn(
-            f"{self!r} reads {_kind_short_name(self.kind)}, which carries "
-            f"no allele, in a grouping keyed by allele. Reading it "
-            f"directly would leave every allele group NaN, so its "
-            f"peptide-level value is projected across them — write "
-            f"peptide_view({self!r}) to say so explicitly and silence "
-            f"this warning.",
+            f"{self!r} reads {subject} in a grouping keyed by allele. "
+            f"Reading it directly {reading}, so its peptide-level value "
+            f"is projected across them — write peptide_view({self!r}) to "
+            f"say so explicitly and silence this warning.",
             UserWarning, stacklevel=4,
         )
         return PeptideView(self).eval(ctx)


### PR DESCRIPTION
Follow-up to #187, found while scoping #168.

## The bug

5.20.0's auto-projection covers `mhc_dependence='none'` only, so supplying
*correct* metadata made the bare read fail more silently than supplying none:

```
no kind_support          bare read = [0.9, 0.9, 0.9]   warns
kind_support=haplotype   bare read = [nan, nan, 0.9]   silent
```

A haplotype prediction scores a whole genotype, and mhctools stamps the row with
the allele it deconvolved as the best presenter. Reading it plainly therefore
hands that joint score to one allele and leaves the rest of the genotype NaN —
the same failure #186 described for allele-free kinds, wearing an allele name.
Both are peptide-level facts that a per-allele read structurally cannot reach,
which is the line the projection is drawn on.

## Why it matters on the default path

Not a corner case:

- MHCflurry's `presentation_allele_mode="auto"` resolves to **haplotype** for six
  alleles or fewer — every ordinary patient genotype.
- #184 (5.18.1) made `TopiaryPredictor` forward `kind_support` automatically.

So `TopiaryPredictor(filter_by="presentation.score >= 0.5")` against a default
MHCflurry run has been reading NaN for every allele but the deconvolved one, and
dropping rows on that basis, with nothing raised.

## What changes

Both peptide-level modes (`none` and `haplotype`) project, with a warning naming
`peptide_view(...)`. The haplotype wording explains the deconvolution rather than
reusing the allele-free phrasing, since the row *does* carry an allele and the
user needs to know why it isn't the subject.

Verified for both row shapes — blank allele, and the best-allele stamp topiary
actually emits today:

| row shape | before | after |
|---|---|---|
| `allele=""` | `[nan, nan, 0.9]` | `[0.9, 0.9, 0.9]` |
| `allele="HLA-A*02:01"` (best) | `[0.9, nan]` | `[0.9, 0.9]` |

`single_allele` is untouched: a plain read there returns a real row, and choosing
which row is a genuine decision that stays with `best_*` / `peptide_view`.

This is a behavior change, not just a warning — a filter or score over a
haplotype presentation kind now sees the genotype's value for every allele
instead of NaN for all but one. That's the point; noted in the CHANGELOG.

## Tests

7 added to `tests/test_peptide_view.py`, parametrized over both row shapes,
including one that pins the invariant this violated: **a labeled haplotype row
must not read more quietly than an unlabeled one.**

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1695 passed, 3 skipped

Version 5.20.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG