### PR TITLE
Allow scoped fields in filters, and report the missing-column case (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 5.23.0
+
+**Scoped fields work in filters (#192):**
+
+`wt.`, `self_nearest.`, `shuffled.` and `self.` raised `TypeError` inside
+a comparison, directing callers to sorting expressions instead. That
+blocked the standard analysis:
+
+```python
+# the mutant binds and the wildtype doesn't — differential agretopicity
+apply_filter(df, (Affinity.value <= 500) & (wt.Affinity.value >= 1000))
+```
+
+Selecting neoepitopes that way is an exclusion, and a sort cannot
+exclude. The same applies to a cross-reactivity rule on
+`self_nearest.`, which is a filter by nature.
+
+The ban never prevented the operation either — `column(wt_value) >= 1000`
+reads the same values and was always allowed — so it only made the
+scoped vocabulary unavailable for it, while leaving the identical
+failure mode reachable by the other spelling.
+
+**The hazard it was standing in for is now reported.** A comparator
+column a producer never wrote makes the expression NaN for every group,
+and NaN in a filter drops the frame. A filter reading a scope the frame
+doesn't carry now warns, naming the missing column. Outside a filter
+NaN is a sensible answer, so ranking and scoring are unaffected.
+
 ## 5.22.1
 
 **Regression coverage for the 5.22.0 projection fix.**
@@ -80,6 +108,7 @@ longer projected on the strength of the blank alone. With
 projects as before — but rows cannot distinguish a genotype-level
 prediction from a per-allele one that lost its allele, so without that
 evidence the conservative reading applies.
+
 
 ## 5.21.1
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -391,7 +391,13 @@ topiary ... --predict-wt --sort-by "affinity.score - wt.affinity.score"
 ```
 
 !!! note
-    `wt.` is for **sorting expressions only**, not filters. Use it in `sort_by`, not in `filter`. When WT columns don't exist, expressions evaluate to NaN. Rows without a length-compatible WT peptide also keep NaN WT prediction values.
+    `wt.` works in filters as well as in sorting and scoring — "the mutant binds and the wildtype doesn't" is a filter, and it is the differential criterion for a neoepitope:
+
+    ```python
+    apply_filter(df, (Affinity.value <= 500) & (wt.Affinity.value >= 1000))
+    ```
+
+    When the `wt_*` columns don't exist the expression is NaN for every group, and NaN in a filter drops everything — so a filter that reads a scope this frame doesn't carry says so rather than quietly returning nothing. Rows without a length-compatible WT peptide also keep NaN WT prediction values.
 
 ## len and count() — peptide-level expressions
 

--- a/tests/test_dsl_extensions.py
+++ b/tests/test_dsl_extensions.py
@@ -463,10 +463,12 @@ class TestWTScope:
         val = wt.Affinity.value.evaluate(df)
         assert math.isnan(val)
 
-    def test_wt_comparison_raises(self):
-        """Scoped fields can't be used in filters — only in ranking expressions."""
-        with pytest.raises(TypeError, match="Scoped fields"):
-            wt.Affinity <= 1000
+    def test_wt_comparison_selects_on_the_wildtype(self):
+        """Filtering on wt is the differential neoepitope criterion (#192)."""
+        df = _group_with_wt()
+
+        assert (wt.Affinity <= 1000).evaluate(df)
+        assert not (wt.Affinity <= 100).evaluate(df)
 
     def test_wt_logistic(self):
         df = _group_with_wt()
@@ -694,10 +696,12 @@ class TestEdgeCasesFromDocs:
         val = wt.Affinity["netmhcpan"].value.evaluate(df)
         assert val == 800.0
 
-    def test_wt_ge_also_raises(self):
-        """Scoped >= should also raise, not just <=."""
-        with pytest.raises(TypeError, match="Scoped fields"):
-            wt.Affinity >= 100
+    def test_wt_ge_also_compares(self):
+        """>= works like <=; neither is refused any more."""
+        df = _group_with_wt()
+
+        assert (wt.Affinity >= 100).evaluate(df)
+        assert not (wt.Affinity >= 10000).evaluate(df)
 
     def test_column_filter_both_bounds(self):
         """Column filter with both min and max (built via AND of comparisons)."""

--- a/tests/test_peptide_view.py
+++ b/tests/test_peptide_view.py
@@ -618,20 +618,20 @@ def test_models_sharing_a_method_name_get_an_honest_error():
         )
 
 
-def test_scoped_field_cannot_reach_a_filter_through_peptide_view():
-    """peptide_view must not become a hole in the wt.* filter guard."""
+def test_a_scoped_field_filters_through_peptide_view():
+    """Scoped fields are filterable (#192); the wrapper doesn't change that."""
+    from topiary.ranking import wt
+
     df = pd.DataFrame([
         _row(allele=allele, kind="pMHC_affinity", value=100.0, score=0.5,
              wt_value=wt_value)
-        for allele, wt_value in zip(ALLELES, (9000.0, 20.0))
+        for allele, wt_value in zip(ALLELES, (9000.0, 9000.0))
     ])
 
-    with pytest.raises(TypeError, match="Scoped fields"):
-        parse("peptide_view(wt.affinity.value) <= 500")
+    kept = apply_filter(df, peptide_view(wt.Affinity.value) >= 500)
 
-    from topiary.ranking import wt
-    with pytest.raises(TypeError, match="Scoped fields"):
-        apply_filter(df, peptide_view(wt.Affinity.value) <= 500)
+    assert len(kept) == len(df)
+    assert parse("peptide_view(wt.affinity.value) >= 500") is not None
 
 
 def test_values_agreeing_within_float_noise_are_accepted():

--- a/tests/test_scoped_filters.py
+++ b/tests/test_scoped_filters.py
@@ -1,0 +1,127 @@
+"""Scoped fields in filters (topiary #192).
+
+`wt.`, `self_nearest.`, `shuffled.` and `self.` used to raise in a comparison,
+on the theory that filtering on a comparator was a mistake. It isn't: "the
+mutant binds and the wildtype doesn't" is the differential criterion for
+selecting a neoepitope, and it is an exclusion, not a sort. The real hazard —
+a comparator column the producer never wrote, which makes the filter drop
+everything — is now reported instead of banned.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from topiary import Affinity, apply_filter, apply_sort, self_nearest, wt
+from topiary.ranking import parse
+
+
+def _df():
+    """Two candidates: one tumor-specific, one whose wildtype also binds."""
+    return pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SPECIFIC", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=50.0,
+             score=0.9, percentile_rank=0.5, prediction_method_name="netmhcpan",
+             wt_value=9000.0, self_nearest_value=8000.0),
+        dict(source_sequence_name="s", peptide="SHARED", peptide_offset=9,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=60.0,
+             score=0.8, percentile_rank=0.6, prediction_method_name="netmhcpan",
+             wt_value=40.0, self_nearest_value=30.0),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# The analyses the guard used to block
+# ---------------------------------------------------------------------------
+
+
+def test_differential_binding_filter():
+    """Mutant binds, wildtype doesn't — the neoepitope criterion."""
+    kept = apply_filter(
+        _df(), (Affinity.value <= 500) & (wt.Affinity.value >= 1000),
+    )
+
+    assert kept["peptide"].tolist() == ["SPECIFIC"]
+
+
+def test_self_similarity_exclusion():
+    """The shape a cross-reactivity rule takes."""
+    kept = apply_filter(
+        _df(), (Affinity.value <= 500) & (self_nearest.Affinity.value >= 1000),
+    )
+
+    assert kept["peptide"].tolist() == ["SPECIFIC"]
+
+
+def test_the_string_form_works_too():
+    """These arrive from --filter-by and from config files."""
+    kept = apply_filter(
+        _df(), parse("affinity <= 500 & wt.affinity.value >= 1000"),
+    )
+
+    assert kept["peptide"].tolist() == ["SPECIFIC"]
+
+
+def test_a_scoped_clause_can_stand_alone():
+    kept = apply_filter(_df(), wt.Affinity.value >= 1000)
+
+    assert kept["peptide"].tolist() == ["SPECIFIC"]
+
+
+def test_scoped_fields_still_work_in_ranking():
+    """What the old error told people to do instead — unchanged."""
+    ordered = apply_sort(
+        _df(), [Affinity.score - wt.Affinity.score],
+    )
+
+    assert ordered["peptide"].tolist() == ["SPECIFIC", "SHARED"]
+
+
+# ---------------------------------------------------------------------------
+# The hazard the ban was standing in for
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_comparator_column_warns_in_a_filter():
+    """NaN in a filter empties the frame; that must not happen quietly."""
+    df = _df().drop(columns=["wt_value"])
+
+    with pytest.warns(UserWarning, match="does not have"):
+        kept = apply_filter(df, wt.Affinity.value >= 1000)
+
+    assert len(kept) == 0
+
+
+def test_the_warning_names_the_column_and_the_scope():
+    df = _df().drop(columns=["wt_value"])
+
+    with pytest.warns(UserWarning) as caught:
+        apply_filter(df, wt.Affinity.value >= 1000)
+
+    message = str(caught[0].message)
+    assert "wt_value" in message and "wt_*" in message
+
+
+def test_no_warning_when_the_columns_are_there():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        apply_filter(_df(), wt.Affinity.value >= 1000)
+
+
+def test_no_warning_outside_a_filter():
+    """NaN is a sensible answer when ranking; only a filter is silent."""
+    df = _df().drop(columns=["wt_value"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        apply_sort(df, [Affinity.score - wt.Affinity.score])
+
+
+def test_unscoped_fields_are_unaffected():
+    """A missing kind is an ordinary NaN, not a producer mistake."""
+    df = _df()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert len(apply_filter(df, parse("stability.score >= 0.5"))) == 0

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -83,7 +83,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.22.1"
+__version__ = "5.23.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1204,6 +1204,7 @@ class Field(DSLNode):
 
         col_name = self.scope + self.field
         if col_name not in sub.columns:
+            self._warn_missing_scope_column(ctx, col_name)
             return ctx.empty_series()
 
         projected = self._maybe_project_peptide_level(ctx, sub)
@@ -1215,6 +1216,27 @@ class Field(DSLNode):
         )[col_name].first()
         vals = vals.reindex(ctx.group_index)
         return pd.to_numeric(vals, errors="coerce")
+
+    def _warn_missing_scope_column(self, ctx, col_name):
+        """Say so when a filter reads a comparator column that isn't there.
+
+        A scoped reference — ``wt.``, ``self_nearest.``, ``shuffled.`` —
+        reads a column a producer may simply not have written.  Absent,
+        it evaluates to NaN, and NaN in a filter drops every group: the
+        frame comes back empty with nothing said.  Outside a filter NaN
+        is a sensible answer, so this only fires where it silently
+        changes the outcome.
+        """
+        if not self.scope or not ctx.filter_context:
+            return
+        import warnings
+        warnings.warn(
+            f"{self!r} reads {col_name!r}, which this frame does not "
+            f"have, so it is NaN for every group — in a filter that "
+            f"drops everything. Populate the "
+            f"{self.scope.rstrip('_')}_* columns, or drop the clause.",
+            UserWarning, stacklevel=4,
+        )
 
     def _maybe_project_peptide_level(self, ctx, sub):
         """Read a peptide-level kind as the peptide-level fact it is.
@@ -1300,7 +1322,6 @@ class Field(DSLNode):
             parts.append(f"scope={self.scope!r}")
         return f"Field({', '.join(parts)})"
 
-    # (Scoped fields cannot appear in filters — guarded in Comparison.__init__)
 
 
 # Canonical "best direction" per (kind, field) lives upstream in
@@ -2517,18 +2538,6 @@ class Comparison(DSLNode):
     __slots__ = ("left", "op", "right")
 
     def __init__(self, left: DSLNode, op, right: DSLNode):
-        for side in (left, right):
-            # Look through peptide_view(): it changes which row is read,
-            # not which columns, so a scoped field stays off-limits in a
-            # filter however it is wrapped.
-            side = _unwrap_peptide_view(side)
-            if isinstance(side, (Field, BestAlleleField)) and side.scope:
-                scope_name = side.scope.rstrip("_")
-                raise TypeError(
-                    f"Scoped fields ({scope_name}.*) can't be used in filters. "
-                    f"Use them in sorting expressions instead, e.g.: "
-                    f"sort_by=[Affinity.score - {scope_name}.Affinity.score]"
-                )
         self.left = left
         self.op = op
         self.right = right


### PR DESCRIPTION
Closes #192. Third of the series (after #196, #197).

## The decision

Scoped fields — `wt.`, `self_nearest.`, `shuffled.`, `self.` — raised `TypeError`
inside a comparison, with the error directing callers to sorting expressions
instead. I removed the ban.

The deciding case isn't `self_nearest`. It's that **filtering on `wt.` is the
standard neoepitope analysis**, not a mistake:

```python
# the mutant binds and the wildtype doesn't — differential agretopicity
apply_filter(df, (Affinity.value <= 500) & (wt.Affinity.value >= 1000))
```

That is an exclusion, and a sort cannot exclude, so the error's advice did not
describe an alternative. A cross-reactivity rule on `self_nearest.` has the same
shape and is what #190 exists to feed.

The ban also never prevented the operation. `column(wt_value) >= 1000` reads the
identical values and was always allowed — so the guard only made the scoped
vocabulary unavailable, while leaving the same failure mode reachable by the
other spelling. A guard you bypass by renaming the reference isn't protecting
anyone.

## What replaces it

The hazard the ban was standing in for is real: a comparator column the producer
never wrote makes the expression NaN for every group, and NaN in a filter drops
the frame — an empty result with nothing said. That is now reported:

```
UserWarning: wt.affinity.value reads 'wt_value', which this frame does not have,
so it is NaN for every group — in a filter that drops everything. Populate the
wt_* columns, or drop the clause.
```

Only in a filter. Outside one, NaN is a sensible answer, so ranking and scoring
are untouched — verified by a test that sorts on the same expression against the
same column-less frame and asserts silence.

## Tests

10 in `tests/test_scoped_filters.py`: the differential filter, the
self-similarity exclusion, the string form (these arrive from `--filter-by` and
config files), a scoped clause standing alone, scoped fields still working in
ranking, the missing-column warning and its contents, silence when the columns
are present, silence outside a filter, and unscoped fields being unaffected.

Three existing tests asserted the old `TypeError` and now assert the behavior
that replaced it — including the one I added in #187, whose premise was that
`peptide_view` must not become a hole in the guard.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1747 passed, 3 skipped

Version 5.23.0, assuming #197 lands first as 5.22.0; will rebase if that order
changes.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG