### PR TITLE
Correct a false compatibility claim in the 5.24.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 5.26.1
+
+**Correction to the 5.24.0 notes.** They claimed the shipped
+`CANONICAL_METHOD_PREFERENCE` "matches the convention already in use
+downstream, so adopting this changes no existing scores." That was
+wrong, and the claim has been removed from the 5.24.0 entry.
+
+The orders differ in where `netmhcstabpan` sits:
+
+```
+topiary   mhcflurry, netmhcpan, netmhcpan_ba, netmhcpan_el, netmhcstabpan
+vaxrank   mhcflurry, netmhcpan, netmhcstabpan, netmhcpan_el, netmhcpan_ba
+```
+
+So a frame where two of those models produce the *same* kind resolves
+differently depending on which table was consulted — reachable for
+`pMHC_affinity`, where `netmhcpan_ba` predicts affinity directly while
+NetMHCstabPan's affinity is a by-product of predicting stability.
+Adopting topiary's table therefore does change that resolution for a
+consumer that had the other order.
+
+The order itself stands, on the rationale the docstring gives: a model
+whose output for a kind is secondary to its main job sorts after ones
+that predict it directly. What was wrong was asserting compatibility
+without checking it — the divergence is exactly the disagreement
+`resolve_default_methods` exists to end, and it was live between two
+tables while the notes said otherwise.
+
 ## 5.26.0
 
 **`predict_self_nearest` — paired MHC binding for the nearest self
@@ -103,8 +131,7 @@ predictors ahead of ones whose output for a kind is secondary to their
 main job (NetMHCstabPan predicts stability; its affinity comes along
 with it), mode variants after the model they vary, and anything unlisted
 alphabetically after those so the answer is always deterministic. Pass
-`preference=` to override it. The shipped order matches the convention
-already in use downstream, so adopting this changes no existing scores.
+`preference=` to override it.
 
 `validate_default_methods(df, default_methods)` reports an entry naming
 a kind or a model the frame doesn't have. `EvalContext` only consults a

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.26.0"
+__version__ = "5.26.1"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
Corrects a false claim in a published release note, found by the consumer it
was about.

The 5.24.0 entry said the shipped `CANONICAL_METHOD_PREFERENCE` "matches the
convention already in use downstream, so adopting this changes no existing
scores." It doesn't:

```
topiary   mhcflurry, netmhcpan, netmhcpan_ba, netmhcpan_el, netmhcstabpan
vaxrank   mhcflurry, netmhcpan, netmhcstabpan, netmhcpan_el, netmhcpan_ba
```

Same five names, different order. A frame where two of those models produce the
*same* kind resolves to a different model depending on which table is consulted
— reachable for `pMHC_affinity`, where `netmhcpan_ba` predicts affinity directly
while NetMHCstabPan's affinity is a by-product of predicting stability.

I had read that table earlier in the session, reordered it on a structural
rationale, and then asserted compatibility with it without re-checking. The
assertion was the error, not the ordering.

**The order stands.** The rationale in the docstring holds: a model whose output
for a kind is secondary to its main job sorts after ones that predict it
directly, so `netmhcpan_ba` belongs ahead of `netmhcstabpan` for affinity. What
changes is the note: adopting topiary's table *does* change that resolution for
a consumer that had the other order, and the release notes now say so instead
of the opposite.

Worth stating plainly: this is precisely the disagreement `resolve_default_methods`
was built to end — two tables, same names, different answers — and it was live
between them while the notes claimed it wasn't.

Version 5.26.1 (notes only; no behavior change).

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG