### PR TITLE
Pin the projection fix with a frame that actually reproduced it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.22.1
+
+**Regression coverage for the 5.22.0 projection fix.**
+
+The test shipped with #197 used a frame where some rows of the kind
+carried a real allele. That case never reproduced the bug: the old row
+scan saw the counter-example and already answered `single_allele`, so
+the test passed before the fix as well as after it. Reproducing requires
+*every* row of the kind to be blank-allele, which is the shape the
+openvax/vaxrank#348 review found. No behavior change — 5.22.0's fix was
+correct, its regression test simply did not pin it.
+
 ## 5.22.0
 
 **`KIND_MHC_DEPENDENCE` — what a kind is about, before any rows (#195):**

--- a/tests/test_kind_mhc_dependence.py
+++ b/tests/test_kind_mhc_dependence.py
@@ -118,20 +118,45 @@ def test_an_allele_scoped_kind_with_no_allele_stays_allele_scoped():
         assert _dependence(df, "pMHC_affinity") == "single_allele"
 
 
-def test_a_blank_allele_row_is_not_projected_across_the_genotype():
-    """It would invent binding evidence for alleles the model never scored."""
+def test_an_all_blank_allele_kind_is_not_projected():
+    """The shape that actually reproduced the bug.
+
+    Every row of the kind must be blank-allele: with even one real
+    allele present, the old row scan saw a counter-example and already
+    answered ``single_allele``. Only when the whole kind scanned as
+    allele-free did it project, spreading one prediction across alleles
+    the model never scored (found in the openvax/vaxrank#348 review, on
+    a frame this shape).
+    """
+    df = pd.DataFrame([
+        # The malformed prediction: affinity, no allele, and the only
+        # affinity row in the frame.
+        _row("pMHC_affinity", allele="", score=0.5, value=7.0),
+        _row("pMHC_stability", allele="HLA-A*02:01", score=0.9, value=100.0),
+        _row("pMHC_stability", allele="HLA-B*07:02", score=0.8, value=200.0),
+    ])
+
+    with pytest.warns(UserWarning, match="carry no allele"):
+        scores = evaluate_scores(df, parse("affinity.value"))
+
+    # Only the group the row is actually in sees it; the two real
+    # alleles read NaN, which is the truth — no affinity was predicted
+    # for either.
+    assert scores.tolist()[0] == 7.0
+    assert pd.isna(scores.tolist()[1]) and pd.isna(scores.tolist()[2])
+
+
+def test_a_blank_allele_among_real_ones_is_also_kept_per_allele():
+    """The adjacent path: a mixed frame, which the row scan already got right."""
     df = pd.DataFrame([
         _row("pMHC_affinity", allele="HLA-A*02:01", score=0.9),
         _row("pMHC_affinity", allele="HLA-B*07:02", score=0.1),
-        # Malformed: an affinity prediction with no allele on it.
         _row("pMHC_affinity", allele="", score=0.5),
     ])
 
     with pytest.warns(UserWarning, match="carry no allele"):
         scores = evaluate_scores(df, parse("affinity.score"))
 
-    # Each allele keeps its own score; the malformed row is not spread
-    # across them.
     assert scores.tolist()[:2] == [0.9, 0.1]
 
 

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -83,7 +83,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.22.0"
+__version__ = "5.22.1"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
Test-only follow-up to #197, prompted by the vaxrank session reproducing the
original defect and pointing out that the shape matters.

## What was wrong with the test I shipped

`test_a_blank_allele_row_is_not_projected_across_the_genotype` used a frame
where two affinity rows carried real alleles and a third was blank. That case
**never reproduced the bug**: the old row scan saw the counter-example and
already answered `single_allele`, so the test passed before the fix as well as
after it. It asserted correct behavior without pinning the regression.

Reproducing requires *every* row of the kind to be blank-allele, so the scan
finds no counter-example and reads the whole kind as peptide-level:

```
rows: pMHC_affinity  allele=""            value=7.0
      pMHC_stability allele=HLA-A*02:01   value=100
      pMHC_stability allele=HLA-B*07:02   value=200

before: affinity.value -> ""=7.0, A*02:01=7.0, B*07:02=7.0   <- invented
after:  affinity.value -> ""=7.0, A*02:01=NaN, B*07:02=NaN
```

Confirmed by evaluating what the old row scan would have answered for each
frame: `none` for the all-blank one (→ projection), `single_allele` for the
mixed one (→ no projection, before or after).

## What this adds

- `test_an_all_blank_allele_kind_is_not_projected` — the reproducing shape,
  asserting the two real alleles read NaN rather than a number no model
  produced.
- The mixed frame is kept as `test_a_blank_allele_among_real_ones_is_also_kept_per_allele`,
  labelled as the adjacent path rather than as the regression.

No behavior change. 5.22.0's fix was correct; its regression test did not pin
it.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1759 passed, 3 skipped

Version 5.22.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG