### PR TITLE
Make apply_sort an ordering rather than a pairwise comparison (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 5.21.1
+
+**Fixed: `apply_sort`'s ranking depended on the order rows arrived in
+(#191).**
+
+The comparator skipped a key when *either* side was missing. Skipping is
+pairwise, so "equal" stopped being transitive — and `sorted` needs a
+consistent comparator. Three groups, sorting on two keys, the same data
+in three input orders:
+
+```
+input ['A', 'B', 'C'] -> ['A', 'B', 'C']   <- A (k0=1) above C (k0=2)
+input ['C', 'B', 'A'] -> ['C', 'B', 'A']
+input ['B', 'A', 'C'] -> ['B', 'C', 'A']
+```
+
+A missing sort key is the ordinary case — a peptide with no presentation
+row has no presentation score — so this was reachable without anything
+unusual, and it silently produced a different ranking depending on how
+the frame had been concatenated.
+
+**Keys are now ranked rather than compared pairwise**, which gives every
+group a definite position while keeping the property the skip was
+reaching for: a group with no value for a key takes the average rank of
+the groups that do have one, so the key neither promotes nor penalizes
+it and the remaining keys decide. Frames with no missing values sort
+exactly as before.
+
+**Also much faster.** The old comparator ran per pair in Python and was
+the dominant cost of sorting:
+
+| rows | groups | before | comparator's share |
+|---|---|---|---|
+| 100,000 | 85,000 | 2.05 s | ~100% |
+| 400,000 | 340,000 | 11.42 s | 74% |
+
+Ordering is now a single `np.lexsort` over the ranked keys.
+
 ## 5.21.0
 
 **`allele_set` — storing what a genotype-level prediction was scored

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -15,7 +15,7 @@ df = apply_sort(df, [Presentation.score, Affinity.score])
 
 `apply_filter` expects a boolean-valued expression (a `Comparison` or `BoolOp`). It errors if the evaluated Series contains values outside `{True, False, 0, 1, NaN}` — e.g. passing `Affinity.score` directly — pointing you at `<=` / `>=`.
 
-`apply_sort` accepts a list of expressions as lexicographic tiebreakers. NaN values fall through to the next key instead of forcing an order.
+`apply_sort` accepts a list of expressions as lexicographic tiebreakers. A group with no value for a key is neutral on it — it takes the average rank of the groups that do have one, so the key neither promotes nor penalizes it and the remaining keys decide.
 
 `TopiaryPredictor(filter_by=..., sort_by=[...])` applies them automatically during prediction.
 

--- a/tests/test_sort_ordering.py
+++ b/tests/test_sort_ordering.py
@@ -1,0 +1,162 @@
+"""apply_sort must be an ordering, not a pairwise comparison (topiary #191).
+
+Skipping a key when either side is missing made "equal" intransitive, so the
+ranking depended on the order rows arrived in and a worse group could outrank
+a better one. Keys are ranked instead, with a missing value taking the
+average rank so it neither gains nor loses by that key.
+"""
+
+import time
+
+import numpy as np
+import pandas as pd
+
+from topiary import Affinity, Column, apply_sort
+
+NAN = float("nan")
+
+
+def _frame(groups, **extra):
+    """One row per group; ``groups`` is (peptide, k0, k1)."""
+    return pd.DataFrame([
+        dict(source_sequence_name="s", peptide=peptide, peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=1.0,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan", k0=k0, k1=k1, **extra)
+        for peptide, k0, k1 in groups
+    ])
+
+
+KEYS = [Column("k0"), Column("k1")]
+
+
+# ---------------------------------------------------------------------------
+# The bug: order-dependent ranking
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_does_not_depend_on_row_order():
+    """A vs B and B vs C compared 'equal'; A vs C did not."""
+    groups = [("A", 1.0, NAN), ("B", NAN, NAN), ("C", 2.0, NAN)]
+
+    rankings = {
+        tuple(apply_sort(_frame([groups[i] for i in perm]), KEYS)["peptide"])
+        for perm in ([0, 1, 2], [2, 1, 0], [1, 0, 2], [1, 2, 0])
+    }
+
+    assert len(rankings) == 1
+
+
+def test_a_better_group_outranks_a_worse_one():
+    groups = [("A", 1.0, NAN), ("B", NAN, NAN), ("C", 2.0, NAN)]
+
+    ordered = apply_sort(_frame(groups), KEYS)["peptide"].tolist()
+
+    # Descending on k0: 2.0 beats 1.0, whatever else is in the frame.
+    assert ordered.index("C") < ordered.index("A")
+
+
+# ---------------------------------------------------------------------------
+# Missing values are neutral, not penalized
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_key_neither_promotes_nor_penalizes():
+    groups = [("A", 9.0, 0.0), ("B", NAN, 0.0), ("C", 1.0, 0.0)]
+
+    ordered = apply_sort(_frame(groups), KEYS)["peptide"].tolist()
+
+    # B sits between the group it would beat and the one it would lose to.
+    assert ordered == ["A", "B", "C"]
+
+
+def test_later_keys_decide_when_a_key_cannot():
+    """The property the old pairwise skip was reaching for."""
+    groups = [("A", NAN, 1.0), ("B", NAN, 9.0), ("C", NAN, 5.0)]
+
+    ordered = apply_sort(_frame(groups), KEYS)["peptide"].tolist()
+
+    assert ordered == ["B", "C", "A"]
+
+
+def test_a_key_everyone_is_missing_is_simply_skipped():
+    groups = [("A", NAN, 1.0), ("B", NAN, 9.0)]
+
+    assert apply_sort(_frame(groups), KEYS)["peptide"].tolist() == ["B", "A"]
+
+
+# ---------------------------------------------------------------------------
+# Ordinary sorting is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_direction_is_respected():
+    groups = [("A", 1.0, 0.0), ("B", 3.0, 0.0), ("C", 2.0, 0.0)]
+
+    descending = apply_sort(_frame(groups), KEYS)["peptide"].tolist()
+    ascending = apply_sort(
+        _frame(groups), KEYS, sort_direction="asc",
+    )["peptide"].tolist()
+
+    assert descending == ["B", "C", "A"]
+    assert ascending == ["A", "C", "B"]
+
+
+def test_affinity_still_sorts_strong_binders_first():
+    df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide=peptide, peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=value,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan")
+        for peptide, value in (("weak", 5000.0), ("strong", 50.0))
+    ])
+
+    assert apply_sort(df, [Affinity.value])["peptide"].tolist() == [
+        "strong", "weak",
+    ]
+
+
+def test_ties_keep_frame_order():
+    groups = [("A", 1.0, 1.0), ("B", 1.0, 1.0), ("C", 1.0, 1.0)]
+
+    assert apply_sort(_frame(groups), KEYS)["peptide"].tolist() == [
+        "A", "B", "C",
+    ]
+
+
+def test_rows_of_a_group_stay_together():
+    df = pd.concat([_frame([("A", 1.0, 0.0)]), _frame([("B", 2.0, 0.0)]),
+                    _frame([("A", 1.0, 0.0)])], ignore_index=True)
+
+    assert apply_sort(df, KEYS)["peptide"].tolist() == ["B", "A", "A"]
+
+
+# ---------------------------------------------------------------------------
+# The same change removes the dominant cost
+# ---------------------------------------------------------------------------
+
+
+def test_sorting_many_groups_is_not_quadratic_in_python():
+    """The comparator was ~100% of apply_sort; this pins that it isn't now."""
+    n = 40_000
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "source_sequence_name": "s",
+        "peptide": [f"PEP{i:06d}" for i in range(n)],
+        "peptide_offset": 0,
+        "allele": "HLA-A*02:01",
+        "kind": "pMHC_affinity",
+        "value": rng.random(n) * 5000,
+        "score": rng.random(n),
+        "percentile_rank": rng.random(n) * 20,
+        "prediction_method_name": "netmhcpan",
+    })
+
+    start = time.perf_counter()
+    apply_sort(df, [Affinity.value, Affinity.score])
+    elapsed = time.perf_counter() - start
+
+    # The Python comparator took ~1s at this size; the bound is loose
+    # enough to survive a slow machine and tight enough to catch a
+    # regression back to per-pair Python calls.
+    assert elapsed < 2.0

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -80,7 +80,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.21.0"
+__version__ = "5.21.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from functools import cmp_to_key
-
 import numpy as np
 import pandas as pd
 from mhctools import Kind
@@ -195,6 +193,32 @@ def _infer_sort_direction(node):
     return "desc"
 
 
+def _neutral_ranked_key(values, ascending):
+    """Rank one sort key, placing missing values in the middle.
+
+    Comparing raw values pairwise and skipping a key when either side is
+    missing is not an ordering: "equal" stops being transitive, so the
+    result depends on the order the rows arrived in, and a worse group
+    can outrank a better one.  Ranking fixes that — every group gets a
+    definite position — while keeping the property that made the skip
+    attractive: a group with no value for this key neither gains nor
+    loses by it, sitting at the average rank of the groups that do have
+    one, so the remaining keys decide.
+
+    Returned smallest-sorts-first, whichever direction the key runs in.
+    """
+    present = ~np.isnan(values)
+    ranked = np.zeros(len(values), dtype=float)
+    if not present.any():
+        # Nothing to rank: the key can't distinguish anyone.
+        return ranked
+    oriented = values if ascending else -values
+    ranks = pd.Series(oriented[present]).rank(method="average").to_numpy()
+    ranked[present] = ranks
+    ranked[~present] = ranks.mean()
+    return ranked
+
+
 def _resolve_sort_direction(node, sort_direction):
     if sort_direction == "auto":
         return _infer_sort_direction(node)
@@ -289,8 +313,12 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
     from its shape (percentile_rank → asc; affinity.value → asc; other →
     desc) when *sort_direction* is ``"auto"``; otherwise the string
-    value is used for all nodes.  NaN values do not force an ordering —
-    they fall through to the next tiebreaker.
+    value is used for all nodes.
+
+    A group with no value for a key is neutral on it: it takes the
+    average rank of the groups that do have one, so the key neither
+    promotes nor penalizes it and the remaining keys decide.  Ties keep
+    the order the groups appear in the frame.
 
     *group_keys*, *default_methods*, *kind_support* and *alleles* are
     the shared context options, forwarded to :class:`EvalContext` — see
@@ -319,19 +347,12 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
         dtype=bool,
     )
 
-    def _cmp(i, j):
-        for col in range(n_keys):
-            a = values_matrix[i, col]
-            b = values_matrix[j, col]
-            if np.isnan(a) or np.isnan(b):
-                continue
-            if a < b:
-                return -1 if directions[col] else 1
-            if a > b:
-                return 1 if directions[col] else -1
-        return 0
-
-    sorted_idx = sorted(range(n_groups), key=cmp_to_key(_cmp))
+    lex_keys = [
+        _neutral_ranked_key(values_matrix[:, col], ascending=directions[col])
+        for col in range(n_keys)
+    ]
+    # np.lexsort reads its last argument as the primary key.
+    sorted_idx = np.lexsort(tuple(reversed(lex_keys)))
     rank_of_group = np.empty(n_groups, dtype=int)
     rank_of_group[sorted_idx] = np.arange(n_groups)
 


### PR DESCRIPTION
Closes #191. First of the series addressing #190–#194.

## The bug

The comparator skipped a key when *either* side was missing. Skipping is
pairwise, so "equal" stopped being transitive — and `sorted` requires a
consistent comparator. Same three groups, three input orders, three answers:

```
input ['A', 'B', 'C'] -> ['A', 'B', 'C']   <- A (k0=1) ranked above C (k0=2)
input ['C', 'B', 'A'] -> ['C', 'B', 'A']
input ['B', 'A', 'C'] -> ['B', 'C', 'A']
```

A missing sort key is the ordinary case — a peptide with no presentation row
has no presentation score — so nothing unusual was needed to hit this. Two runs
over the same predictions differing only in concatenation order could rank
candidates differently, with no error either time.

## The semantic question, and why not NaN-last

The obvious fix — sort missing values last within their key — is a total order
and one line of `np.lexsort`. I implemented it first and it broke
`test_sort_by_comma_separated_keys_fall_through_on_missing`, which encodes a
deliberate product decision: a peptide with no presentation prediction but high
expression should not be sunk by the missing key; the next key should decide.
That test is right, and NaN-last would have quietly reversed it.

So keys are **ranked** instead, with a missing value taking the **average rank**
of the groups that do have one. That is a total order — every group gets a
definite position — while keeping exactly the property the skip was reaching
for:

| | old (pairwise skip) | NaN-last | ranked, missing = neutral |
|---|---|---|---|
| transitive | ✗ | ✓ | ✓ |
| missing doesn't sink you | ✓ | ✗ | ✓ |
| missing can outrank the best value | ✓ | ✗ | ✗ |

The last row is a deliberate narrowing: under the old rule a group with *no*
presentation evidence could outrank one with the strongest presentation, as
long as a later key favored it. Neutral means it sits mid-field on that key
instead. Frames with no missing values sort exactly as before, which is why the
rest of the suite is untouched.

## Also removes the dominant cost

The comparator ran per pair in Python:

| rows | groups | apply_sort | comparator's share | np.lexsort, same keys |
|---|---|---|---|---|
| 100,000 | 85,000 | 2.05 s | ~100% | 8 ms |
| 200,000 | 170,000 | 4.56 s | 82% | 33 ms |
| 400,000 | 340,000 | 11.42 s | 74% | 39 ms |

Ordering is now a single `np.lexsort` over the ranked keys. A test pins that
40,000 groups sort in under 2 s, which the old implementation could not do.

## Tests

10 in `tests/test_sort_ordering.py`: the three-permutation determinism check,
better-outranks-worse, missing-is-neutral in both directions, later keys
deciding, an all-missing key being skipped, direction handling, tie stability,
rows of a group staying together, and the timing bound.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1737 passed, 3 skipped

Version 5.21.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG