### PR TITLE
Keep both versions when one LENS tool appears twice (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,25 @@ array` — so a consumer could not route around it either.
 Multi-version LENS tables are a real input shape, not a constructed
 edge case.
 
-When one tool appears with several versions its columns are now
-qualified — `netmhcpan_4.1b_affinity_value`,
-`netmhcpan_4.2_affinity_value` — following the convention `to_wide`
-already uses for the same situation, and topiary warns, naming the tool
-and the versions. `Metadata.models` records each. A file with one
-version per tool is unchanged, down to the absence of a warning.
+When two versions of one tool would claim the same output column, that
+tool's columns are now qualified with the version —
+`netmhcpan_4.1b_affinity_value`, `netmhcpan_4.2_affinity_value` —
+following the convention `to_wide` already uses for the same situation,
+and topiary warns, naming the tool and the versions.
+
+The test is a genuine name collision, not merely "two version strings
+appeared for this tool". A file that spells one run's version
+inconsistently across metrics — `netmhcpan_4.1b.aff_nm` beside
+`netmhcpan_4.1.score_ba` — has no collision, and qualifying it would
+split one predictor's affinity axis into two half-populated ones,
+undoing what #206 fixed.
+
+`Metadata.models` keeps its documented `{method: version}` shape, so
+`models["netmhcpan"]` still answers for every file; where a method has
+several versions it holds one of them. The full mapping is
+`metadata.extra["topiary_model_keys"]`, which gives each emitted model
+key the `[method, version]` it was built from. A file with one version
+per tool is unchanged, down to the absence of a warning.
 
 **Fixed: `from_wide` lost the version it was handed.** Independent of
 LENS, and older. `to_wide` appends the version to the model key when one
@@ -31,9 +44,19 @@ method has several, but `from_wide` set
 `prediction_method_name` to the whole key and left `predictor_version`
 NaN — so a round trip produced a method named `netmhcpan_4.1b` with no
 version, and a version-qualified reference like
-`Affinity["netmhcpan", "4.2"]` matched nothing. `to_wide` now records
-the qualified keys in its metadata and `from_wide` reverses the
-encoding, so the method is the method and the version is the version.
+`Affinity["netmhcpan", "4.2"]` matched nothing.
+
+`to_wide` now records what each model key was built from in
+`attrs["topiary_model_keys"]`, and `from_wide` reads it. It does not
+guess: a method genuinely named `netmhcpan_4.1b` and an encoded
+`(netmhcpan, 4.1b)` are the same string, so stripping a trailing
+`_{version}` would rename the former. Only the writer knows which it
+made, and now it says so.
+
+**Added: the DSL refuses a silently arbitrary version.** An unqualified
+`Affinity.value` on a frame holding one method at two versions raised
+nothing and returned whichever row came first. It now raises, listing
+the versions, the way it already did for two methods.
 
 ## 5.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 5.28.2
+
+**Fixed: `read_lens` collapsed two versions of one tool into one column
+(#208).** A regression introduced by 5.28.0.
+
+Keying binding columns on `(tool, metric)` fixed the version-brittleness
+in #206 but left the emitted name — `{tool}_{kind}_{field}` — with no
+room for a version. A table carrying both `netmhcpan_4.1b.aff_nm` and
+`netmhcpan_4.2.aff_nm` produced the column `netmhcpan_affinity_value`
+twice, one version's values were dropped, and `Metadata.models` kept
+only one. topiary said nothing: the sole signal was a pandas
+duplicate-column warning later, which doesn't name the predictor that
+lost its values, and `to_long()` raised `ValueError: Expected a 1D
+array` — so a consumer could not route around it either.
+
+Multi-version LENS tables are a real input shape, not a constructed
+edge case.
+
+When one tool appears with several versions its columns are now
+qualified — `netmhcpan_4.1b_affinity_value`,
+`netmhcpan_4.2_affinity_value` — following the convention `to_wide`
+already uses for the same situation, and topiary warns, naming the tool
+and the versions. `Metadata.models` records each. A file with one
+version per tool is unchanged, down to the absence of a warning.
+
+**Fixed: `from_wide` lost the version it was handed.** Independent of
+LENS, and older. `to_wide` appends the version to the model key when one
+method has several, but `from_wide` set
+`prediction_method_name` to the whole key and left `predictor_version`
+NaN — so a round trip produced a method named `netmhcpan_4.1b` with no
+version, and a version-qualified reference like
+`Affinity["netmhcpan", "4.2"]` matched nothing. `to_wide` now records
+the qualified keys in its metadata and `from_wide` reverses the
+encoding, so the method is the method and the version is the version.
+
 ## 5.28.1
 
 **Fixed: `derive_mhc_class` classified alleles by name prefix.**
@@ -28,6 +63,7 @@ following it.
 
 Distinct alleles are parsed once per call rather than once per row:
 100k rows over two distinct alleles takes ~13 ms.
+
 
 ## 5.28.0
 

--- a/tests/test_lens_multi_version.py
+++ b/tests/test_lens_multi_version.py
@@ -1,0 +1,179 @@
+"""One LENS file, two versions of one tool (topiary #208).
+
+Stripping the version from a binding column name is lossy when a table carries
+`netmhcpan_4.1b.aff_nm` *and* `netmhcpan_4.2.aff_nm`: both became
+`netmhcpan_affinity_value`, one set of values was dropped, and the only signal
+was a pandas duplicate-column warning later — which doesn't name the predictor
+that lost its values. `to_long()` then raised, so a consumer couldn't route
+around it either.
+
+Multi-version tables are a real input shape, not a constructed edge case.
+"""
+
+import pathlib
+import warnings
+
+import pandas as pd
+import pytest
+
+from topiary import Affinity, from_wide, read_lens, to_wide
+from topiary.ranking import evaluate_scores
+
+FIXTURE = pathlib.Path(__file__).parent / "data" / "lens" / "sample_v1_4.tsv"
+
+
+def _two_version_file(tmp_path, source="netmhcpan_4.1b.aff_nm",
+                      added="netmhcpan_4.2.aff_nm", offset=45.0):
+    """The fixture plus a second version of one tool, with distinct values."""
+    lines = FIXTURE.read_text().splitlines()
+    header = lines[0].split("\t")
+    index = header.index(source)
+    header.append(added)
+    rows = ["\t".join(header)]
+    for line in lines[1:]:
+        fields = line.split("\t")
+        fields.append(str(float(fields[index]) + offset))
+        rows.append("\t".join(fields))
+    path = tmp_path / "two_versions.tsv"
+    path.write_text("\n".join(rows) + "\n")
+    return path
+
+
+def _read(path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return read_lens(path)
+
+
+# ---------------------------------------------------------------------------
+# Nothing is lost, and nothing collides
+# ---------------------------------------------------------------------------
+
+
+def test_columns_do_not_collide(tmp_path):
+    result = _read(_two_version_file(tmp_path))
+
+    assert result.df.columns.is_unique
+
+
+def test_both_versions_get_their_own_column(tmp_path):
+    result = _read(_two_version_file(tmp_path))
+
+    assert "netmhcpan_4.1b_affinity_value" in result.df.columns
+    assert "netmhcpan_4.2_affinity_value" in result.df.columns
+
+
+def test_both_versions_keep_their_values(tmp_path):
+    result = _read(_two_version_file(tmp_path))
+    df = result.df
+
+    # The second version was written as the first plus 45.
+    assert (
+        df["netmhcpan_4.2_affinity_value"]
+        - df["netmhcpan_4.1b_affinity_value"]
+    ).round(6).eq(45.0).all()
+
+
+def test_metadata_records_both(tmp_path):
+    result = _read(_two_version_file(tmp_path))
+
+    models = dict(result.metadata.models)
+    assert models["netmhcpan_4.1b"] == "4.1b"
+    assert models["netmhcpan_4.2"] == "4.2"
+
+
+def test_the_collision_is_announced(tmp_path):
+    path = _two_version_file(tmp_path)
+
+    with pytest.warns(UserWarning, match=r"netmhcpan appears with versions"):
+        read_lens(path)
+
+
+def test_a_single_version_file_is_unchanged(tmp_path):
+    """No collision, no qualification, no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = read_lens(FIXTURE)
+
+    assert "netmhcpan_affinity_value" in result.df.columns
+    assert dict(result.metadata.models)["netmhcpan"] == "4.1b"
+
+
+# ---------------------------------------------------------------------------
+# The long form is usable, with the version addressable
+# ---------------------------------------------------------------------------
+
+
+def test_to_long_works(tmp_path):
+    """It raised on a duplicate column, so there was no consumer escape."""
+    result = _read(_two_version_file(tmp_path))
+
+    long_result = result.to_long()
+
+    assert len(long_result.df) > 0
+
+
+def test_the_method_is_the_method_and_the_version_is_the_version(tmp_path):
+    """Not a method named 'netmhcpan_4.1b' with no version."""
+    long_df = _read(_two_version_file(tmp_path)).to_long().df
+    netmhcpan = long_df[long_df["prediction_method_name"] == "netmhcpan"]
+
+    assert sorted(netmhcpan["predictor_version"].dropna().unique()) == [
+        "4.1b", "4.2",
+    ]
+
+
+def test_a_version_qualified_reference_resolves(tmp_path):
+    """affinity['netmhcpan', '4.2'] is an advertised capability."""
+    long_df = _read(_two_version_file(tmp_path)).to_long().df
+
+    scores = evaluate_scores(long_df, Affinity["netmhcpan", "4.2"].value)
+
+    assert scores.notna().any()
+
+
+def test_the_two_versions_score_differently(tmp_path):
+    long_df = _read(_two_version_file(tmp_path)).to_long().df
+
+    first = evaluate_scores(long_df, Affinity["netmhcpan", "4.1b"].value)
+    second = evaluate_scores(long_df, Affinity["netmhcpan", "4.2"].value)
+
+    assert not first.equals(second)
+
+
+# ---------------------------------------------------------------------------
+# The same round-trip gap, independent of LENS
+# ---------------------------------------------------------------------------
+
+
+def test_to_wide_from_wide_recovers_method_and_version():
+    """to_wide qualifies the key on collision; from_wide must reverse it."""
+    long_df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=value,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan", predictor_version=version)
+        for value, version in ((75.0, "4.1b"), (120.0, "4.2"))
+    ])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        restored = from_wide(to_wide(long_df))
+
+    pairs = sorted(zip(restored["prediction_method_name"],
+                       restored["predictor_version"]))
+    assert pairs == [("netmhcpan", "4.1b"), ("netmhcpan", "4.2")]
+
+
+def test_a_single_version_round_trip_is_unchanged():
+    long_df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=75.0,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan", predictor_version="4.1b"),
+    ])
+
+    restored = from_wide(to_wide(long_df))
+
+    assert restored["prediction_method_name"].tolist() == ["netmhcpan"]
+    assert restored["predictor_version"].tolist() == ["4.1b"]

--- a/tests/test_lens_multi_version.py
+++ b/tests/test_lens_multi_version.py
@@ -32,16 +32,44 @@ def _two_version_file(tmp_path, source="netmhcpan_4.1b.aff_nm",
     rows = ["\t".join(header)]
     for line in lines[1:]:
         fields = line.split("\t")
-        fields.append(str(float(fields[index]) + offset))
+        cell = fields[index].strip()
+        # A blank or NA affinity is a legitimate cell; carry it through as
+        # one rather than crashing the fixture builder on float("NA").
+        if cell in ("", "NA", "nan"):
+            fields.append(cell)
+        else:
+            fields.append(str(float(cell) + offset))
         rows.append("\t".join(fields))
     path = tmp_path / "two_versions.tsv"
     path.write_text("\n".join(rows) + "\n")
     return path
 
 
+COLLISION_WARNING = r".*appears with versions"
+
+
+def _drifted_version_file(tmp_path, column="netmhcpan_4.1b.score_ba",
+                          drifted="netmhcpan_4.1.score_ba"):
+    """The fixture with one column's version spelled differently.
+
+    One run of one tool, inconsistently labelled across its metrics --
+    which is drift, not a second version, since no two columns claim the
+    same output name.
+    """
+    lines = FIXTURE.read_text().splitlines()
+    header = lines[0].split("\t")
+    header[header.index(column)] = drifted
+    lines[0] = "\t".join(header)
+    path = tmp_path / "drifted_version.tsv"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
 def _read(path):
+    """Read, muting only the collision warning these tests provoke."""
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
+        warnings.simplefilter("error", UserWarning)
+        warnings.filterwarnings("ignore", COLLISION_WARNING, UserWarning)
         return read_lens(path)
 
 
@@ -74,12 +102,25 @@ def test_both_versions_keep_their_values(tmp_path):
     ).round(6).eq(45.0).all()
 
 
-def test_metadata_records_both(tmp_path):
+def test_metadata_keeps_its_documented_shape(tmp_path):
+    """models stays method -> version; it cannot express two versions."""
     result = _read(_two_version_file(tmp_path))
 
     models = dict(result.metadata.models)
-    assert models["netmhcpan_4.1b"] == "4.1b"
-    assert models["netmhcpan_4.2"] == "4.2"
+    assert "netmhcpan" in models
+    assert models["netmhcpan"] in ("4.1b", "4.2")
+    # Keys stay bare method names -- a caller reading models["netmhcpan"]
+    # gets an answer for every file, multi-version or not.
+    assert not any(key.startswith("netmhcpan_") for key in models)
+
+
+def test_metadata_records_what_each_key_was_built_from(tmp_path):
+    """The full truth lives in the explicit key map, not in models."""
+    result = _read(_two_version_file(tmp_path))
+
+    keys = result.metadata.extra["topiary_model_keys"]
+    assert keys["netmhcpan_4.1b"] == ["netmhcpan", "4.1b"]
+    assert keys["netmhcpan_4.2"] == ["netmhcpan", "4.2"]
 
 
 def test_the_collision_is_announced(tmp_path):
@@ -142,6 +183,39 @@ def test_the_two_versions_score_differently(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Qualifying is for real collisions only
+# ---------------------------------------------------------------------------
+
+
+def test_version_drift_across_metrics_does_not_split_the_predictor(tmp_path):
+    """One run, two spellings of its version, still one predictor.
+
+    A file that writes `netmhcpan_4.1b.aff_nm` beside
+    `netmhcpan_4.1.score_ba` is inconsistent, not multi-version: no two
+    columns claim the same output name. Qualifying on "two version
+    strings appeared for this tool" would split the affinity axis in
+    half and undo what #206 fixed.
+    """
+    path = _drifted_version_file(tmp_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = read_lens(path)
+
+    assert "netmhcpan_affinity_value" in result.df.columns
+    assert "netmhcpan_affinity_score" in result.df.columns
+
+    long_df = result.to_long().df
+    netmhcpan = long_df[long_df["prediction_method_name"] == "netmhcpan"]
+    affinity = netmhcpan[netmhcpan["kind"] == "pMHC_affinity"]
+    assert affinity["predictor_version"].nunique(dropna=False) == 1
+    # Value and score reached the same rows rather than separate ones.
+    assert affinity["value"].notna().any()
+    assert affinity["score"].notna().any()
+    assert (affinity["value"].notna() & affinity["score"].notna()).any()
+
+
+# ---------------------------------------------------------------------------
 # The same round-trip gap, independent of LENS
 # ---------------------------------------------------------------------------
 
@@ -163,6 +237,26 @@ def test_to_wide_from_wide_recovers_method_and_version():
     pairs = sorted(zip(restored["prediction_method_name"],
                        restored["predictor_version"]))
     assert pairs == [("netmhcpan", "4.1b"), ("netmhcpan", "4.2")]
+
+
+def test_a_method_whose_name_ends_in_a_version_survives():
+    """'netmhcpan_4.1b' as a method name is not an encoded key.
+
+    Guessing at the encoding by stripping a trailing '_{version}' cannot
+    tell the two apart and renames this method to 'netmhcpan'.
+    """
+    long_df = pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=75.0,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan_4.1b",
+             predictor_version="4.1b"),
+    ])
+
+    restored = from_wide(to_wide(long_df))
+
+    assert restored["prediction_method_name"].tolist() == ["netmhcpan_4.1b"]
+    assert restored["predictor_version"].tolist() == ["4.1b"]
 
 
 def test_a_single_version_round_trip_is_unchanged():

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.28.1"
+__version__ = "5.28.2"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -2,8 +2,10 @@
 
 Reads LENS TSV reports (v1.4, v1.5.1, v1.9) into Topiary's wide-form
 schema with a :class:`TopiaryResult` return.  Binding columns are
-remapped to Topiary's ``{model}_{kind}_{field}`` convention; per-model
-versions go into the metadata comment block.  LENS-specific columns
+remapped to Topiary's ``{model}_{kind}_{field}`` convention, or
+``{model}_{version}_{kind}_{field}`` where one tool appears at two
+versions for the same metric; per-model versions go into the metadata
+comment block.  LENS-specific columns
 (``erv_*``, ``priority_score_*``, ``b2m_*``, etc.) pass through as
 annotation columns for use via ``Column("...")`` in the DSL.
 
@@ -30,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -46,10 +49,11 @@ logger = logging.getLogger(__name__)
 
 # LENS binding column → (model, version, kind, wide-field)
 #
-# The version is extracted here so we can populate ``Metadata.models``;
-# the emitted Topiary wide-form column name uses just ``{model}_{kind}_{field}``
-# (no version), matching the convention of ``to_wide`` / ``from_wide`` when
-# there is no multi-version collision within a single file.
+# The version is extracted here so we can populate ``Metadata.models``.
+# The emitted wide-form name is ``{model}_{kind}_{field}`` — no version —
+# except where one tool appears with several versions for the same
+# metric, when the version is included to keep both, matching what
+# ``to_wide`` does in the same situation.
 #: LENS names a binding column ``<tool>_<version>.<metric>``. The
 #: version is opaque: ``aff_nm`` is an IC50 whether NetMHCpan 4.1, 4.1b
 #: or 4.2 produced it. Keying the table on the version too meant a
@@ -175,7 +179,7 @@ def read_lens(path, tag: str | None = None) -> TopiaryResult:
             "proceeding with best-effort mapping", path.name,
         )
 
-    df, models = _remap_binding_columns(df)
+    df, models, model_key_parts = _remap_binding_columns(df)
     df = _normalize_alleles(df)
     df = _rename_annotations(df)
     df = _handle_tpm(df)
@@ -193,6 +197,12 @@ def read_lens(path, tag: str | None = None) -> TopiaryResult:
     )
     if version is not None:
         meta.extra["lens_version"] = version
+    # ``models`` is keyed by method, so it cannot express a file that
+    # carries two versions of one tool. Record what each emitted model
+    # key was actually built from, which is what ``from_wide`` reads to
+    # split a key back into method and version.
+    meta.extra["topiary_model_keys"] = model_key_parts
+    df.attrs["topiary_model_keys"] = model_key_parts
 
     return TopiaryResult(df, meta)
 
@@ -205,8 +215,12 @@ def read_lens(path, tag: str | None = None) -> TopiaryResult:
 def _remap_binding_columns(df: pd.DataFrame):
     """Rename LENS binding columns to Topiary wide form.
 
-    Returns ``(df, models_dict)`` where *models_dict* maps method
-    name → version for every binding model present.
+    Returns ``(df, models_dict, model_key_parts)``.  *models_dict* maps
+    method name → version for every binding model present, keeping that
+    shape even when a method has several versions (it then holds the
+    first).  *model_key_parts* maps each emitted model key to its
+    ``[method, version]``, which is what lets ``from_wide`` recover the
+    two separately.
     """
     parsed_columns = []
     unmapped = []
@@ -228,13 +242,26 @@ def _remap_binding_columns(df: pd.DataFrame):
     # the collision only surfaces later as a pandas duplicate-column
     # warning that doesn't name the predictor. Qualify the name instead,
     # the way ``to_wide`` does for the same situation.
+    #
+    # The test is whether two versions claim the *same output column*,
+    # not whether two version strings appear anywhere for the tool: a
+    # file that spells one run's version inconsistently across metrics
+    # (``netmhcpan_4.1b.aff_nm`` beside ``netmhcpan_4.1.score_ba``) has
+    # no collision, and splitting it into two predictors would undo
+    # exactly what keying on (tool, metric) was for.
+    versions_by_output = {}
+    for column, model, version, kind, field in parsed_columns:
+        versions_by_output.setdefault((model, kind, field), set()).add(version)
+    collided_models = {
+        model for (model, _, _), versions in versions_by_output.items()
+        if len(versions) > 1
+    }
     collided = {
         model: sorted(set(versions))
         for model, versions in versions_by_model.items()
-        if len(set(versions)) > 1
+        if model in collided_models
     }
     if collided:
-        import warnings
         warnings.warn(
             "; ".join(
                 f"{model} appears with versions {versions}"
@@ -248,15 +275,22 @@ def _remap_binding_columns(df: pd.DataFrame):
 
     rename = {}
     models = {}
+    model_key_parts = {}
     for column, model, version, kind, field in parsed_columns:
         if model in collided:
-            rename[column] = f"{model}_{version}_{kind}_{field}"
-            models[f"{model}_{version}"] = version
+            key = f"{model}_{version}"
+            rename[column] = f"{key}_{kind}_{field}"
+            model_key_parts[key] = [model, version]
         else:
             rename[column] = f"{model}_{kind}_{field}"
-            models[model] = version
+            model_key_parts[model] = [model, version]
+        # ``models`` keeps its documented shape — method name → version —
+        # so ``models["netmhcpan"]`` still answers for every file. When one
+        # method has several versions it can only hold one of them; the
+        # full mapping lives in ``model_key_parts``, which is what
+        # ``from_wide`` reads to recover method and version separately.
+        models.setdefault(model, version)
     if unmapped:
-        import warnings
         warnings.warn(
             f"LENS binding column(s) {sorted(unmapped)} look like predictor "
             f"output but name a tool or metric this topiary doesn't know, so "
@@ -265,7 +299,7 @@ def _remap_binding_columns(df: pd.DataFrame):
             f"kind or field was assigned to them.",
             UserWarning, stacklevel=3,
         )
-    return df.rename(columns=rename), models
+    return df.rename(columns=rename), models, model_key_parts
 
 
 def _normalize_alleles(df: pd.DataFrame) -> pd.DataFrame:

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -208,9 +208,9 @@ def _remap_binding_columns(df: pd.DataFrame):
     Returns ``(df, models_dict)`` where *models_dict* maps method
     name → version for every binding model present.
     """
-    rename = {}
-    models = {}
+    parsed_columns = []
     unmapped = []
+    versions_by_model = {}
     for column in df.columns:
         parsed = _parse_binding_column(column)
         if parsed is None:
@@ -219,8 +219,42 @@ def _remap_binding_columns(df: pd.DataFrame):
         if kind is None:
             unmapped.append(column)
             continue
-        rename[column] = f"{model}_{kind}_{field}"
-        models[model] = version
+        parsed_columns.append((column, model, version, kind, field))
+        versions_by_model.setdefault(model, []).append(version)
+
+    # A LENS table may legitimately carry two versions of one tool. The
+    # emitted name has no room for a version, so both would land on the
+    # same column and one set of values would be lost — silently, since
+    # the collision only surfaces later as a pandas duplicate-column
+    # warning that doesn't name the predictor. Qualify the name instead,
+    # the way ``to_wide`` does for the same situation.
+    collided = {
+        model: sorted(set(versions))
+        for model, versions in versions_by_model.items()
+        if len(set(versions)) > 1
+    }
+    if collided:
+        import warnings
+        warnings.warn(
+            "; ".join(
+                f"{model} appears with versions {versions}"
+                for model, versions in sorted(collided.items())
+            )
+            + ". Including the version in the column names so both are "
+            "kept — the emitted names are "
+            "'{tool}_{version}_{kind}_{field}' for these tools.",
+            UserWarning, stacklevel=3,
+        )
+
+    rename = {}
+    models = {}
+    for column, model, version, kind, field in parsed_columns:
+        if model in collided:
+            rename[column] = f"{model}_{version}_{kind}_{field}"
+            models[f"{model}_{version}"] = version
+        else:
+            rename[column] = f"{model}_{kind}_{field}"
+            models[model] = version
     if unmapped:
         import warnings
         warnings.warn(

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1246,6 +1246,42 @@ def _filter_kind_method_version(ctx, kind, method, version):
                     f"'modelname'}} to EvalContext."
                 )
 
+    # Same ambiguity one level down: a single method present at two
+    # versions. Without this the groupby below would silently take
+    # whichever row came first, which is an arbitrary choice between two
+    # real predictions rather than an answer.
+    if (
+        version is None
+        and "predictor_version" in sub.columns
+        and "prediction_method_name" in sub.columns
+    ):
+        pairs = sub[["prediction_method_name", "predictor_version"]].astype(str)
+        counted = sub[list(ctx.group_keys)].copy()
+        counted["_pair"] = (
+            pairs["prediction_method_name"] + "\x00"
+            + pairs["predictor_version"]
+        )
+        pairs_per_group = counted.groupby(
+            ctx.group_keys, sort=False, dropna=False,
+        )["_pair"].nunique()
+        if (pairs_per_group > 1).any():
+            listed = ", ".join(
+                f"{m} {v}" for m, v in sorted(
+                    {
+                        (m, v) for m, v in zip(
+                            sub["prediction_method_name"],
+                            sub["predictor_version"].astype(str),
+                        ) if pd.notna(m)
+                    }
+                )
+            )
+            raise ValueError(
+                f"Ambiguous: {_kind_name(kind)} is present at more than "
+                f"one predictor version ({listed}). Use "
+                f"{_kind_short_name(kind)}['modelname', 'version'] "
+                f"to pick one."
+            )
+
     return sub
 
 

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -186,6 +186,22 @@ def to_wide(df):
                 if version_str:
                     model_versions[method_str] = version_str
                     break
+    if version_collision and "predictor_version" in df.columns:
+        # The column names carry the version, so the metadata has to as
+        # well: keyed by method alone it can only hold one of them, and
+        # from_wide would have nothing to reverse the encoding with.
+        for method, rows in (
+            df.dropna(subset=["prediction_method_name"])
+            .groupby("prediction_method_name", sort=False)
+        ):
+            method_str = str(method).strip()
+            if not method_str:
+                continue
+            for version in rows["predictor_version"].dropna().unique():
+                version_str = _version_str(version)
+                if version_str:
+                    model_versions[f"{method_str}_{version_str}"] = version_str
+
     attr_models = getattr(df, "attrs", {}).get("topiary_models", {})
     if observed_methods and hasattr(attr_models, "items"):
         for method, version in attr_models.items():
@@ -312,10 +328,19 @@ def from_wide(df, metadata=None):
 
         chunk = group_df.copy()
         chunk["kind"] = canonical_kind
-        chunk["prediction_method_name"] = model_key
 
         # Resolve version from metadata.
         version = version_lookup.get(model_key, np.nan)
+        method_name = model_key
+        if isinstance(version, str) and version and model_key.endswith(
+            f"_{version}"
+        ):
+            # to_wide appends the version to the model key when one
+            # method has several; strip it back off so the method is the
+            # method and the version is the version, rather than a
+            # method named "netmhcpan_4.1b".
+            method_name = model_key[: -(len(version) + 1)]
+        chunk["prediction_method_name"] = method_name
         chunk["predictor_version"] = version
 
         for wide_field, long_col in WIDE_TO_LONG_FIELD.items():

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -2,7 +2,10 @@
 
 Long form: one row per (peptide, allele, model, kind).
 Wide form: one row per (peptide, allele, source), prediction columns become
-``{model}_{kind}_{field}`` (e.g. ``netmhcpan_affinity_value``).
+``{model_key}_{kind}_{field}`` (e.g. ``netmhcpan_affinity_value``), where
+*model_key* is the method name, or ``{method}_{version}`` where one
+method is present at several versions and the bare name could not hold
+both.  ``attrs["topiary_model_keys"]`` records which is which.
 """
 
 import functools
@@ -63,9 +66,12 @@ def _version_str(value):
 def _parse_wide_column(col_name):
     """Parse a wide-form column name into (model_key, kind_short, field).
 
-    Returns None if the column does not match the ``{model}_{kind}_{field}``
-    pattern where kind is a known prediction kind and field is one of
-    value/score/rank.
+    Returns None if the column does not match the
+    ``{model_key}_{kind}_{field}`` pattern where kind is a known
+    prediction kind and field is one of value/score/rank.  The model key
+    is returned whole: whether it encodes a version is not decidable
+    from the name, and ``from_wide`` resolves it from
+    ``attrs["topiary_model_keys"]`` instead.
     """
     # Split off the rightmost segment as field candidate.
     parts = col_name.rsplit("_", 1)
@@ -115,7 +121,7 @@ def to_wide(df):
     -------
     pandas.DataFrame
         Wide-form DataFrame where prediction columns become
-        ``{model}_{kind}_{field}`` columns.
+        ``{model_key}_{kind}_{field}`` columns.
     """
     if hasattr(df, "wide_df") and hasattr(df, "metadata") and hasattr(df, "df"):
         return df.wide_df
@@ -156,11 +162,18 @@ def to_wide(df):
     else:
         model_col = pd.Series("unknown", index=work.index)
 
+    model_key_parts = {}
     if version_collision and "predictor_version" in work.columns:
-        version_col = work["predictor_version"].fillna("").astype(str)
+        version_col = work["predictor_version"].map(_version_str).fillna("")
         work["_model_key"] = model_col + "_" + version_col
+        for key, method, version in zip(
+            work["_model_key"], model_col, version_col
+        ):
+            model_key_parts[str(key)] = [str(method), str(version) or None]
     else:
         work["_model_key"] = model_col
+        for key, method in zip(work["_model_key"], model_col):
+            model_key_parts[str(key)] = [str(method), None]
 
     work["_kind_short"] = work["kind"].apply(_kind_short_name)
 
@@ -186,22 +199,6 @@ def to_wide(df):
                 if version_str:
                     model_versions[method_str] = version_str
                     break
-    if version_collision and "predictor_version" in df.columns:
-        # The column names carry the version, so the metadata has to as
-        # well: keyed by method alone it can only hold one of them, and
-        # from_wide would have nothing to reverse the encoding with.
-        for method, rows in (
-            df.dropna(subset=["prediction_method_name"])
-            .groupby("prediction_method_name", sort=False)
-        ):
-            method_str = str(method).strip()
-            if not method_str:
-                continue
-            for version in rows["predictor_version"].dropna().unique():
-                version_str = _version_str(version)
-                if version_str:
-                    model_versions[f"{method_str}_{version_str}"] = version_str
-
     attr_models = getattr(df, "attrs", {}).get("topiary_models", {})
     if observed_methods and hasattr(attr_models, "items"):
         for method, version in attr_models.items():
@@ -263,6 +260,13 @@ def to_wide(df):
 
     if model_versions:
         wide.attrs["topiary_models"] = model_versions
+    if model_key_parts:
+        # What each model key was built from. from_wide reads this rather
+        # than trying to reverse the concatenation by guessing at a
+        # suffix: a method genuinely named "netmhcpan_4.1b" and an
+        # encoded (netmhcpan, 4.1b) are the same string, and only the
+        # writer knows which it made.
+        wide.attrs["topiary_model_keys"] = model_key_parts
 
     return wide
 
@@ -273,7 +277,7 @@ def from_wide(df, metadata=None):
     Parameters
     ----------
     df : pandas.DataFrame
-        Wide-form DataFrame with ``{model}_{kind}_{field}`` columns.
+        Wide-form DataFrame with ``{model_key}_{kind}_{field}`` columns.
     metadata : topiary.io.Metadata, optional
         If provided, model versions are used to populate
         ``predictor_version``.
@@ -317,6 +321,11 @@ def from_wide(df, metadata=None):
     # Also check .attrs if available.
     if not version_lookup and hasattr(df, "attrs"):
         version_lookup = df.attrs.get("topiary_models", {})
+    key_parts = {}
+    if metadata is not None and hasattr(metadata, "extra"):
+        key_parts = (metadata.extra or {}).get("topiary_model_keys") or {}
+    if not key_parts and hasattr(df, "attrs"):
+        key_parts = df.attrs.get("topiary_model_keys") or {}
 
     # For each group-key row, emit one long row per (model, kind).
     group_df = df[group_cols]
@@ -329,17 +338,18 @@ def from_wide(df, metadata=None):
         chunk = group_df.copy()
         chunk["kind"] = canonical_kind
 
-        # Resolve version from metadata.
-        version = version_lookup.get(model_key, np.nan)
-        method_name = model_key
-        if isinstance(version, str) and version and model_key.endswith(
-            f"_{version}"
-        ):
-            # to_wide appends the version to the model key when one
-            # method has several; strip it back off so the method is the
-            # method and the version is the version, rather than a
-            # method named "netmhcpan_4.1b".
-            method_name = model_key[: -(len(version) + 1)]
+        # Prefer what the writer recorded: when one method has several
+        # versions its key is "{method}_{version}", and only the writer
+        # knows whether a given key was built that way or is simply a
+        # method whose name ends in something that looks like one.
+        recorded = key_parts.get(model_key)
+        if recorded:
+            method_name, version = recorded[0], recorded[1]
+            if version is None:
+                version = version_lookup.get(model_key, np.nan)
+        else:
+            method_name = model_key
+            version = version_lookup.get(model_key, np.nan)
         chunk["prediction_method_name"] = method_name
         chunk["predictor_version"] = version
 


### PR DESCRIPTION
Closes #208 — a regression I introduced in 5.28.0.

## What I broke

Keying binding columns on `(tool, metric)` fixed #206's version-brittleness, but
the emitted name — `{tool}_{kind}_{field}` — has no room for a version. A table
carrying both versions of one tool produced the same column twice:

```python
[c for c in r.df.columns if "netmhcpan" in c]
# ['netmhcpan_affinity_value', 'netmhcpan_affinity_value']
r.to_long()
# ValueError: Expected a 1D array, got an array with shape (30, 2)
```

One version's values dropped, `Metadata.models` kept one, **topiary said
nothing** — the only signal was a pandas duplicate-column warning later, which
doesn't name the predictor that lost its values. And `to_long()` raising meant a
consumer couldn't route around it. Downstream it presents as zero predictions
from a file that used to work.

## The fix

When one tool appears with several versions, its columns are qualified —
`netmhcpan_4.1b_affinity_value` / `netmhcpan_4.2_affinity_value` — following
**the convention `to_wide` already uses for exactly this situation**, rather
than inventing one. topiary warns, naming the tool and the versions. A
single-version file is unchanged, down to the absence of a warning.

The trigger is a genuine name collision — two versions claiming the same output
column — not merely "two version strings appeared for this tool". See the
review section below for why that distinction matters.

`Metadata.models` keeps its documented `{method: version}` shape, so
`models["netmhcpan"]` still answers for every file. The full mapping is
`metadata.extra["topiary_model_keys"]`, giving each emitted model key the
`[method, version]` it was built from.

I kept version-as-data rather than putting the version back in the general
naming scheme: the qualification only appears where a collision forces it, so
the migration away from name-parsing isn't reversed for the common case.

## And an older bug this exposed

Independent of LENS. `to_wide` appends the version to the model key on
collision, but `from_wide` set `prediction_method_name` to the *whole key* and
left `predictor_version` NaN:

```
before:  [('netmhcpan_4.1b', nan, 75.0), ('netmhcpan_4.2', nan, 120.0)]
after:   [('netmhcpan', '4.1b', 75.0),   ('netmhcpan', '4.2', 120.0)]
```

So a round trip produced a method *named* `netmhcpan_4.1b` with no version, and
`Affinity["netmhcpan", "4.2"]` matched nothing. `to_wide` now records what each
model key was built from in `attrs["topiary_model_keys"]`, and `from_wide` reads
it rather than guessing.
That's what makes version-qualified references work on a multi-version LENS
file, which is the capability #208 said collapsing versions would remove:

```python
evaluate_scores(long_df, Affinity["netmhcpan", "4.2"].value)  # resolves
```

## What the review caught

Two real defects in my first cut, both now fixed and verified:

**Version drift within a file split the predictor.** The collision test was
"two version strings appeared for this tool". A file spelling one run's version
inconsistently across metrics — `netmhcpan_4.1b.aff_nm` beside
`netmhcpan_4.1.score_ba` — has no collision, but was qualified anyway into two
half-populated predictors, undoing exactly what #206 fixed:

```
before:  cols ['netmhcpan_4.1_affinity_score', 'netmhcpan_4.1b_affinity_rank',
               'netmhcpan_4.1b_affinity_value']   warned: True
         long rows: {('netmhcpan','4.1'): 30, ('netmhcpan','4.1b'): 60}
after:   cols ['netmhcpan_affinity_score', 'netmhcpan_affinity_rank',
               'netmhcpan_affinity_value']        warned: False
         long rows: {('netmhcpan','4.1b'): 60}
```

**`from_wide` guessed at the encoding.** Stripping a trailing `_{version}` from
the model key renames a method genuinely *named* `netmhcpan_4.1b` — the encoded
key and the real name are the same string, and only the writer knows which it
made. Hence the explicit key map:

```
before:  ('netmhcpan_4.1b', '4.1b')  ->  ('netmhcpan', '4.1b')   # corrupted
after:   ('netmhcpan_4.1b', '4.1b')  ->  ('netmhcpan_4.1b', '4.1b')
```

Also from the review: `Metadata.models` keeps its documented shape instead of
gaining qualified keys; three docstrings asserting the old naming rule; a
module-level `warnings` import; and the tests no longer blanket-ignore
`UserWarning` or call `float()` on cells that may be `NA`.

## One addition

The DSL now raises on an unqualified `Affinity.value` when one method is present
at two versions, instead of silently returning whichever row came first — the
way it already did for two competing methods.

## Tests

15 in `tests/test_lens_multi_version.py`: no collision, both columns present,
both sets of values intact (the second version is written as the first plus a
known offset, so a silent overwrite fails), the key map, the warning, a
single-version file unchanged and silent, `to_long()` working,
method-and-version recovered separately, version-qualified references resolving
and the two versions scoring differently, version drift *not* splitting the
predictor, a method whose name ends in its own version surviving a round trip,
plus the `to_wide`/`from_wide` round-trip on its own.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1883 passed, 3 skipped

Version 5.28.2.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
