### PR TITLE
Add from_predictions() to build the long form without copying the schema (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 5.25.0
+
+**`from_predictions()` — build the long form without copying the schema
+(#194):**
+
+```python
+from topiary import from_predictions
+
+df = from_predictions(predictions)                        # Prediction objects
+df = from_predictions(model.predict_dataframe(peptides))  # or mhctools' rows
+
+df = from_predictions(
+    predictions,
+    allele_set={"pMHC_presentation": patient_alleles},    # genotype-level kinds
+)
+```
+
+A caller holding `mhctools.Prediction` objects — a report reader, a
+cache, anything that didn't run a `TopiaryPredictor` end to end — had to
+write topiary's long form by hand: the column names, the `kind` strings,
+the value / affinity / score / percentile_rank mapping, and the
+provenance columns. That is a copy of the schema topiary cannot see and
+cannot migrate, so a column added here never reaches it. `allele_set`
+(5.21.0) is the live example.
+
+The normalization is now one function, shared by `from_predictions` and
+by `TopiaryPredictor`'s own output, so the two paths cannot diverge.
+`allele_set` takes a sequence (applies to every row) or a
+`{kind: alleles}` mapping, which is what a mixed list of per-allele and
+genotype-level predictions needs.
+
+An empty input returns an empty frame **in topiary's vocabulary** rather
+than mhctools' — a caller that got `offset` and `predictor_name` back
+from an empty result would break on the frame's shape, not on its
+emptiness.
+
 ## 5.24.0
 
 **Opt-in canonical method resolution (#193):**
@@ -35,6 +71,7 @@ otherwise inert — and stays inert until the day two models produce that
 kind, when it starts deciding. Checking up front turns a typo in a
 config file into an error where it was written.
 
+
 ## 5.23.0
 
 **Scoped fields work in filters (#192):**
@@ -62,6 +99,7 @@ column a producer never wrote makes the expression NaN for every group,
 and NaN in a filter drops the frame. A filter reading a scope the frame
 doesn't carry now warns, naming the missing column. Outside a filter
 NaN is a sensible answer, so ranking and scoring are unaffected.
+
 
 ## 5.22.1
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,6 +255,24 @@ mean(Affinity["netmhcpan"].logistic(350, 150),
 minimum(Affinity["netmhcpan"].value, Affinity["mhcflurry"].value)
 ```
 
+## Building the long form
+
+Callers holding `mhctools.Prediction` objects — a report reader, a cache, anything that didn't run a `TopiaryPredictor` end to end — should build the frame with `from_predictions` rather than by hand:
+
+```python
+from topiary import from_predictions
+
+df = from_predictions(predictions)                       # Prediction objects
+df = from_predictions(model.predict_dataframe(peptides)) # or mhctools' own rows
+
+df = from_predictions(
+    predictions,
+    allele_set={"pMHC_presentation": patient_alleles},   # genotype-level kinds
+)
+```
+
+It renames to topiary's column vocabulary, fills the context columns a producer may not have set, derives `peptide_length`, and backfills `affinity` for affinity rows — the same normalization `TopiaryPredictor` applies to its own output, so both paths produce one long form. A hand-written builder is a copy of that schema topiary can't see and can't migrate: a column added here never reaches it.
+
 ## Filter expressions
 
 | Expression | Creates |

--- a/tests/test_from_predictions.py
+++ b/tests/test_from_predictions.py
@@ -1,0 +1,182 @@
+"""from_predictions(): building the long form without copying the schema.
+
+A consumer holding ``mhctools.Prediction`` objects — a report reader, a cache,
+anything that didn't run a TopiaryPredictor end to end — had to write topiary's
+long form by hand. That is a copy of the schema topiary can't see and can't
+migrate: a column added here silently never reaches it (topiary #194).
+"""
+
+import pandas as pd
+import pytest
+from mhctools.pred import Prediction
+
+from topiary import from_predictions
+from topiary.ranking import EvalContext, evaluate_scores, parse
+
+
+def _prediction(kind="pMHC_affinity", allele="HLA-A*02:01", value=50.0,
+                score=0.9, percentile_rank=0.5, peptide="SIINFEKLA", offset=3):
+    return Prediction(
+        kind=kind, peptide=peptide, allele=allele, value=value, score=score,
+        percentile_rank=percentile_rank, predictor_name="mhcflurry",
+        predictor_version="2.1.1", source_sequence_name="prot1", offset=offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The schema it produces
+# ---------------------------------------------------------------------------
+
+
+def test_it_speaks_topiarys_column_vocabulary():
+    df = from_predictions([_prediction()])
+
+    assert "peptide_offset" in df.columns and "offset" not in df.columns
+    assert "prediction_method_name" in df.columns
+    assert "predictor_name" not in df.columns
+
+
+def test_derived_columns_are_filled():
+    df = from_predictions([_prediction()])
+
+    row = df.iloc[0]
+    assert row["peptide_length"] == len("SIINFEKLA")
+    assert row["affinity"] == 50.0
+    assert row["peptide_offset"] == 3
+
+
+def test_affinity_is_only_backfilled_for_affinity_rows():
+    df = from_predictions([
+        _prediction(),
+        _prediction(kind="antigen_processing", allele="", value=None,
+                    score=0.77, percentile_rank=None),
+    ])
+
+    by_kind = dict(zip(df["kind"], df["affinity"]))
+    assert by_kind["pMHC_affinity"] == 50.0
+    assert pd.isna(by_kind["antigen_processing"])
+
+
+def test_the_result_evaluates_in_the_dsl():
+    """The point: what comes out is usable without further massaging."""
+    df = from_predictions([_prediction()])
+
+    assert evaluate_scores(df, parse("affinity.value")).tolist() == [50.0]
+    assert EvalContext(df).group_keys == [
+        "source_sequence_name", "peptide", "peptide_offset", "allele",
+    ]
+
+
+def test_a_frame_in_mhctools_shape_is_accepted_too():
+    """predict_dataframe() hands back rows, not Prediction objects."""
+    raw = pd.DataFrame([_prediction().to_row()])
+
+    df = from_predictions(raw)
+
+    assert df.iloc[0]["prediction_method_name"] == "mhcflurry"
+    assert df.iloc[0]["peptide_offset"] == 3
+
+
+def test_sample_name_is_written_through():
+    df = from_predictions([_prediction()], sample_name="tumor")
+
+    assert df["sample_name"].tolist() == ["tumor"]
+
+
+def test_an_empty_input_still_has_topiarys_shape():
+    """A caller that got mhctools' names back would break on the frame."""
+    df = from_predictions([])
+
+    assert len(df) == 0
+    for column in ("peptide_offset", "prediction_method_name",
+                   "peptide_length", "affinity"):
+        assert column in df.columns
+    assert "offset" not in df.columns and "predictor_name" not in df.columns
+
+
+# ---------------------------------------------------------------------------
+# allele_set — the column a hand-written builder would have missed
+# ---------------------------------------------------------------------------
+
+
+def test_a_sequence_applies_to_every_row():
+    df = from_predictions(
+        [_prediction(kind="pMHC_presentation")],
+        allele_set=["HLA-B*07:02", "HLA-A*02:01"],
+    )
+
+    # Sorted, so the same genotype compares equal however it was listed.
+    assert df["allele_set"].tolist() == ["HLA-A*02:01,HLA-B*07:02"]
+
+
+def test_a_mapping_applies_per_kind():
+    """A mixed list: presentation scored per genotype, affinity per allele."""
+    df = from_predictions(
+        [_prediction(), _prediction(kind="pMHC_presentation")],
+        allele_set={"pMHC_presentation": ["HLA-A*02:01", "HLA-B*07:02"]},
+    )
+
+    by_kind = dict(zip(df["kind"], df["allele_set"]))
+    assert by_kind["pMHC_presentation"] == "HLA-A*02:01,HLA-B*07:02"
+    assert by_kind["pMHC_affinity"] == ""
+
+
+def test_the_set_makes_the_frame_self_describing():
+    """What the column is for: it survives where kind_support cannot."""
+    df = from_predictions(
+        [_prediction(kind="pMHC_presentation", value=None, score=0.9)],
+        allele_set={"pMHC_presentation": ["HLA-A*02:01", "HLA-B*07:02"]},
+    )
+
+    assert "allele_set" in EvalContext(df).group_keys
+
+
+def test_no_allele_set_column_when_none_is_given():
+    df = from_predictions([_prediction()])
+
+    assert "allele_set" not in df.columns
+
+
+# ---------------------------------------------------------------------------
+# It agrees with what the predictor produces
+# ---------------------------------------------------------------------------
+
+
+def test_it_matches_the_predictors_own_normalization():
+    """One definition of the long form, shared by both paths."""
+    from mhctools import RandomBindingPredictor
+
+    from topiary import TopiaryPredictor
+
+    predictor = TopiaryPredictor(
+        models=[RandomBindingPredictor(["HLA-A*02:01"])],
+    )
+    result = predictor.predict_from_named_peptides({"pep1": "SIINFEKLA"})
+    predicted = result.df if hasattr(result, "df") else result
+
+    rebuilt = from_predictions(
+        pd.DataFrame([
+            {"peptide": row["peptide"], "allele": row["allele"],
+             "kind": row["kind"], "score": row["score"], "value": row["value"],
+             "percentile_rank": row["percentile_rank"],
+             "predictor_name": row["prediction_method_name"],
+             "predictor_version": row["predictor_version"],
+             "source_sequence_name": row["source_sequence_name"],
+             "offset": row["peptide_offset"], "sample_name": "",
+             "n_flank": "", "c_flank": "", "tcr": None}
+            for _, row in predicted.iterrows()
+        ])
+    )
+
+    shared = ["peptide", "allele", "kind", "peptide_offset", "peptide_length",
+              "prediction_method_name", "affinity"]
+    pd.testing.assert_frame_equal(
+        rebuilt[shared].reset_index(drop=True),
+        predicted[shared].reset_index(drop=True),
+    )
+
+
+@pytest.mark.parametrize("bad", [object(), 42])
+def test_a_non_prediction_input_fails_loudly(bad):
+    with pytest.raises((AttributeError, TypeError)):
+        from_predictions([bad])

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -1,4 +1,4 @@
-from .predictor import TopiaryPredictor
+from .predictor import TopiaryPredictor, from_predictions
 from .ranking import (
     self_nearest,
     Affinity,
@@ -86,10 +86,11 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.24.0"
+__version__ = "5.25.0"
 
 __all__ = [
     "TopiaryPredictor",
+    "from_predictions",
     "CachedPredictor",
     "mhcflurry_composite_version",
     "SelfProteome",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -12,6 +12,7 @@
 
 import logging
 from collections import Counter
+from collections.abc import Mapping
 
 import numpy as np
 import pandas as pd
@@ -32,6 +33,8 @@ from .ranking import (
     parse,
 )
 from .io import _model_version_str
+from mhctools.pred import COLUMNS as _PRED_COLUMNS
+
 from .protein_fragment import ProteinFragment
 from .sequence_helpers import (
     check_padding_around_mutation,
@@ -417,6 +420,106 @@ def _add_legacy_mutation_columns(df, fragments):
     intervals = tmp.apply(_interval, axis=1, result_type="expand")
     df["mutation_start_in_peptide"] = intervals[0]
     df["mutation_end_in_peptide"] = intervals[1]
+    return df
+
+
+#: mhctools' own row vocabulary, so an empty result still has the
+#: right shape without topiary restating the columns.
+_MHCTOOLS_COLUMNS = _PRED_COLUMNS
+
+
+def _normalize_prediction_frame(df):
+    """Put an mhctools prediction frame into topiary's long form.
+
+    Renames to topiary's column vocabulary, fills the context columns a
+    producer may not have set, derives ``peptide_length``, and backfills
+    ``affinity`` for affinity rows.  The single definition of what the
+    long form is, shared by the predictor and :func:`from_predictions`.
+    """
+    df = df.rename(columns={
+        "offset": "peptide_offset",
+        "predictor_name": "prediction_method_name",
+    }).copy()
+    if "source_sequence_name" not in df.columns:
+        df["source_sequence_name"] = None
+    if "peptide_offset" not in df.columns:
+        df["peptide_offset"] = 0
+    if df.empty:
+        # No rows to derive from, but the shape still has to be topiary's
+        # — a caller that got mhctools' column names back from an empty
+        # result would break on the frame, not on the emptiness.
+        for column in ("peptide_length", "affinity"):
+            if column not in df.columns:
+                df[column] = pd.Series(dtype=float)
+        return df
+    df["peptide_length"] = df["peptide"].str.len()
+    if "affinity" not in df.columns:
+        df["affinity"] = np.where(
+            df["kind"] == "pMHC_affinity", df["value"], np.nan
+        )
+    return _backfill_value_from_score(df)
+
+
+def from_predictions(predictions, *, sample_name="", allele_set=None):
+    """Build topiary's long-form frame from mhctools predictions.
+
+    For callers holding ``mhctools.Prediction`` objects — a report
+    reader, a cache, anything that didn't run a
+    :class:`TopiaryPredictor` end to end — rather than hand-writing the
+    schema.  A hand-written builder is a copy of topiary's long form
+    that topiary can't see and can't migrate: a column added here (
+    ``allele_set``, say) silently never reaches it.
+
+    Parameters
+    ----------
+    predictions : iterable of mhctools.Prediction, or DataFrame
+        Predictions, or a frame already in mhctools' row shape (what
+        ``predict_dataframe()`` returns).
+    sample_name : str
+        Written to every row.  Blank is normal for a single-sample run
+        and is not treated as identity.
+    allele_set : sequence or dict, optional
+        The genotype a prediction was scored against, for kinds where
+        that is the subject rather than the single ``allele`` on the row
+        (see ``allele_set`` in the docs).  A sequence applies to every
+        row; a ``{kind: alleles}`` mapping applies per kind, which is
+        what a mixed list of per-allele and genotype-level predictions
+        needs.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Long form: one row per prediction, ready for the ranking DSL and
+        for :func:`topiary.to_csv`.
+    """
+    if isinstance(predictions, pd.DataFrame):
+        raw = predictions.copy()
+    else:
+        rows = [p.to_row(sample_name) for p in predictions]
+        if not rows:
+            return _normalize_prediction_frame(
+                pd.DataFrame(columns=list(_MHCTOOLS_COLUMNS))
+            )
+        raw = pd.DataFrame(rows)
+
+    df = _normalize_prediction_frame(raw)
+    if df.empty or allele_set is None:
+        return df
+    return _attach_allele_sets(df, allele_set)
+
+
+def _attach_allele_sets(df, allele_set):
+    """Write ``allele_set`` from a sequence (all rows) or a per-kind map."""
+    df = df.copy()
+    if ALLELE_SET_COLUMN not in df.columns:
+        df[ALLELE_SET_COLUMN] = ""
+    if isinstance(allele_set, Mapping):
+        for kind, alleles in allele_set.items():
+            kind_value = _kind_value(kind)
+            formatted = format_allele_set(alleles)
+            df.loc[df["kind"] == kind_value, ALLELE_SET_COLUMN] = formatted
+    else:
+        df[ALLELE_SET_COLUMN] = format_allele_set(allele_set)
     return df
 
 
@@ -816,23 +919,7 @@ class TopiaryPredictor(object):
 
     def _format_prediction_df(self, df):
         """Normalize mhctools prediction output to Topiary's schema."""
-        if df.empty:
-            return df.copy()
-
-        df = df.rename(columns={
-            "offset": "peptide_offset",
-            "predictor_name": "prediction_method_name",
-        }).copy()
-        if "source_sequence_name" not in df.columns:
-            df["source_sequence_name"] = None
-        if "peptide_offset" not in df.columns:
-            df["peptide_offset"] = 0
-        df["peptide_length"] = df["peptide"].str.len()
-        if "affinity" not in df.columns:
-            df["affinity"] = np.where(
-                df["kind"] == "pMHC_affinity", df["value"], np.nan
-            )
-        return _backfill_value_from_score(df)
+        return _normalize_prediction_frame(df)
 
     def _apply_filter(self, df):
         """Apply filter and sort if configured."""


### PR DESCRIPTION
Closes #194. Fifth of the series.

## What it adds

```python
from topiary import from_predictions

df = from_predictions(predictions)                        # Prediction objects
df = from_predictions(model.predict_dataframe(peptides))  # or mhctools' rows

df = from_predictions(
    predictions,
    allele_set={"pMHC_presentation": patient_alleles},    # genotype-level kinds
)
```

## Why it belongs upstream

A caller holding `mhctools.Prediction` objects had to write topiary's long form
by hand — column names, `kind` strings, the value / affinity / score /
percentile_rank mapping, provenance columns. That is a copy of the schema
topiary cannot see and cannot migrate, so **a column added here never reaches
it**. `allele_set` (#189) is the live example: a hand-built frame doesn't get it
by upgrading.

The implementation is deliberately thin, and that's the argument for it living
here: mhctools' `to_row()` already knows the row shape, and
`TopiaryPredictor._format_prediction_df` already knows the normalization. This
extracts the second into a module-level function and composes the two, so
**neither shape is restated** and the predictor path and the builder path share
one definition. A test asserts the two produce identical frames for the same
predictions.

`allele_set` takes a sequence (every row) or a `{kind: alleles}` mapping — the
mapping is what a mixed list of per-allele and genotype-level predictions
actually needs, and it goes through `format_allele_set`, so the same genotype
compares equal however the caller listed it.

## One thing worth flagging

An empty input returns an empty frame **in topiary's vocabulary**. It previously
would have come back with mhctools' `offset` and `predictor_name`, because the
shared normalization returned early on empty before renaming. A caller that got
those names back from an empty result would break on the frame's shape rather
than on its emptiness — so the early return now happens after the renaming, and
only skips the row-wise derivations. This also affects `TopiaryPredictor`'s own
empty results, which is the same fix in the same place.

## Tests

14 in `tests/test_from_predictions.py`: the column vocabulary, derived columns,
affinity backfilled only for affinity rows, the result evaluating in the DSL
without further massaging, mhctools-shaped frames accepted, `sample_name`,
the empty-input shape, `allele_set` as sequence and as per-kind mapping, the
set making the frame self-describing, and agreement with the predictor's own
normalization.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1773 passed, 3 skipped

Version 5.25.0, assuming #198 (5.23.0) and #200 (5.24.0) land first.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG