### PR TITLE
Key LENS binding columns on tool and metric, not on the version (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 5.28.0
+
+**Fixed: `read_lens` dropped a predictor whose version spelling it
+didn't know (#206).**
+
+A LENS binding column is named `<tool>_<version>.<metric>`, and the
+mapping table was keyed on the whole name. `netmhcpan_4.1b.aff_nm`
+mapped; `netmhcpan_4.1.aff_nm` passed through verbatim, so that
+predictor's entire affinity axis was absent from the normalized frame —
+with nothing raised. A consumer reading normalized names could not tell
+"this tool emitted nothing" from "this tool emitted something under a
+version I don't recognize".
+
+`aff_nm` is an IC50 whichever NetMHCpan produced it, so the table is now
+keyed on `(tool, metric)` and the version is *recorded* — in
+`Metadata.models`, where it already was — rather than matched. A new
+predictor release needs no change here. Version detection had the same
+brittleness for its NetMHCstabPan marker and got the same treatment.
+
+**A column topiary doesn't recognize is now reported.** One that looks
+like predictor output but names an unknown tool or metric warns, naming
+the column. Its values stay in the frame under the original name —
+nothing is discarded — but the silence was the part that made this
+expensive to find.
+
+**Correction to the 5.27.0 notes.** They described the `allele_set`
+callable as serving "attribution decided per peptide". It doesn't.
+`allele_set` declares *the genotype a prediction was scored against*, and
+a peptide-level score is then projected to every allele group present —
+so naming one allele does not withhold the score from the others.
+Attributing a peptide-level score to some alleles and not others is a
+different operation, and one topiary does not provide. The callable is
+still useful for its actual purpose: per-prediction genotype
+declaration, where different predictions in one frame were scored
+against different allele sets.
+
 ## 5.27.0
 
 **`from_predictions()` can carry a consumer's own columns and per-peptide

--- a/tests/test_lens_versions.py
+++ b/tests/test_lens_versions.py
@@ -1,0 +1,141 @@
+"""read_lens must not hinge on a predictor's version spelling (topiary #206).
+
+A LENS binding column is named `<tool>_<version>.<metric>`. The mapping table
+was keyed on the whole name, so a version topiary hadn't seen passed through
+unmapped — and a consumer reading normalized names cannot tell "this tool
+emitted nothing" from "this tool emitted something I don't recognize". The
+predictor's entire axis just wasn't there.
+
+`aff_nm` is an IC50 whichever NetMHCpan produced it, so the table is keyed on
+(tool, metric) and the version is recorded instead.
+"""
+
+import pathlib
+import warnings
+
+import pytest
+
+from topiary import read_lens
+from topiary.io_lens import detect_lens_version
+
+FIXTURE = pathlib.Path(__file__).parent / "data" / "lens" / "sample_v1_4.tsv"
+
+BINDING_COLUMNS = (
+    "netmhcpan_presentation_score", "netmhcpan_presentation_rank",
+    "netmhcpan_affinity_score", "netmhcpan_affinity_rank",
+    "netmhcpan_affinity_value", "mhcflurry_affinity_value",
+    "mhcflurry_affinity_rank", "mhcflurry_antigen_processing_score",
+    "mhcflurry_presentation_score", "mhcflurry_presentation_rank",
+    "netmhcstabpan_stability_score", "netmhcstabpan_stability_value",
+    "netmhcstabpan_stability_rank",
+)
+
+
+def _respun(tmp_path, *substitutions):
+    """The real fixture with its version segments rewritten."""
+    text = FIXTURE.read_text()
+    for old, new in substitutions:
+        text = text.replace(old, new)
+    path = tmp_path / "lens.tsv"
+    path.write_text(text)
+    return path
+
+
+def _frame(result):
+    return result.df if hasattr(result, "df") else result
+
+
+@pytest.mark.parametrize("substitution", [
+    (),
+    (("netmhcpan_4.1b.", "netmhcpan_4.1."),),
+    (("netmhcpan_4.1b.", "netmhcpan_4.2."),),
+    (("mhcflurry_2.1.1.", "mhcflurry_3.0."),),
+    (("netmhcstabpan_1.0.", "netmhcstabpan_1.1."),),
+    (("netmhcpan_4.1b.", "netmhcpan_5."),
+     ("mhcflurry_2.1.1.", "mhcflurry_2.2.0."),),
+])
+def test_every_binding_column_maps_whatever_the_version(tmp_path, substitution):
+    df = _frame(read_lens(_respun(tmp_path, *substitution)))
+
+    missing = [c for c in BINDING_COLUMNS if c not in df.columns]
+    assert not missing
+
+
+def test_the_version_is_recorded_rather_than_matched(tmp_path):
+    result = read_lens(_respun(tmp_path, ("netmhcpan_4.1b.", "netmhcpan_4.2.")))
+
+    assert result.metadata.models["netmhcpan"] == "4.2"
+
+
+def test_values_are_unchanged_by_the_version_spelling(tmp_path):
+    """Same file, different version segment: identical numbers."""
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+
+    original = _frame(read_lens(_respun(first)))
+    respun = _frame(read_lens(
+        _respun(second, ("netmhcpan_4.1b.", "netmhcpan_4.9.")),
+    ))
+
+    for column in BINDING_COLUMNS:
+        assert original[column].equals(respun[column]), column
+
+
+# ---------------------------------------------------------------------------
+# What topiary doesn't know, it says
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_tool_is_reported_not_dropped(tmp_path):
+    path = _respun(tmp_path, ("netmhcpan_4.1b.aff_nm", "brandnewtool_1.0.aff_nm"))
+
+    with pytest.warns(UserWarning, match="brandnewtool_1.0.aff_nm"):
+        df = _frame(read_lens(path))
+
+    # Still in the frame under its own name — reported, not discarded.
+    assert "brandnewtool_1.0.aff_nm" in df.columns
+
+
+def test_an_unknown_metric_is_reported(tmp_path):
+    path = _respun(tmp_path, ("netmhcpan_4.1b.aff_nm", "netmhcpan_4.1b.brand_new"))
+
+    with pytest.warns(UserWarning, match="netmhcpan_4.1b.brand_new"):
+        read_lens(path)
+
+
+def test_a_known_file_says_nothing(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        read_lens(_respun(tmp_path))
+
+
+def test_non_predictor_columns_are_not_reported(tmp_path):
+    """Ordinary annotation columns aren't predictor-shaped."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        read_lens(_respun(tmp_path))
+
+    assert not [w for w in caught if "predictor output" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# Version detection has the same brittleness, and the same fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", ["1.0", "1.1", "2.0"])
+def test_v1_4_is_detected_whatever_netmhcstabpan_version(version):
+    columns = [f"netmhcstabpan_{version}.stab_pred_score", "peptide", "allele"]
+
+    assert detect_lens_version(columns) == "v1.4"
+
+
+def test_later_versions_still_detect_by_their_own_markers():
+    assert detect_lens_version(["lohhla_allele_loss_pval"]) == "v1.9"
+    assert detect_lens_version(["snaf_exp"]) == "v1.5.1"
+
+
+def test_an_unrecognizable_file_is_still_none():
+    assert detect_lens_version(["peptide", "allele"]) is None

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.27.0"
+__version__ = "5.28.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -50,24 +50,55 @@ logger = logging.getLogger(__name__)
 # the emitted Topiary wide-form column name uses just ``{model}_{kind}_{field}``
 # (no version), matching the convention of ``to_wide`` / ``from_wide`` when
 # there is no multi-version collision within a single file.
-_BINDING_MAP = {
-    # NetMHCpan 4.1b (present in v1.4, v1.5.1; absent in v1.9)
-    "netmhcpan_4.1b.aff_nm":       ("netmhcpan",     "4.1b",  "affinity",     "value"),
-    "netmhcpan_4.1b.score_ba":     ("netmhcpan",     "4.1b",  "affinity",     "score"),
-    "netmhcpan_4.1b.perc_rank_ba": ("netmhcpan",     "4.1b",  "affinity",     "rank"),
-    "netmhcpan_4.1b.score_el":     ("netmhcpan",     "4.1b",  "presentation", "score"),
-    "netmhcpan_4.1b.perc_rank_el": ("netmhcpan",     "4.1b",  "presentation", "rank"),
-    # MHCflurry 2.1.1 (present in all three versions)
-    "mhcflurry_2.1.1.aff":         ("mhcflurry",     "2.1.1", "affinity",     "value"),
-    "mhcflurry_2.1.1.aff_perc":    ("mhcflurry",     "2.1.1", "affinity",     "rank"),
-    "mhcflurry_2.1.1.proc_score":  ("mhcflurry",     "2.1.1", "antigen_processing", "score"),
-    "mhcflurry_2.1.1.pres_score":  ("mhcflurry",     "2.1.1", "presentation", "score"),
-    "mhcflurry_2.1.1.pres_perc":   ("mhcflurry",     "2.1.1", "presentation", "rank"),
-    # NetMHCstabpan 1.0 (v1.4 only)
-    "netmhcstabpan_1.0.stab_pred_score": ("netmhcstabpan", "1.0", "stability", "score"),
-    "netmhcstabpan_1.0.halflife_hours":  ("netmhcstabpan", "1.0", "stability", "value"),
-    "netmhcstabpan_1.0.perc_rank_stab":  ("netmhcstabpan", "1.0", "stability", "rank"),
+#: LENS names a binding column ``<tool>_<version>.<metric>``. The
+#: version is opaque: ``aff_nm`` is an IC50 whether NetMHCpan 4.1, 4.1b
+#: or 4.2 produced it. Keying the table on the version too meant a
+#: spelling topiary had not seen dropped that predictor's whole axis
+#: from the frame, with nothing raised — so the table is keyed on what
+#: determines meaning, and the version is recorded rather than matched.
+_BINDING_METRICS = {
+    ("netmhcpan", "aff_nm"):              ("affinity",           "value"),
+    ("netmhcpan", "score_ba"):            ("affinity",           "score"),
+    ("netmhcpan", "perc_rank_ba"):        ("affinity",           "rank"),
+    ("netmhcpan", "score_el"):            ("presentation",       "score"),
+    ("netmhcpan", "perc_rank_el"):        ("presentation",       "rank"),
+    ("mhcflurry", "aff"):                 ("affinity",           "value"),
+    ("mhcflurry", "aff_perc"):            ("affinity",           "rank"),
+    ("mhcflurry", "proc_score"):          ("antigen_processing", "score"),
+    ("mhcflurry", "pres_score"):          ("presentation",       "score"),
+    ("mhcflurry", "pres_perc"):           ("presentation",       "rank"),
+    ("netmhcstabpan", "stab_pred_score"): ("stability",          "score"),
+    ("netmhcstabpan", "halflife_hours"):  ("stability",          "value"),
+    ("netmhcstabpan", "perc_rank_stab"):  ("stability",          "rank"),
 }
+
+#: ``<tool>_<version>.<metric>`` — the shape of a LENS binding column.
+#: A column matching this that the table doesn't cover is a predictor
+#: topiary hasn't met, which is worth saying out loud rather than
+#: leaving as an absence.
+_BINDING_COLUMN = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
+
+
+def _parse_binding_column(column):
+    """``(tool, version, kind, field)`` for a LENS binding column.
+
+    Returns ``None`` when the column isn't predictor-shaped at all, and
+    ``(tool, version, None, None)`` when it is but names a tool or
+    metric the table doesn't cover — the caller reports those rather
+    than dropping them silently.
+    """
+    if not isinstance(column, str):
+        return None
+    match = _BINDING_COLUMN.match(column)
+    if match is None:
+        return None
+    tool, version, metric = match.groups()
+    spec = _BINDING_METRICS.get((tool.lower(), metric.lower()))
+    if spec is None:
+        return tool.lower(), version, None, None
+    kind, field = spec
+    return tool.lower(), version, kind, field
+
 
 # LENS metadata column → Topiary column (pass-through rename).
 _ANNOTATION_RENAME = {
@@ -78,10 +109,16 @@ _ANNOTATION_RENAME = {
 }
 
 # Columns used by version detection.
+#: Columns used by version detection.  The v1.4 marker is expressed as
+#: a (tool, metric) pair for the same reason the binding table is: a
+#: NetMHCstabPan release topiary hasn't seen should not make a v1.4 file
+#: undetectable.
 _VERSION_MARKERS = [
     ("v1.9",   {"lohhla_allele_loss_pval"}),
     ("v1.5.1", {"snaf_exp"}),
-    ("v1.4",   {"netmhcstabpan_1.0.stab_pred_score"}),
+]
+_VERSION_MARKER_METRICS = [
+    ("v1.4", ("netmhcstabpan", "stab_pred_score")),
 ]
 
 
@@ -95,6 +132,16 @@ def detect_lens_version(columns) -> str | None:
     cols = set(columns)
     for version, markers in _VERSION_MARKERS:
         if markers <= cols:
+            return version
+    present = set()
+    for column in cols:
+        parsed = _parse_binding_column(column)
+        if parsed is not None:
+            tool, _, _, _ = parsed
+            match = _BINDING_COLUMN.match(column)
+            present.add((tool, match.group(3).lower()))
+    for version, marker in _VERSION_MARKER_METRICS:
+        if marker in present:
             return version
     return None
 
@@ -163,12 +210,27 @@ def _remap_binding_columns(df: pd.DataFrame):
     """
     rename = {}
     models = {}
-    for lens_col, (model, version, kind, field) in _BINDING_MAP.items():
-        if lens_col not in df.columns:
+    unmapped = []
+    for column in df.columns:
+        parsed = _parse_binding_column(column)
+        if parsed is None:
             continue
-        wide_col = f"{model}_{kind}_{field}"
-        rename[lens_col] = wide_col
+        model, version, kind, field = parsed
+        if kind is None:
+            unmapped.append(column)
+            continue
+        rename[column] = f"{model}_{kind}_{field}"
         models[model] = version
+    if unmapped:
+        import warnings
+        warnings.warn(
+            f"LENS binding column(s) {sorted(unmapped)} look like predictor "
+            f"output but name a tool or metric this topiary doesn't know, so "
+            f"they are left unnormalized. Their values are still in the "
+            f"frame under the original names — nothing was dropped — but no "
+            f"kind or field was assigned to them.",
+            UserWarning, stacklevel=3,
+        )
     return df.rename(columns=rename), models
 
 

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -489,8 +489,15 @@ def from_predictions(predictions, *, sample_name="", allele_set=None,
           mixed list of per-allele and genotype-level predictions;
         - a **callable** taking one prediction (or one row, for a
           DataFrame input) and returning its alleles, or ``None`` —
-          for attribution decided per peptide, where two peptides in
-          one frame legitimately get different sets for the same kind.
+          for a frame where different predictions were scored against
+          different genotypes.
+
+        All three declare *what a prediction was scored against*. None
+        of them withholds a peptide-level score from an allele: that
+        score projects to every allele group present, so naming a subset
+        here does not restrict it. Attribution — crediting a
+        peptide-level score to some alleles and not others — is a
+        separate decision topiary does not make for you.
     extra_columns : dict, optional
         Columns to write alongside the schema, as ``{name: value}``.
         A scalar fills the column; a sequence is taken positionally,


### PR DESCRIPTION
Closes #206. Also corrects a claim I made about #203's `allele_set` callable.

## The bug

A LENS binding column is named `<tool>_<version>.<metric>`, and `_BINDING_MAP`
was keyed on the whole name:

```
netmhcpan_4.1b.aff_nm  ->  netmhcpan_affinity_value   (mapped)
netmhcpan_4.1.aff_nm   ->  netmhcpan_4.1.aff_nm       (passed through)
```

So a version topiary hadn't seen took that predictor's **entire affinity axis**
out of the normalized frame, with nothing raised. A consumer reading normalized
names cannot distinguish "this tool emitted nothing" from "this tool emitted
something under a spelling I don't recognize" — which is why this is expensive
to find rather than merely wrong.

## The fix, as the issue suggested

`aff_nm` is an IC50 whichever NetMHCpan produced it, so the table is keyed on
`(tool, metric)` and the version is **recorded** — in `Metadata.models`, where
it already was — rather than matched. Verified against the real v1.4 fixture
with its version segments rewritten:

| fixture | binding columns mapped | `models` |
|---|---|---|
| unchanged (4.1b) | 13/13 | `netmhcpan: 4.1b` |
| `4.1b` → `4.1` | 13/13 | `netmhcpan: 4.1` |
| `4.1b` → `4.2` | 13/13 | `netmhcpan: 4.2` |
| mhcflurry `2.1.1` → `3.0` | 13/13 | `mhcflurry: 3.0` |
| stabpan `1.0` → `1.1` | 13/13 | `netmhcstabpan: 1.1` |

A test also asserts the *values* are identical across a version rewrite, not
just that the columns appear.

Version detection had the same brittleness — its v1.4 marker was the literal
`netmhcstabpan_1.0.stab_pred_score` — and got the same treatment, so a
NetMHCstabPan release topiary hasn't seen no longer makes a v1.4 file
undetectable.

## And the fallback the issue asked for

A column that looks like predictor output but names an unknown tool or metric
now warns, naming the column. Its values stay in the frame under the original
name — nothing is discarded — but silence was the actual defect.

## Correction to the 5.27.0 notes

Separate matter, same PR because it's a one-paragraph doc fix. Those notes
described the `allele_set` callable as serving "attribution decided per
peptide". It doesn't, and the consumer who asked for #203 established that by
testing it: declaring `allele_set=[A]` still gives `B*07:02` the score, because
`allele_set` says *what a prediction was scored against* and a peptide-level
score then projects to every allele group present.

Attribution — crediting a peptide-level score to some alleles and not others —
is a different operation, and one topiary does not provide. The callable
remains useful for its real purpose (per-prediction genotype declaration). The
changelog and the docstring now say what it does instead of what I assumed it
covered.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1842 passed, 3 skipped (17 new in `tests/test_lens_versions.py`)

Version 5.28.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG