### PR TITLE
Add opt-in canonical method resolution (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 5.24.0
+
+**Opt-in canonical method resolution (#193):**
+
+```python
+from topiary import resolve_default_methods, validate_default_methods
+
+defaults = resolve_default_methods(df)   # {"pMHC_affinity": "mhcflurry"}
+evaluate_scores(df, node, default_methods=defaults)
+```
+
+An unqualified reference to a kind produced by several models raises,
+and that stays — silently choosing a model is not something topiary
+should do behind a caller's back. What was missing is a supported way to
+say *pick the canonical one*, so every consumer wrote its own preference
+table, and two tools could disagree about what canonical means with
+nothing surfacing the difference.
+
+`resolve_default_methods` returns an entry only for kinds that actually
+have a choice. It resolves by `CANONICAL_METHOD_PREFERENCE`, which is a
+**tie-break convention, not a quality ranking**: general-purpose
+predictors ahead of ones whose output for a kind is secondary to their
+main job (NetMHCstabPan predicts stability; its affinity comes along
+with it), mode variants after the model they vary, and anything unlisted
+alphabetically after those so the answer is always deterministic. Pass
+`preference=` to override it. The shipped order matches the convention
+already in use downstream, so adopting this changes no existing scores.
+
+`validate_default_methods(df, default_methods)` reports an entry naming
+a kind or a model the frame doesn't have. `EvalContext` only consults a
+default when a kind is *actually* ambiguous, so such an entry is
+otherwise inert — and stays inert until the day two models produce that
+kind, when it starts deciding. Checking up front turns a typo in a
+config file into an error where it was written.
+
 ## 5.23.0
 
 **Scoped fields work in filters (#192):**
@@ -39,6 +74,7 @@ the test passed before the fix as well as after it. Reproducing requires
 *every* row of the kind to be blank-allele, which is the shape the
 openvax/vaxrank#348 review found. No behavior change — 5.22.0's fix was
 correct, its regression test simply did not pin it.
+
 
 ## 5.22.0
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -50,6 +50,21 @@ scores = evaluate_scores(kept, Affinity.score, group_keys=group_keys)
 
 `apply_filter`, `apply_sort` and `evaluate_scores` accept the same keyword-only context options — `group_keys`, `default_methods`, `kind_support` and `alleles` — so filtering, sorting and scoring can share one grouping and one method resolution.
 
+When several models produce the same kind, an unqualified reference raises rather than picking one. To say "pick the canonical one" explicitly:
+
+```python
+from topiary import resolve_default_methods, validate_default_methods
+
+defaults = resolve_default_methods(df)          # {"pMHC_affinity": "mhcflurry"}
+evaluate_scores(df, node, default_methods=defaults)
+
+validate_default_methods(df, user_supplied)     # catches a typo at config time
+```
+
+`resolve_default_methods` returns an entry only for kinds that actually have a choice, and resolves by `CANONICAL_METHOD_PREFERENCE` — a **tie-break convention, not a quality ranking**. It orders general-purpose predictors ahead of ones whose output for a kind is secondary to their main job, then anything unlisted alphabetically, so the answer is always deterministic. Pass your own `preference=` to override it, or qualify the reference (`Affinity["netmhcpan"]`) if you care which model answers.
+
+`validate_default_methods` exists because `EvalContext` only consults a default when a kind is *actually* ambiguous — so an entry naming a model that never ran sits inert until the day two models do produce that kind, and then starts deciding.
+
 One thing is deliberately *not* shared: on a frame where several methods produce the same kind, `apply_filter` auto-aggregates an unqualified reference across them (`nanmin` for `<`/`<=`, `nanmax` for `>`/`>=`), while `apply_sort` and `evaluate_scores` stay strict and raise on the ambiguity. Pass `default_methods={"affinity": "mhcflurry"}` (or qualify the reference, `Affinity["mhcflurry"]`) to get one answer from all three.
 
 All three options are forwarded to `EvalContext`, which you can also build directly when you need the raw per-group Series:

--- a/tests/test_canonical_methods.py
+++ b/tests/test_canonical_methods.py
@@ -1,0 +1,146 @@
+"""Opt-in canonical method resolution (topiary #193).
+
+An unqualified reference to a kind produced by several models raises, which is
+right — silently choosing a model is not something topiary should do behind a
+caller's back. But there was no supported way to say "pick the canonical one",
+so every consumer wrote its own preference table, and two tools could disagree
+about what canonical means with nothing surfacing the difference.
+"""
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    CANONICAL_METHOD_PREFERENCE,
+    apply_filter,
+    evaluate_scores,
+    resolve_default_methods,
+    validate_default_methods,
+)
+from topiary.ranking import parse
+
+
+def _row(kind, method, value=100.0, score=0.5):
+    return dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+                allele="HLA-A*02:01", kind=kind, value=value, score=score,
+                percentile_rank=1.0, prediction_method_name=method)
+
+
+def _two_model_df():
+    return pd.DataFrame([
+        _row("pMHC_affinity", "netmhcpan", value=50.0),
+        _row("pMHC_affinity", "mhcflurry", value=900.0),
+        _row("pMHC_stability", "netmhcstabpan", value=3.0),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# What it resolves
+# ---------------------------------------------------------------------------
+
+
+def test_only_kinds_with_a_real_choice_are_resolved():
+    """A kind with one model needs no default; saying so would be noise."""
+    resolved = resolve_default_methods(_two_model_df())
+
+    assert resolved == {"pMHC_affinity": "mhcflurry"}
+
+
+def test_the_result_unblocks_an_unqualified_reference():
+    df = _two_model_df()
+
+    with pytest.raises(ValueError, match="Ambiguous"):
+        evaluate_scores(df, parse("affinity.value"))
+
+    scores = evaluate_scores(
+        df, parse("affinity.value"), default_methods=resolve_default_methods(df),
+    )
+    assert scores.tolist()[0] == 900.0
+
+
+def test_a_filter_was_never_blocked_and_still_is_not():
+    """Filters auto-aggregate across models; only sorting and scoring raise."""
+    df = _two_model_df()
+
+    assert len(apply_filter(df, parse("affinity <= 500"))) > 0
+
+
+def test_resolution_is_deterministic_for_unlisted_models():
+    df = pd.DataFrame([
+        _row("pMHC_affinity", "zebra-predictor"),
+        _row("pMHC_affinity", "aardvark-predictor"),
+    ])
+
+    assert resolve_default_methods(df) == {
+        "pMHC_affinity": "aardvark-predictor",
+    }
+
+
+def test_a_listed_model_beats_an_unlisted_one():
+    df = pd.DataFrame([
+        _row("pMHC_affinity", "aardvark-predictor"),
+        _row("pMHC_affinity", "netmhcpan"),
+    ])
+
+    assert resolve_default_methods(df) == {"pMHC_affinity": "netmhcpan"}
+
+
+def test_the_preference_order_is_overridable():
+    df = _two_model_df()
+
+    resolved = resolve_default_methods(df, preference=("netmhcpan",))
+
+    assert resolved == {"pMHC_affinity": "netmhcpan"}
+
+
+def test_the_shipped_order_prefers_general_predictors():
+    """Documented as a tie-break convention, not a quality ranking."""
+    assert CANONICAL_METHOD_PREFERENCE.index("netmhcpan") < (
+        CANONICAL_METHOD_PREFERENCE.index("netmhcstabpan")
+    )
+
+
+@pytest.mark.parametrize("df", [
+    None,
+    pd.DataFrame(),
+    pd.DataFrame([{"peptide": "SIINFEKLA"}]),
+])
+def test_a_frame_with_nothing_to_resolve_gives_nothing(df):
+    assert resolve_default_methods(df) == {}
+
+
+# ---------------------------------------------------------------------------
+# Validation: an entry that names something the frame doesn't have
+# ---------------------------------------------------------------------------
+
+
+def test_a_model_absent_from_the_frame_is_reported():
+    """Otherwise it sits inert until the day the kind becomes ambiguous."""
+    df = _two_model_df()
+
+    with pytest.raises(ValueError, match="netmhcpan-typo"):
+        validate_default_methods(df, {"pMHC_affinity": "netmhcpan-typo"})
+
+
+def test_an_unknown_kind_is_reported():
+    with pytest.raises(ValueError, match="not a known kind"):
+        validate_default_methods(_two_model_df(), {"banana": "mhcflurry"})
+
+
+def test_a_kind_absent_from_the_frame_is_not_an_error():
+    """A pipeline-wide default may cover kinds this frame doesn't carry."""
+    df = pd.DataFrame([_row("pMHC_affinity", "mhcflurry")])
+
+    validate_default_methods(df, {"pMHC_stability": "netmhcstabpan"})
+
+
+def test_short_names_and_aliases_are_accepted():
+    df = _two_model_df()
+
+    validate_default_methods(df, {"affinity": "mhcflurry"})
+
+
+def test_what_resolve_returns_always_validates():
+    df = _two_model_df()
+
+    validate_default_methods(df, resolve_default_methods(df))

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -16,9 +16,12 @@ from .ranking import (
     Includes,
     IsIn,
     KIND_ALIASES,
+    CANONICAL_METHOD_PREFERENCE,
     KIND_MHC_DEPENDENCE,
     MHC_DEPENDENCE_VALUES,
     mhc_dependence,
+    resolve_default_methods,
+    validate_default_methods,
     KindAccessor,
     Len,
     LogisticExpr,
@@ -83,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.23.0"
+__version__ = "5.24.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -105,9 +108,12 @@ __all__ = [
     "Includes",
     "IsIn",
     "KIND_ALIASES",
+    "CANONICAL_METHOD_PREFERENCE",
     "KIND_MHC_DEPENDENCE",
     "MHC_DEPENDENCE_VALUES",
     "mhc_dependence",
+    "resolve_default_methods",
+    "validate_default_methods",
     "KindAccessor",
     "Len",
     "LogisticExpr",

--- a/topiary/ranking/__init__.py
+++ b/topiary/ranking/__init__.py
@@ -49,9 +49,12 @@ from .nodes import (
     _GROUP_KEYS_VARIANT,
     _iter_known_kinds,
     KIND_ALIASES,
+    CANONICAL_METHOD_PREFERENCE,
     KIND_MHC_DEPENDENCE,
     MHC_DEPENDENCE_VALUES,
     mhc_dependence,
+    resolve_default_methods,
+    validate_default_methods,
     _kind_matches,
     _kind_name,
     _kind_short_name,
@@ -131,7 +134,10 @@ __all__ = [
     "peptide_view",
     # Kind / field name resolution (public)
     "KIND_ALIASES",
+    "CANONICAL_METHOD_PREFERENCE",
     "KIND_MHC_DEPENDENCE",
     "MHC_DEPENDENCE_VALUES",
     "mhc_dependence",
+    "resolve_default_methods",
+    "validate_default_methods",
 ]

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -355,6 +355,91 @@ def _normalize_alleles(alleles):
     return declared
 
 
+#: Order used to pick one model when a kind has several and the caller
+#: hasn't said which.  This is a **tie-break convention, not a quality
+#: ranking** — topiary is not asserting that one predictor is better
+#: than another.  It orders general-purpose predictors ahead of ones
+#: whose output for a kind is secondary to their main job (NetMHCstabPan
+#: predicts stability; its affinity comes along with it), and mode
+#: variants after the model they vary.  Anything unlisted sorts
+#: alphabetically after these, so the answer is always deterministic.
+#:
+#: Callers who care which model answers should qualify the reference —
+#: ``Affinity["netmhcpan"]`` — or pass their own *preference*.
+CANONICAL_METHOD_PREFERENCE = (
+    "mhcflurry",
+    "netmhcpan",
+    "netmhcpan_ba",
+    "netmhcpan_el",
+    "netmhcstabpan",
+)
+
+
+def resolve_default_methods(df, preference=None):
+    """Pick one ``prediction_method_name`` per kind that has several.
+
+    Unqualified references raise when a kind was produced by more than
+    one model, which is the right default — silently choosing a model is
+    not something topiary should do behind a caller's back.  This is the
+    explicit way to say "pick the canonical one", so consumers stop
+    writing their own preference table and disagreeing with each other
+    about what canonical means.
+
+    Kinds with a single model are omitted: the result only speaks where
+    there is a real choice.  Returns a mapping suitable for
+    ``default_methods=``.
+
+    *preference* overrides :data:`CANONICAL_METHOD_PREFERENCE`.
+    """
+    if df is None or df.empty:
+        return {}
+    needed = {"kind", "prediction_method_name"}
+    if not needed.issubset(df.columns):
+        return {}
+    order = list(CANONICAL_METHOD_PREFERENCE if preference is None else preference)
+    rank = {name.lower(): i for i, name in enumerate(order)}
+
+    resolved = {}
+    for kind_value, group in df.groupby("kind", sort=False, dropna=True):
+        methods = sorted({
+            str(m) for m in group["prediction_method_name"].dropna().unique()
+        })
+        if len(methods) < 2:
+            continue
+        resolved[str(kind_value)] = min(
+            methods, key=lambda m: (rank.get(m.lower(), len(order)), m.lower()),
+        )
+    return resolved
+
+
+def validate_default_methods(df, default_methods):
+    """Raise if *default_methods* names a kind or model *df* doesn't have.
+
+    ``EvalContext`` only consults a default when a kind is actually
+    ambiguous, so an entry naming a model that never ran is otherwise
+    silently inert — and stays inert until the day two models do produce
+    that kind, when it starts deciding.  Checking up front turns a typo
+    in a config file into an error at the point it was written.
+    """
+    if not default_methods:
+        return
+    normalized = _normalize_default_methods(default_methods)
+    if df is None or df.empty or "kind" not in df.columns:
+        return
+    if "prediction_method_name" not in df.columns:
+        return
+    for kind_value, method in normalized.items():
+        rows = df[df["kind"] == kind_value]
+        if rows.empty:
+            continue
+        available = sorted({
+            str(m) for m in rows["prediction_method_name"].dropna().unique()
+        })
+        lowered = method.lower()
+        if not any(lowered in name.lower() for name in available):
+            raise _method_not_found_error(kind_value, method, available)
+
+
 def _normalize_default_methods(mapping):
     """Canonicalize ``default_methods`` keys to DataFrame ``kind`` values.
 


### PR DESCRIPTION
Closes #193. Fourth of the series.

## What it adds

```python
from topiary import resolve_default_methods, validate_default_methods

defaults = resolve_default_methods(df)   # {"pMHC_affinity": "mhcflurry"}
evaluate_scores(df, node, default_methods=defaults)

validate_default_methods(df, user_supplied)   # catches a typo at config time
```

The strictness stays: an unqualified reference to a kind produced by several
models still raises, because silently choosing a model behind a caller's back is
the failure class this repo keeps removing. What was missing is a supported way
to say *pick the canonical one*, so every consumer wrote its own preference
table — and two tools could disagree about what canonical means with nothing
surfacing the difference.

## The judgment call, and how I kept it small

Ordering predictors invites a scientific claim topiary shouldn't make: MHCflurry
2.0 and NetMHCpan 4.1 are comparable, with different strengths, and a benchmark
argument doesn't belong in a tie-break. So `CANONICAL_METHOD_PREFERENCE` is
documented as a **tie-break convention, not a quality ranking**, and its
rationale avoids quality entirely:

- general-purpose predictors ahead of ones whose output for a kind is secondary
  to their main job (NetMHCstabPan predicts stability; its affinity comes along
  with it)
- mode variants after the model they vary (`netmhcpan_ba`, `netmhcpan_el`)
- anything unlisted alphabetically after those, so the answer is deterministic

Callers who care which model answers should qualify the reference or pass
`preference=`.

**The shipped order matches the convention already in use downstream**, so
adopting this changes no existing scores — a silent rescoring on adoption would
have made the deduplication worse than the duplication.

## The validator is not decoration

`EvalContext` consults a default only when a kind is *actually* ambiguous, so an
entry naming a model that never ran is inert — and stays inert until the day two
models produce that kind, when it quietly starts deciding.
`validate_default_methods` turns that into an error where the config was
written. A kind absent from the frame is not an error, since a pipeline-wide
default may legitimately cover kinds a given frame doesn't carry.

## Tests

15 in `tests/test_canonical_methods.py`, including one worth naming: filters
were *never* blocked by the ambiguity — `apply_filter` auto-aggregates across
models, so only sorting and scoring ever raised. That asymmetry is now pinned,
because it is the thing most likely to confuse someone reading the error.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1773 passed, 3 skipped

Version 5.24.0, assuming #199 (5.22.1) and #198 (5.23.0) land first; will rebase
if that order changes.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG