### PR TITLE
Score the nearest self peptide at each row's own allele (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 5.26.0
+
+**`predict_self_nearest` — paired MHC binding for the nearest self
+peptide (#190):**
+
+```python
+TopiaryPredictor(
+    models=[...], alleles=[...],
+    self_proteome=SelfProteome.from_fasta(path),   # your reference
+    predict_self_nearest=True,
+)
+```
+
+`SelfProteome.nearest()` already said *which* healthy peptide a
+candidate resembles. Whether that peptide is presented by the same
+allele is a separate question, and it is the one a cross-reactivity
+judgement turns on: a near-identical self peptide the patient's MHC
+never presents is not the same risk as one it does.
+
+The flag runs a second prediction pass, as `predict_wt` does, scoring
+each `self_nearest_peptide` at its row's own allele and filling
+`self_nearest_value` / `_score` / `_percentile_rank`. The columns reach
+the DSL through the `self_nearest` scope, so an exclusion is expressible
+directly — and since 5.23.0 scoped fields work in filters, which is what
+an exclusion needs:
+
+```python
+apply_filter(df, (Affinity.value <= 500) & (self_nearest.Affinity.value >= 1000))
+```
+
+The reference proteome stays the caller's: `SelfProteome` takes a FASTA,
+a peptide mapping, or Ensembl with your own `cta_source` and
+`tissue_gene_ids`. Topiary computes the comparison, not the definition
+of self.
+
+**Known limitation.** The self peptide is scored without flanking
+context — it comes from the reference proteome, and `nearest()` reports
+its gene, transcript and offset but not the residues either side. Kinds
+that read flanks (antigen processing, and presentation where its model
+uses them) are scored on the peptide alone; affinity and stability are
+unaffected.
+
 ## 5.25.0
 
 **`from_predictions()` — build the long form without copying the schema

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -111,7 +111,11 @@ Germline takes precedence when populated; reference is the fallback. Both `None`
 
 For cross-reactivity filtering — "what's the closest peptide in essential healthy tissues, and does it also bind this MHC?"
 
-Topiary **does not compute** these — producers populate externally (via BLAST / edit distance against a healthy-tissue proteome with their own definition of "self"). The DSL scope just reads `self_nearest_*` columns. When columns are absent, `self_nearest.*` returns NaN.
+Topiary computes these when you give it a reference proteome: `TopiaryPredictor(self_proteome=..., predict_self_nearest=True)` fills the similarity columns from `SelfProteome.nearest()` and then scores each `self_nearest_peptide` at its row's own allele, filling `self_nearest_value` / `_score` / `_percentile_rank`. That second half is the one a cross-reactivity judgement turns on — a near-identical self peptide the patient's MHC never presents is not the same risk as one it does.
+
+The self peptide is scored **without flanking context**: it comes from the reference proteome, and `nearest()` reports its gene, transcript and offset but not the residues either side. Kinds that read flanks — antigen processing, and presentation where its model uses them — are therefore scored on the peptide alone; affinity and stability are unaffected.
+
+Without `predict_self_nearest`, or for producers populating externally (via BLAST / edit distance against a healthy-tissue proteome with their own definition of "self"). The DSL scope just reads `self_nearest_*` columns. When columns are absent, `self_nearest.*` returns NaN.
 
 Reserved column namespace:
 

--- a/tests/test_self_nearest_population.py
+++ b/tests/test_self_nearest_population.py
@@ -1,0 +1,167 @@
+"""Populating self_nearest_* including paired MHC binding (topiary #190).
+
+`SelfProteome.nearest()` says *which* healthy peptide a candidate resembles.
+Whether that peptide is presented by the same allele is a separate question,
+and it's the one a cross-reactivity judgement turns on: a near-identical self
+peptide the patient's MHC never presents is not the same risk as one it does.
+
+That second half needs a prediction pass wired into the predictor's own model
+and allele configuration, which is why it can't reasonably live downstream.
+"""
+
+import pandas as pd
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import SelfProteome, TopiaryPredictor, apply_filter, self_nearest
+from topiary.ranking import evaluate_scores, parse
+
+ALLELES = ["HLA-A*02:01", "HLA-B*07:02"]
+
+
+def _proteome():
+    """A healthy proteome holding SIINFEKLA, one substitution from our query."""
+    return SelfProteome.from_peptides(
+        {"SELF_PROT": "SIINFEKLLSIINFEKLA"}, peptide_lengths=[9],
+    )
+
+
+def _predict(predict_self_nearest, proteome=None, peptide="SIINFEKLK"):
+    predictor = TopiaryPredictor(
+        models=[RandomBindingPredictor(ALLELES)],
+        self_proteome=_proteome() if proteome is None else proteome,
+        predict_self_nearest=predict_self_nearest,
+    )
+    result = predictor.predict_from_named_peptides({"pep1": peptide})
+    return result.df if hasattr(result, "df") else result
+
+
+# ---------------------------------------------------------------------------
+# Opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_similarity_alone_is_the_default():
+    df = _predict(predict_self_nearest=False)
+
+    assert "self_nearest_peptide" in df.columns
+    assert "self_nearest_value" not in df.columns
+
+
+def test_the_flag_populates_the_binding_columns():
+    df = _predict(predict_self_nearest=True)
+
+    for column in ("self_nearest_value", "self_nearest_score",
+                   "self_nearest_percentile_rank"):
+        assert column in df.columns
+        assert df[column].notna().all()
+
+
+def test_without_a_proteome_the_columns_are_present_but_empty():
+    """Nothing to compare against; the shape stays predictable."""
+    predictor = TopiaryPredictor(
+        models=[RandomBindingPredictor(ALLELES)], predict_self_nearest=True,
+    )
+    result = predictor.predict_from_named_peptides({"pep1": "SIINFEKLK"})
+    df = result.df if hasattr(result, "df") else result
+
+    assert df["self_nearest_value"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# What the numbers mean
+# ---------------------------------------------------------------------------
+
+
+def test_the_binding_is_the_self_peptides_not_the_candidates():
+    df = _predict(predict_self_nearest=True)
+
+    # Different peptides, so different predictions — the column would be
+    # useless if it echoed the row's own value.
+    assert (df["self_nearest_value"] != df["value"]).all()
+
+
+def test_it_is_scored_at_each_row_s_own_allele():
+    """The point of the pass: presentation is allele-specific."""
+    df = _predict(predict_self_nearest=True)
+
+    by_allele = dict(zip(df["allele"], df["self_nearest_value"]))
+    assert set(by_allele) == set(ALLELES)
+    assert by_allele[ALLELES[0]] != by_allele[ALLELES[1]]
+
+
+def test_the_same_self_peptide_is_found_for_both_alleles():
+    df = _predict(predict_self_nearest=True)
+
+    assert df["self_nearest_peptide"].nunique() == 1
+    assert df["self_nearest_edit_distance"].tolist() == [1, 1]
+
+
+def test_a_peptide_length_the_model_cannot_score_is_skipped():
+    """8-mers here; the model only handles what it declares."""
+    proteome = SelfProteome.from_peptides(
+        {"SELF_PROT": "SIINFEKL"}, peptide_lengths=[8],
+    )
+    predictor = TopiaryPredictor(
+        models=[RandomBindingPredictor(ALLELES, default_peptide_lengths=[9])],
+        self_proteome=proteome, predict_self_nearest=True,
+    )
+    result = predictor.predict_from_named_peptides({"pep1": "SIINFEKLK"})
+    df = result.df if hasattr(result, "df") else result
+
+    # No 9-mer in the reference, so nothing to score and nothing invented.
+    assert df["self_nearest_value"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# It reaches the DSL, which is what a policy consumes
+# ---------------------------------------------------------------------------
+
+
+def test_the_scope_reads_the_populated_columns():
+    df = _predict(predict_self_nearest=True)
+
+    scores = evaluate_scores(df, self_nearest.Affinity.value)
+
+    assert scores.notna().all()
+    assert scores.tolist() == df["self_nearest_value"].tolist()
+
+
+def test_a_cross_reactivity_exclusion_runs_end_to_end():
+    """The shape of a safety rule, on a frame topiary populated itself."""
+    df = _predict(predict_self_nearest=True)
+    threshold = df["self_nearest_value"].min() + 1.0
+
+    kept = apply_filter(df, self_nearest.Affinity.value >= threshold)
+
+    # The allele whose self peptide binds strongly is excluded; the other
+    # survives.
+    assert len(kept) < len(df)
+    assert (kept["self_nearest_value"] >= threshold).all()
+
+
+def test_the_string_form_reaches_it_too():
+    df = _predict(predict_self_nearest=True)
+
+    assert evaluate_scores(
+        df, parse("self_nearest.affinity.value"),
+    ).notna().all()
+
+
+@pytest.mark.parametrize("column", [
+    "self_nearest_peptide", "self_nearest_edit_distance",
+    "self_nearest_gene_id", "self_nearest_transcript_id",
+])
+def test_the_similarity_columns_are_still_there(column):
+    df = _predict(predict_self_nearest=True)
+
+    assert column in df.columns
+    assert df[column].notna().all()
+
+
+def test_predictions_are_not_duplicated_by_the_join():
+    """A self peptide matching several rows must not multiply them."""
+    before = len(_predict(predict_self_nearest=False))
+    after = len(_predict(predict_self_nearest=True))
+
+    assert before == after == len(ALLELES)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.25.0"
+__version__ = "5.26.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -539,6 +539,7 @@ class TopiaryPredictor(object):
         mhc_model=None,
         mhc_models=None,
         self_proteome=None,
+        predict_self_nearest=False,
         predict_wt=False,
         name=None,
     ):
@@ -599,6 +600,13 @@ class TopiaryPredictor(object):
 
         mhc_model, mhc_models : legacy aliases for ``models``.
 
+        predict_self_nearest : bool
+            Score each ``self_nearest_peptide`` at its row's allele,
+            populating ``self_nearest_value`` / ``_score`` /
+            ``_percentile_rank``. Requires ``self_proteome``. The self
+            peptide is scored without flanking context — see
+            :meth:`_maybe_predict_self_nearest`.
+
         predict_wt : bool
             If True, run the configured MHC model(s) on each populated
             ``wt_peptide`` and attach ``wt_*`` prediction columns before
@@ -651,6 +659,7 @@ class TopiaryPredictor(object):
         self.only_novel_epitopes = only_novel_epitopes
         self.raise_on_error = raise_on_error
         self.self_proteome = self_proteome
+        self.predict_self_nearest = predict_self_nearest
         self.predict_wt = predict_wt
         if name is None:
             self.name = None
@@ -925,7 +934,9 @@ class TopiaryPredictor(object):
         """Apply filter and sort if configured."""
         if df.empty:
             return df
-        df = self._maybe_attach_self_nearest(df)
+        df = self._maybe_predict_self_nearest(
+            self._maybe_attach_self_nearest(df)
+        )
         # Forward the allele-mode metadata this predictor already owns:
         # without it, DSL nodes that dispatch on ``mhc_dependence``
         # (``peptide_view``, ``best_*``) fall back to guessing from the
@@ -953,6 +964,85 @@ class TopiaryPredictor(object):
         unique = df["peptide"].drop_duplicates().tolist()
         nearest = self.self_proteome.nearest(unique)
         return df.merge(nearest, on="peptide", how="left")
+
+    def _maybe_predict_self_nearest(self, df):
+        """Score each ``self_nearest_peptide`` at the row's own allele.
+
+        The similarity columns say *which* healthy peptide a candidate
+        resembles; this says whether that peptide is presented by the
+        same allele — which is the question a cross-reactivity judgement
+        actually turns on. A near-identical self peptide the patient's
+        MHC never presents is not the same risk as one it does.
+
+        Runs a second prediction pass, as ``predict_wt`` does, and joins
+        each result back to the mutant row it belongs to by allele,
+        kind, and predictor identity.
+
+        The self peptide is scored **without flanking context**: it
+        comes from the reference proteome, and ``nearest()`` reports its
+        gene, transcript and offset but not the residues either side.
+        Kinds that read flanks — antigen processing, and presentation
+        when its model uses them — are therefore scored on the peptide
+        alone. Affinity and stability are unaffected.
+        """
+        self_columns = (
+            "self_nearest_value", "self_nearest_score",
+            "self_nearest_percentile_rank",
+        )
+
+        def _ensure(out):
+            out = out.copy()
+            for column in self_columns:
+                if column not in out.columns:
+                    out[column] = np.nan
+            return out
+
+        if not self.predict_self_nearest or df.empty:
+            return df
+        if "self_nearest_peptide" not in df.columns:
+            return _ensure(df)
+
+        predicted = []
+        for model, model_key in zip(self.models, self._model_keys):
+            candidates = df
+            if _MODEL_KEY_COLUMN in df.columns:
+                candidates = df[df[_MODEL_KEY_COLUMN].eq(model_key)]
+            lengths = set(model.default_peptide_lengths)
+            peptides = sorted({
+                str(peptide)
+                for peptide in candidates["self_nearest_peptide"].dropna()
+                if len(str(peptide)) in lengths
+            })
+            if not peptides:
+                continue
+            if hasattr(model, "predict_dataframe"):
+                raw = model.predict_dataframe(peptides)
+            else:
+                raw = model.predict_peptides_dataframe(peptides)
+            if raw.empty:
+                continue
+            predicted.append(self._format_prediction_df(raw))
+
+        if not predicted:
+            return _ensure(df)
+
+        self_predictions = pd.concat(predicted, ignore_index=True)
+        join_keys = ["allele", "kind", "prediction_method_name",
+                     "predictor_version"]
+        available = [k for k in join_keys if k in self_predictions.columns
+                     and k in df.columns]
+        joined = self_predictions[
+            ["peptide", *available, "value", "score", "percentile_rank"]
+        ].rename(columns={
+            "peptide": "self_nearest_peptide",
+            "value": "self_nearest_value",
+            "score": "self_nearest_score",
+            "percentile_rank": "self_nearest_percentile_rank",
+        }).drop_duplicates(subset=["self_nearest_peptide", *available])
+
+        return _ensure(df.merge(
+            joined, on=["self_nearest_peptide", *available], how="left",
+        ))
 
     def _maybe_predict_wt_peptides(self, df, fragments=None):
         """Score populated ``wt_peptide`` values and attach ``wt_*``


### PR DESCRIPTION
Closes #190. Last of the series.

## What was missing

`SelfProteome.nearest()` (5.8.0) already filled the similarity columns, and
`TopiaryPredictor(self_proteome=...)` already joined them on. What did not
exist is the half a cross-reactivity judgement actually turns on: **is that self
peptide presented by the same allele?** A near-identical self peptide the
patient's MHC never presents is not the same risk as one it does.

```python
TopiaryPredictor(
    models=[...], alleles=[...],
    self_proteome=SelfProteome.from_fasta(path),
    predict_self_nearest=True,
)
```

Runs a second prediction pass — the same shape as `predict_wt` — scoring each
`self_nearest_peptide` at its row's own allele and filling
`self_nearest_value` / `_score` / `_percentile_rank`. Allele-specific, which is
the whole point:

```
  peptide      allele  self_nearest_peptide  self_nearest_value
SIINFEKLK HLA-A*02:01             SIINFEKLA              493.08
SIINFEKLK HLA-B*07:02             SIINFEKLA             5018.25
```

Same self peptide, two very different answers about whether it matters.

## The reference stays the caller's

`SelfProteome` takes a FASTA, a peptide mapping, or Ensembl with the caller's
own `cta_source` and `tissue_gene_ids`. Topiary computes the comparison, not the
definition of self — which is what lets a consumer that already has an authority
for tissue and CTA facts use this without inheriting a second opinion. That
separation is why #124 was split; the bundled-proteome half is not needed for
any of this.

## It closes the loop with the rest of the series

The columns reach the DSL through the `self_nearest` scope, and since #198
scoped fields work in filters — which is what an exclusion needs:

```python
apply_filter(df, (Affinity.value <= 500) & (self_nearest.Affinity.value >= 1000))
```

A test runs that end to end on a frame topiary populated itself, which is the
first time the two halves have been exercised together.

## Known limitation, stated rather than hidden

The self peptide is scored **without flanking context**. It comes from the
reference proteome, and `nearest()` reports its gene, transcript and offset but
not the residues either side, so there is nothing to supply. Kinds that read
flanks — antigen processing, and presentation where its model uses them — are
scored on the peptide alone; affinity and stability are unaffected. Documented
in `docs/fragments.md` and in the method's docstring.

## Tests

15 in `tests/test_self_nearest_population.py`, including the ones that would
catch a plausible-but-wrong implementation: the value differs from the row's own
prediction (a column echoing the candidate would be useless), it differs between
alleles for the same self peptide, a peptide length the model can't score yields
NaN rather than an invented number, and the join doesn't multiply rows.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1784 passed, 3 skipped

Version 5.26.0, assuming #200 (5.24.0) and #201 (5.25.0) land first.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG