### PR TITLE
Let from_predictions carry consumer columns and per-peptide allele sets (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 5.27.0
+
+**`from_predictions()` can carry a consumer's own columns and per-peptide
+allele sets (#203):**
+
+```python
+df = from_predictions(
+    predictions,
+    extra_columns={"prediction_id": ids, "peptide_offset": offsets},
+    allele_set=lambda prediction: attribution_for(prediction),
+)
+```
+
+5.26.0's version could not express two things a real consumer needs, so
+adopting it would still have meant hand-writing the frame — which is
+what the function exists to stop.
+
+`extra_columns` carries identity a prediction doesn't itself have: a
+provenance key the consumer groups by rather than letting topiary infer
+from `source_sequence_name`, or an offset belonging to the candidate a
+peptide came from rather than to the prediction object. A scalar fills
+the column; a sequence is positional, one value per prediction, and a
+length mismatch is an error rather than a silent misalignment.
+
+`allele_set` now also takes a **callable**, receiving each prediction
+(or each row, for a DataFrame input) and returning its alleles or
+``None``. Per-kind was the wrong granularity for attribution decided per
+peptide, where two peptides in one frame legitimately get different sets
+for the same kind — and the alternative, one call per candidate, doesn't
+scale to a report with ~100k of them.
+
+The 1:1 input ordering is now **documented as part of the contract**,
+since positional data depends on it. It was already true; it wasn't
+promised.
+
 ## 5.26.1
 
 **Correction to the 5.24.0 notes.** They claimed the shipped
@@ -27,6 +62,7 @@ that predict it directly. What was wrong was asserting compatibility
 without checking it — the divergence is exactly the disagreement
 `resolve_default_methods` exists to end, and it was live between two
 tables while the notes said otherwise.
+
 
 ## 5.26.0
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -271,6 +271,18 @@ df = from_predictions(
 )
 ```
 
+Rows come back **in input order**, one per prediction, which is what lets positional data line up:
+
+```python
+df = from_predictions(
+    predictions,
+    extra_columns={"prediction_id": ids, "peptide_offset": offsets},
+    allele_set=lambda prediction: attribution_for(prediction),
+)
+```
+
+`extra_columns` carries identity a prediction doesn't itself have — a provenance key the consumer groups by, or an offset belonging to the candidate a peptide came from rather than to the prediction. A scalar fills the column; a sequence is positional and must match the input's length. `allele_set` also takes a callable, for attribution decided per peptide, where two peptides in one frame legitimately get different sets for the same kind.
+
 It renames to topiary's column vocabulary, fills the context columns a producer may not have set, derives `peptide_length`, and backfills `affinity` for affinity rows — the same normalization `TopiaryPredictor` applies to its own output, so both paths produce one long form. A hand-written builder is a copy of that schema topiary can't see and can't migrate: a column added here never reaches it.
 
 ## Filter expressions

--- a/tests/test_from_predictions.py
+++ b/tests/test_from_predictions.py
@@ -180,3 +180,129 @@ def test_it_matches_the_predictors_own_normalization():
 def test_a_non_prediction_input_fails_loudly(bad):
     with pytest.raises((AttributeError, TypeError)):
         from_predictions([bad])
+
+
+# ---------------------------------------------------------------------------
+# Carrying a consumer's own columns (topiary #203)
+# ---------------------------------------------------------------------------
+
+
+def _two():
+    return [
+        _prediction(peptide="SIINFEKLA", allele="HLA-A*02:01", value=50.0),
+        _prediction(peptide="ELAGIGILT", allele="HLA-B*07:02", value=900.0),
+    ]
+
+
+def test_a_sequence_is_positional_one_value_per_prediction():
+    """A consumer's group identity isn't on the Prediction object."""
+    df = from_predictions(
+        _two(), extra_columns={"prediction_id": ["variant-1", "variant-2"]},
+    )
+
+    assert df["prediction_id"].tolist() == ["variant-1", "variant-2"]
+
+
+def test_rows_come_back_in_input_order():
+    """The 1:1 ordering is the contract positional data relies on."""
+    df = from_predictions(_two())
+
+    assert df["peptide"].tolist() == ["SIINFEKLA", "ELAGIGILT"]
+
+
+def test_a_scalar_fills_the_column():
+    df = from_predictions(_two(), extra_columns={"source": "lens"})
+
+    assert df["source"].tolist() == ["lens", "lens"]
+
+
+def test_an_extra_column_can_replace_a_derived_one():
+    """A candidate's offset, not the prediction's."""
+    df = from_predictions(_two(), extra_columns={"peptide_offset": [10, 25]})
+
+    assert df["peptide_offset"].tolist() == [10, 25]
+
+
+def test_a_length_mismatch_is_rejected():
+    with pytest.raises(ValueError, match="one value per prediction"):
+        from_predictions(_two(), extra_columns={"prediction_id": ["only-one"]})
+
+
+def test_the_identity_reaches_the_group_keys():
+    """The reason the column has to be there at build time."""
+    from topiary.ranking import EvalContext
+
+    df = from_predictions(
+        _two(), extra_columns={"prediction_id": ["variant-1", "variant-2"]},
+    )
+    keys = ["prediction_id", "peptide", "peptide_offset", "allele"]
+
+    assert EvalContext(df, group_keys=keys).group_keys == keys
+
+
+def test_extra_columns_work_on_a_dataframe_input():
+    raw = pd.DataFrame([p.to_row() for p in _two()])
+
+    df = from_predictions(raw, extra_columns={"prediction_id": ["a", "b"]})
+
+    assert df["prediction_id"].tolist() == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Per-peptide allele sets
+# ---------------------------------------------------------------------------
+
+
+def test_a_callable_gives_each_prediction_its_own_set():
+    """Attribution decided per peptide, not per kind."""
+    policy = {
+        "SIINFEKLA": ["HLA-A*02:01"],
+        "ELAGIGILT": ["HLA-A*02:01", "HLA-B*07:02"],
+    }
+
+    df = from_predictions(_two(), allele_set=lambda p: policy.get(p.peptide))
+
+    assert df["allele_set"].tolist() == [
+        "HLA-A*02:01", "HLA-A*02:01,HLA-B*07:02",
+    ]
+
+
+def test_a_callable_returning_none_leaves_the_set_empty():
+    df = from_predictions(
+        _two(),
+        allele_set=lambda p: ["HLA-A*02:01"] if p.peptide == "SIINFEKLA" else None,
+    )
+
+    assert df["allele_set"].tolist() == ["HLA-A*02:01", ""]
+
+
+def test_a_callable_receives_rows_for_a_dataframe_input():
+    raw = pd.DataFrame([p.to_row() for p in _two()])
+
+    df = from_predictions(raw, allele_set=lambda row: [row["allele"]])
+
+    assert df["allele_set"].tolist() == ["HLA-A*02:01", "HLA-B*07:02"]
+
+
+def test_the_sequence_and_mapping_forms_still_work():
+    by_kind = from_predictions(
+        _two(), allele_set={"pMHC_affinity": ["HLA-B*07:02", "HLA-A*02:01"]},
+    )
+    flat = from_predictions(_two(), allele_set=["HLA-A*02:01"])
+
+    assert by_kind["allele_set"].tolist() == ["HLA-A*02:01,HLA-B*07:02"] * 2
+    assert flat["allele_set"].tolist() == ["HLA-A*02:01"] * 2
+
+
+def test_both_together_is_the_shape_a_consumer_needs():
+    """Own identity plus per-peptide attribution, in one call."""
+    df = from_predictions(
+        _two(),
+        extra_columns={"prediction_id": ["variant-1", "variant-2"],
+                       "peptide_offset": [10, 25]},
+        allele_set=lambda p: [p.allele],
+    )
+
+    assert df["prediction_id"].tolist() == ["variant-1", "variant-2"]
+    assert df["peptide_offset"].tolist() == [10, 25]
+    assert df["allele_set"].tolist() == ["HLA-A*02:01", "HLA-B*07:02"]

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.26.1"
+__version__ = "5.27.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -12,7 +12,7 @@
 
 import logging
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 import numpy as np
 import pandas as pd
@@ -460,7 +460,8 @@ def _normalize_prediction_frame(df):
     return _backfill_value_from_score(df)
 
 
-def from_predictions(predictions, *, sample_name="", allele_set=None):
+def from_predictions(predictions, *, sample_name="", allele_set=None,
+                     extra_columns=None):
     """Build topiary's long-form frame from mhctools predictions.
 
     For callers holding ``mhctools.Prediction`` objects — a report
@@ -478,42 +479,88 @@ def from_predictions(predictions, *, sample_name="", allele_set=None):
     sample_name : str
         Written to every row.  Blank is normal for a single-sample run
         and is not treated as identity.
-    allele_set : sequence or dict, optional
+    allele_set : sequence, dict, or callable, optional
         The genotype a prediction was scored against, for kinds where
         that is the subject rather than the single ``allele`` on the row
-        (see ``allele_set`` in the docs).  A sequence applies to every
-        row; a ``{kind: alleles}`` mapping applies per kind, which is
-        what a mixed list of per-allele and genotype-level predictions
-        needs.
+        (see ``allele_set`` in the docs).  Three forms:
+
+        - a **sequence** of allele names — applies to every row;
+        - a ``{kind: alleles}`` **mapping** — applies per kind, for a
+          mixed list of per-allele and genotype-level predictions;
+        - a **callable** taking one prediction (or one row, for a
+          DataFrame input) and returning its alleles, or ``None`` —
+          for attribution decided per peptide, where two peptides in
+          one frame legitimately get different sets for the same kind.
+    extra_columns : dict, optional
+        Columns to write alongside the schema, as ``{name: value}``.
+        A scalar fills the column; a sequence is taken positionally,
+        one entry per prediction, and must match the input's length.
+
+        This is for identity a prediction doesn't carry: a provenance
+        key the consumer groups by, or an offset that belongs to the
+        candidate a peptide came from rather than to the prediction
+        object.  Without it a caller with its own group identity would
+        still be hand-writing the frame, which is what this function
+        exists to stop.
 
     Returns
     -------
     pandas.DataFrame
-        Long form: one row per prediction, ready for the ranking DSL and
-        for :func:`topiary.to_csv`.
+        Long form: one row per prediction, **in input order**, ready for
+        the ranking DSL and for :func:`topiary.to_csv`.  The 1:1 order
+        is part of the contract, so positional data lines up.
     """
     if isinstance(predictions, pd.DataFrame):
-        raw = predictions.copy()
+        sources = [row for _, row in predictions.iterrows()]
+        raw = predictions.copy().reset_index(drop=True)
     else:
-        rows = [p.to_row(sample_name) for p in predictions]
+        sources = list(predictions)
+        rows = [p.to_row(sample_name) for p in sources]
         if not rows:
-            return _normalize_prediction_frame(
+            empty = _normalize_prediction_frame(
                 pd.DataFrame(columns=list(_MHCTOOLS_COLUMNS))
             )
+            return _attach_extra_columns(empty, extra_columns, sources)
         raw = pd.DataFrame(rows)
 
     df = _normalize_prediction_frame(raw)
+    df = _attach_extra_columns(df, extra_columns, sources)
     if df.empty or allele_set is None:
         return df
-    return _attach_allele_sets(df, allele_set)
+    return _attach_allele_sets(df, allele_set, sources)
 
 
-def _attach_allele_sets(df, allele_set):
-    """Write ``allele_set`` from a sequence (all rows) or a per-kind map."""
+def _attach_extra_columns(df, extra_columns, sources):
+    """Write caller-supplied columns, scalars or one value per prediction."""
+    if not extra_columns:
+        return df
+    df = df.copy()
+    for name, value in extra_columns.items():
+        if isinstance(value, str) or not isinstance(value, Iterable):
+            df[name] = value
+            continue
+        values = list(value)
+        if len(values) != len(sources):
+            raise ValueError(
+                f"extra_columns[{name!r}] has {len(values)} values for "
+                f"{len(sources)} prediction(s). A sequence is positional — "
+                f"one value per prediction, in input order — so the lengths "
+                f"have to match. Pass a scalar to fill the column instead."
+            )
+        df[name] = values
+    return df
+
+
+def _attach_allele_sets(df, allele_set, sources):
+    """Write ``allele_set``: per row, per kind, or one set for the frame."""
     df = df.copy()
     if ALLELE_SET_COLUMN not in df.columns:
         df[ALLELE_SET_COLUMN] = ""
-    if isinstance(allele_set, Mapping):
+    if callable(allele_set):
+        df[ALLELE_SET_COLUMN] = [
+            format_allele_set(allele_set(source) or ()) for source in sources
+        ]
+    elif isinstance(allele_set, Mapping):
         for kind, alleles in allele_set.items():
             kind_value = _kind_value(kind)
             formatted = format_allele_set(alleles)


### PR DESCRIPTION
Closes #203. Follow-up to #201, from the consumer that tried to adopt it and
couldn't.

## What was missing

5.26.0's `from_predictions` could not express two things a real consumer needs,
so adopting it would still have meant hand-writing the frame — which is exactly
what the function exists to stop.

**1. A consumer's own identity columns.** vaxrank groups by an explicit
`prediction_id` rather than letting topiary infer from `source_sequence_name`,
and its `peptide_offset` belongs to the *candidate* a peptide came from, not to
the `mhctools.Prediction`. Neither can be read off the prediction objects.

```python
df = from_predictions(
    predictions,
    extra_columns={"prediction_id": ids, "peptide_offset": offsets},
)
```

A scalar fills the column; a sequence is positional, one value per prediction.
A length mismatch raises rather than misaligning silently.

**2. Per-peptide allele sets.** `allele_set` took a sequence or `{kind: alleles}`,
but attribution can be decided *per peptide*: two peptides in one frame
legitimately get different sets for the same kind. Per-kind was simply the wrong
granularity, and the workaround — one call per candidate — doesn't scale to a
report with ~100k of them.

```python
df = from_predictions(predictions, allele_set=lambda prediction: attribution_for(prediction))
```

A callable receives each prediction (or each row, for a DataFrame input) and
returns its alleles or `None`. The sequence and mapping forms are unchanged.

## The contract that makes positional data safe

The issue noted that a post-hoc `.assign()` would work "only if row order and
count were guaranteed to match the input sequence — which is not documented."
It was already true; it wasn't promised. It is now: **one row per prediction, in
input order**, stated in the docstring and in `docs/api.md`, and pinned by a
test.

## Tests

12 added (26 in the file): positional sequences, scalars, an extra column
replacing a derived one (`peptide_offset`), the length-mismatch error, the
identity reaching `group_keys`, extra columns on a DataFrame input, per-peptide
callables including one returning `None`, callables receiving rows for a
DataFrame input, the older forms still working, and both features together —
the shape a consumer actually needs.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1825 passed, 3 skipped

Version 5.27.0 (5.26.1 is the notes correction in #204).

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG