### PR TITLE
Share one EvalContext across operations; forward default_methods (#179, #178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 5.29.0
+
+**Added: `context=` on `apply_filter` / `apply_sort` / `evaluate_scores`
+(#179).** Since #176 the three entry points took the same `group_keys` /
+`default_methods` / `kind_support` / `alleles` kwargs, so callers could
+*specify* one grouping — but each call still built its own `EvalContext`
+and recomputed the grouping, a `drop_duplicates` over the frame plus a
+row-to-group code array. Pass a prebuilt context instead and that work
+happens once:
+
+```python
+ctx = EvalContext(df, group_keys=gk)
+affinity = evaluate_scores(df, Affinity.value, context=ctx)
+presented = evaluate_scores(df, Presentation.score, context=ctx)
+ordered = apply_sort(df, [Affinity.value], context=ctx)
+```
+
+**What is shareable is narrower than the issue's example suggests, and
+worth stating plainly: `apply_filter` and `apply_sort` both return new
+frames, so a context cannot be threaded down a filter → sort → score
+pipeline.** It is reusable across operations on one *unchanged* frame —
+several `evaluate_scores` calls for different score columns, or a filter
+and a sort keyed the same way. Passing a context built on a different
+frame raises rather than silently mapping rows to another frame's
+groups; the check is identity, not equality.
+
+`apply_filter` needs `filter_context=True` and `apply_sort` deliberately
+needs it `False`, so a shared context cannot simply be handed to both.
+New `EvalContext.derive(**overrides)` returns a context on the same
+frame with options changed, inheriting the frame-derived caches when
+`df` / `group_keys` / `alleles` are untouched and dropping them when
+they are. `apply_filter` uses it internally, so the caller's own context
+is never flipped.
+
+**Added: `default_methods` on `TopiaryPredictor` and
+`TopiaryResult.filter_by` / `sort_by` (#178).** A predictor running two
+models that produce the same kind made every unqualified reference in
+`sort_by` ambiguous, and there was no way to resolve it through the
+predictor:
+
+```python
+TopiaryPredictor(
+    models=[NetMHCpan, MHCflurry], alleles=[...],
+    sort_by=Affinity.value,                      # ValueError: Ambiguous
+    default_methods={"pMHC_affinity": "mhcflurry"},   # now resolvable
+)
+```
+
+Filtering hid this — `filter_context=True` auto-aggregates directional
+comparisons across methods — so it surfaced on the sort rather than on
+the filter that looks the same. `TopiaryResult.filter_by` / `sort_by`
+also gained `group_keys`, for a frame that acquired a provenance column
+after prediction.
+
+There is deliberately no `group_keys` on `TopiaryPredictor`: it builds
+its own frame, so the inferred grouping is right by construction, and a
+knob that can only be set wrong is not worth the surface. `kind_support`
+was already forwarded on both paths.
+
 ## 5.28.2
 
 **Fixed: `read_lens` collapsed two versions of one tool into one column

--- a/docs/api.md
+++ b/docs/api.md
@@ -312,6 +312,10 @@ options, all forwarded to `EvalContext`:
 
 See [Group identity](ranking.md#group-identity) for when to pass `group_keys`.
 
+All three also accept `context=`, a prebuilt `EvalContext` used in place
+of the four options above — see [Sharing a
+context](ranking.md#sharing-a-context).
+
 ## String parsing
 
 ### Kind aliases

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -82,6 +82,30 @@ With a single group key, `ctx.group_index` is a flat `Index` of bare values (mat
 
 To map a per-group result back onto rows, use `ctx.row_group_codes()`, which gives each row the position of its group in `group_index`. Looking group keys up by value is unreliable when a key is null: `NaN` never equals itself.
 
+### Sharing a context
+
+Building a context is not free: it takes a `drop_duplicates` over the frame for the group index and a code array mapping every row to its group. When you run several operations over one frame, build the context once and pass it as `context=`:
+
+```python
+ctx = EvalContext(df, group_keys=group_keys)
+
+affinity = evaluate_scores(df, Affinity.value, context=ctx)
+presented = evaluate_scores(df, Presentation.score, context=ctx)
+ordered = apply_sort(df, [Affinity.value], context=ctx)
+```
+
+`context=` replaces the four options above rather than combining with them — passing both raises, so there is no question of which one won.
+
+**A context belongs to one frame.** `apply_filter` and `apply_sort` both return *new* frames, so a context cannot be threaded down a filter → sort → score pipeline; each step needs its own. Reuse applies to several operations on one unchanged frame. Passing a context built on a different frame raises rather than mapping rows to another frame's groups, and the check is identity rather than equality — a copy has its own row order to account for.
+
+`apply_filter` evaluates with `filter_context=True` (unqualified same-kind references auto-aggregate) while `apply_sort` deliberately does not. Handing one context to both is still fine: `apply_filter` derives the variant it needs, inheriting the grouping rather than recomputing it, and leaves your context's own flag alone. To vary an option yourself:
+
+```python
+strict = ctx.derive(default_methods={"pMHC_affinity": "netmhcpan"})
+```
+
+`derive` inherits the cached grouping when `df`, `group_keys` and `alleles` are unchanged, and recomputes it when they are not.
+
 ## Prediction kinds
 
 Each MHC prediction model produces one or more *kinds* of output. The built-in accessors are:

--- a/tests/test_context_forwarding.py
+++ b/tests/test_context_forwarding.py
@@ -1,0 +1,153 @@
+"""TopiaryPredictor and TopiaryResult forwarding context options (topiary #178).
+
+`kind_support` is already forwarded on both paths. `default_methods` was not,
+and it is the one that turns a working configuration into a hard error: a
+predictor running two models that produce the same kind makes every
+unqualified reference in `sort_by` ambiguous, and there was no way to resolve
+it through the predictor.
+
+Filtering hides this — `filter_context=True` auto-aggregates directional
+comparisons across methods — so the failure surfaces on the sort, not the
+filter that looks the same.
+"""
+
+import pandas as pd
+import pytest
+
+from mhctools import RandomBindingPredictor
+
+from topiary import Affinity, TopiaryResult, TopiaryPredictor
+from topiary.io import Metadata
+
+
+def _two_method_frame():
+    rows = []
+    for peptide, base in (("SIINFEKLA", 80.0), ("KLQAAMAVL", 300.0)):
+        for method, offset in (("netmhcpan", 0.0), ("mhcflurry", 45.0)):
+            rows.append(dict(
+                source_sequence_name="s", peptide=peptide, peptide_offset=0,
+                allele="HLA-A*02:01", kind="pMHC_affinity",
+                value=base + offset, score=0.5, percentile_rank=1.0,
+                prediction_method_name=method, predictor_version="1",
+            ))
+    return pd.DataFrame(rows)
+
+
+def _result():
+    return TopiaryResult(_two_method_frame(), Metadata(form="long"))
+
+
+def _predictor(**kwargs):
+    """A predictor with a real model, so only filter/sort is under test."""
+    return TopiaryPredictor(
+        models=RandomBindingPredictor, alleles=["A0201"], **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TopiaryResult
+# ---------------------------------------------------------------------------
+
+
+def test_sort_by_is_ambiguous_without_default_methods():
+    """Unchanged behavior — the safety error is the starting point."""
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _result().sort_by([Affinity.value])
+
+
+def test_sort_by_forwards_default_methods():
+    sorted_result = _result().sort_by(
+        [Affinity.value], default_methods={"pMHC_affinity": "mhcflurry"},
+    )
+
+    assert len(sorted_result.df) == 4
+
+
+def test_sort_by_actually_sorts_on_the_named_method():
+    """Not merely 'it stopped raising' — the chosen method decides the order."""
+    df = _two_method_frame()
+    # Make the two methods disagree on which peptide is best.
+    df.loc[df.prediction_method_name == "mhcflurry", "value"] = [900.0, 10.0]
+    result = TopiaryResult(df, Metadata(form="long"))
+
+    by_netmhcpan = result.sort_by(
+        [Affinity.value], default_methods={"pMHC_affinity": "netmhcpan"},
+    ).df["peptide"].tolist()
+    by_mhcflurry = result.sort_by(
+        [Affinity.value], default_methods={"pMHC_affinity": "mhcflurry"},
+    ).df["peptide"].tolist()
+
+    assert by_netmhcpan[0] == "SIINFEKLA"
+    assert by_mhcflurry[0] == "KLQAAMAVL"
+
+
+def test_filter_by_forwards_default_methods():
+    """Filtering auto-aggregates, so this pins the method rather than a raise."""
+    kept = _result().filter_by(
+        Affinity.value <= 200, default_methods={"pMHC_affinity": "netmhcpan"},
+    ).df
+
+    assert set(kept["peptide"]) == {"SIINFEKLA"}
+
+
+def test_filter_by_forwards_group_keys():
+    kept = _result().filter_by(Affinity.value <= 200, group_keys=["peptide"]).df
+
+    assert not kept.empty
+
+
+def test_sort_by_forwards_group_keys():
+    ordered = _result().sort_by(
+        [Affinity.value], group_keys=["peptide"],
+        default_methods={"pMHC_affinity": "netmhcpan"},
+    ).df
+
+    assert ordered["peptide"].tolist()[0] == "SIINFEKLA"
+
+
+# ---------------------------------------------------------------------------
+# TopiaryPredictor
+# ---------------------------------------------------------------------------
+
+
+def test_the_predictor_accepts_default_methods():
+    predictor = _predictor(
+        sort_by=Affinity.value,
+        default_methods={"pMHC_affinity": "mhcflurry"},
+    )
+
+    assert predictor.default_methods == {"pMHC_affinity": "mhcflurry"}
+
+
+def test_the_predictor_forwards_default_methods_to_sort():
+    """The gap #178 names: a two-model predictor could not sort at all."""
+    predictor = _predictor(
+        sort_by=[Affinity.value],
+        default_methods={"pMHC_affinity": "mhcflurry"},
+    )
+
+    ordered = predictor._apply_filter(_two_method_frame())
+
+    assert len(ordered) == 4
+
+
+def test_without_default_methods_the_predictor_still_raises():
+    predictor = _predictor(sort_by=[Affinity.value])
+
+    with pytest.raises(ValueError, match="Ambiguous"):
+        predictor._apply_filter(_two_method_frame())
+
+
+def test_the_predictor_forwards_default_methods_to_filter():
+    predictor = _predictor(
+        filter_by=Affinity.value <= 200,
+        default_methods={"pMHC_affinity": "netmhcpan"},
+    )
+
+    kept = predictor._apply_filter(_two_method_frame())
+
+    assert set(kept["peptide"]) == {"SIINFEKLA"}
+
+
+def test_default_methods_defaults_to_none():
+    assert _predictor().default_methods is None

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -1,0 +1,224 @@
+"""Sharing one EvalContext across operations (topiary #179).
+
+Each entry point used to build its own context, recomputing the grouping —
+a `drop_duplicates` over the frame plus a row→group code array — every time.
+The options were shareable since #176; the *work* was not.
+
+What is shareable is bounded by a fact worth stating plainly: `apply_filter`
+and `apply_sort` both return new frames, so a context cannot be threaded
+down a filter→sort→score pipeline. It is reusable across operations on one
+unchanged frame — several `evaluate_scores` calls for different score
+columns, or a filter and a sort keyed the same way.
+"""
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    Affinity,
+    EvalContext,
+    apply_filter,
+    apply_sort,
+    evaluate_scores,
+)
+
+
+def _frame(n_peptides=6, methods=("netmhcpan",)):
+    rows = []
+    for p in range(n_peptides):
+        for allele in ("HLA-A*02:01", "HLA-B*07:02"):
+            for method in methods:
+                rows.append(dict(
+                    source_sequence_name=f"src{p % 2}",
+                    peptide=f"PEPTIDE{p}A"[:9],
+                    peptide_offset=p,
+                    allele=allele,
+                    kind="pMHC_affinity",
+                    value=float(100 * p + len(allele)),
+                    score=0.5,
+                    percentile_rank=float(p),
+                    prediction_method_name=method,
+                    predictor_version="1",
+                ))
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# A shared context gives the same answers
+# ---------------------------------------------------------------------------
+
+
+def test_scores_match_a_fresh_context():
+    df = _frame()
+    ctx = EvalContext(df)
+
+    separate = evaluate_scores(df, Affinity.value)
+    shared = evaluate_scores(df, Affinity.value, context=ctx)
+
+    pd.testing.assert_series_equal(separate, shared)
+
+
+def test_sort_matches_a_fresh_context():
+    df = _frame()
+    ctx = EvalContext(df)
+
+    separate = apply_sort(df, [Affinity.value])
+    shared = apply_sort(df, [Affinity.value], context=ctx)
+
+    pd.testing.assert_frame_equal(separate, shared)
+
+
+def test_filter_matches_a_fresh_context():
+    df = _frame()
+    ctx = EvalContext(df)
+
+    separate = apply_filter(df, Affinity.value <= 300)
+    shared = apply_filter(df, Affinity.value <= 300, context=ctx)
+
+    pd.testing.assert_frame_equal(separate, shared)
+
+
+def test_the_grouping_is_computed_once():
+    """The point of sharing: the caches carry over, they aren't rebuilt."""
+    df = _frame()
+    ctx = EvalContext(df)
+    evaluate_scores(df, Affinity.value, context=ctx)
+
+    index_before = ctx.group_index
+    codes_before = ctx.row_group_codes()
+    evaluate_scores(df, Affinity.score, context=ctx)
+
+    assert ctx.group_index is index_before
+    assert ctx.row_group_codes() is codes_before
+
+
+# ---------------------------------------------------------------------------
+# filter_context differs between filter and sort, and must not leak
+# ---------------------------------------------------------------------------
+
+
+def test_a_filter_does_not_flip_the_caller_s_context():
+    """apply_filter needs filter_context=True; the caller's stays as it was."""
+    df = _frame()
+    ctx = EvalContext(df)
+
+    apply_filter(df, Affinity.value <= 300, context=ctx)
+
+    assert ctx.filter_context is False
+
+
+def test_the_derived_filter_context_reuses_the_grouping():
+    df = _frame()
+    ctx = EvalContext(df)
+    ctx.group_index  # populate the cache
+
+    derived = ctx.derive(filter_context=True)
+
+    assert derived.filter_context is True
+    assert derived.group_index is ctx.group_index
+    assert derived.key_frame is ctx.key_frame
+
+
+def test_sorting_stays_strict_through_a_filter_context():
+    """A context that filtered must not carry auto-aggregation into a sort."""
+    df = _frame(methods=("netmhcpan", "mhcflurry"))
+    ctx = EvalContext(df, filter_context=True)
+
+    with pytest.raises(ValueError, match="Ambiguous"):
+        apply_sort(df, [Affinity.value], context=ctx)
+
+
+# ---------------------------------------------------------------------------
+# Reshaping an option drops the caches rather than reusing a wrong one
+# ---------------------------------------------------------------------------
+
+
+def test_deriving_a_new_grouping_does_not_inherit_the_old_index():
+    df = _frame()
+    ctx = EvalContext(df)
+    ctx.group_index
+
+    derived = ctx.derive(group_keys=["peptide"])
+
+    assert derived.group_keys == ["peptide"]
+    assert derived.group_index is not ctx.group_index
+    assert len(derived.group_index) < len(ctx.group_index)
+
+
+def test_derive_rejects_an_unknown_option():
+    with pytest.raises(TypeError, match="Unknown EvalContext option"):
+        EvalContext(_frame()).derive(filter_contxt=True)
+
+
+# ---------------------------------------------------------------------------
+# The staleness hazard the identity check exists for
+# ---------------------------------------------------------------------------
+
+
+def test_a_context_from_another_frame_is_refused():
+    """The whole hazard: a stale context maps rows to the wrong groups."""
+    df = _frame()
+    ctx = EvalContext(df)
+    filtered = apply_filter(df, Affinity.value <= 300)
+
+    with pytest.raises(ValueError, match="different DataFrame"):
+        evaluate_scores(filtered, Affinity.value, context=ctx)
+
+
+def test_the_message_says_filter_and_sort_return_new_frames():
+    """Because that is why a pipeline cannot thread one context through."""
+    df = _frame()
+    ctx = EvalContext(df)
+
+    with pytest.raises(ValueError, match="return new frames"):
+        apply_sort(apply_sort(df, [Affinity.value]), [Affinity.value],
+                   context=ctx)
+
+
+def test_an_equal_but_distinct_frame_is_still_refused():
+    """Identity, not equality — a copy has its own row order to account for."""
+    df = _frame()
+    ctx = EvalContext(df)
+
+    with pytest.raises(ValueError, match="different DataFrame"):
+        evaluate_scores(df.copy(), Affinity.value, context=ctx)
+
+
+def test_context_and_options_together_are_refused():
+    df = _frame()
+    ctx = EvalContext(df)
+
+    with pytest.raises(ValueError, match="not both"):
+        apply_filter(df, Affinity.value <= 300, context=ctx,
+                     group_keys=["peptide"])
+
+
+def test_a_non_context_is_refused():
+    df = _frame()
+
+    with pytest.raises(TypeError, match="must be an EvalContext"):
+        evaluate_scores(df, Affinity.value, context={"group_keys": ["peptide"]})
+
+
+# ---------------------------------------------------------------------------
+# A shared context honors the options it was built with
+# ---------------------------------------------------------------------------
+
+
+def test_default_methods_come_from_the_shared_context():
+    df = _frame(methods=("netmhcpan", "mhcflurry"))
+    ctx = EvalContext(df, default_methods={"pMHC_affinity": "mhcflurry"})
+
+    scores = evaluate_scores(df, Affinity.value, context=ctx)
+
+    assert scores.notna().all()
+
+
+def test_explicit_group_keys_survive_into_a_shared_context():
+    df = _frame()
+    ctx = EvalContext(df, group_keys=["peptide"])
+
+    scores = evaluate_scores(df, Affinity.value, context=ctx)
+    fresh = evaluate_scores(df, Affinity.value, group_keys=["peptide"])
+
+    pd.testing.assert_series_equal(scores, fresh)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,7 +86,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.28.2"
+__version__ = "5.29.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -585,6 +585,7 @@ class TopiaryPredictor(object):
         filter_by=None,
         sort_by=None,
         sort_direction="auto",
+        default_methods=None,
         padding_around_mutation=None,
         only_novel_epitopes=False,
         min_gene_expression=0.0,
@@ -636,6 +637,28 @@ class TopiaryPredictor(object):
         sort_direction : "auto", "asc", or "desc"
             Direction for every sort key; "auto" infers per-key
             (asc for percentile_rank and raw affinity, desc otherwise).
+
+        default_methods : dict, optional
+            Per-kind default ``prediction_method_name``, forwarded to
+            ``filter_by`` / ``sort_by`` evaluation.  Needed when this
+            predictor runs two models that produce the same kind: an
+            unqualified reference like ``sort_by=Affinity.value`` is
+            then ambiguous and raises, and this is the only way to
+            resolve it through the predictor::
+
+                TopiaryPredictor(
+                    models=[NetMHCpan, MHCflurry], alleles=[...],
+                    sort_by=Affinity.value,
+                    default_methods={"pMHC_affinity": "mhcflurry"},
+                )
+
+            Accepts the same key spellings as
+            :class:`~topiary.ranking.EvalContext`.  There is
+            deliberately no ``group_keys`` counterpart: the predictor
+            builds its own frame, so the inferred grouping is right by
+            construction.  Use :meth:`TopiaryResult.filter_by` /
+            :meth:`~TopiaryResult.sort_by`, which do take one, if you
+            joined columns on afterwards.
 
         padding_around_mutation : int, optional
             Residues around a mutation to include in candidate epitopes.
@@ -707,6 +730,7 @@ class TopiaryPredictor(object):
         self.filter_by = _coerce_filter_node(filter_by)
         self.sort_by = _coerce_sort_nodes(sort_by)
         self.sort_direction = sort_direction
+        self.default_methods = default_methods
 
         self.min_transcript_expression = min_transcript_expression
         self.min_gene_expression = min_gene_expression
@@ -996,12 +1020,20 @@ class TopiaryPredictor(object):
         # (``peptide_view``, ``best_*``) fall back to guessing from the
         # rows on exactly the path ``filter_by`` / ``sort_by`` drive.
         kind_support = self.kind_support
+        # Likewise ``default_methods``: a predictor running two models
+        # that produce the same kind makes every unqualified reference
+        # in ``sort_by`` ambiguous, and without this there is no way to
+        # resolve it through the predictor.
+        default_methods = self.default_methods
         if self.filter_by is not None:
-            df = apply_filter(df, self.filter_by, kind_support=kind_support)
+            df = apply_filter(
+                df, self.filter_by, kind_support=kind_support,
+                default_methods=default_methods,
+            )
         if self.sort_by:
             df = apply_sort(
                 df, self.sort_by, sort_direction=self.sort_direction,
-                kind_support=kind_support,
+                kind_support=kind_support, default_methods=default_methods,
             )
         return df
 

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -225,8 +225,59 @@ def _resolve_sort_direction(node, sort_direction):
     return sort_direction
 
 
+def _resolve_context(df, context, *, filter_context, group_keys,
+                     default_methods, kind_support, alleles):
+    """Build the context for an entry point, or adopt the caller's.
+
+    A context caches its grouping against one specific frame, so reusing
+    one across a frame it was not built on would silently score rows
+    against another frame's groups.  The check is identity, not
+    equality: ``apply_filter`` and ``apply_sort`` both return new
+    frames, so a context is only reusable for operations on the frame it
+    was built from -- several ``evaluate_scores`` calls for different
+    score columns, say, or a filter and a sort keyed the same way.
+    """
+    if context is None:
+        return EvalContext(
+            df, group_keys=group_keys, filter_context=filter_context,
+            default_methods=default_methods, kind_support=kind_support,
+            alleles=alleles,
+        )
+    if not isinstance(context, EvalContext):
+        raise TypeError(
+            f"context must be an EvalContext, got "
+            f"{type(context).__name__}"
+        )
+    conflicting = [
+        name for name, value in (
+            ("group_keys", group_keys),
+            ("default_methods", default_methods),
+            ("kind_support", kind_support),
+            ("alleles", alleles),
+        ) if value is not None
+    ]
+    if conflicting:
+        raise ValueError(
+            f"Pass either context= or the individual context options, "
+            f"not both; got context= with {', '.join(sorted(conflicting))}. "
+            f"Use context.derive({conflicting[0]}=...) to change one."
+        )
+    if context.df is not df:
+        raise ValueError(
+            "context was built on a different DataFrame. A context caches "
+            "its grouping against one frame, so reusing it on another "
+            "would map rows to the wrong groups. Note that apply_filter "
+            "and apply_sort return new frames -- build a context per "
+            "frame, or share one across operations on the same frame."
+        )
+    if context.filter_context == filter_context:
+        return context
+    return context.derive(filter_context=filter_context)
+
+
 def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
-                    kind_support=None, alleles=None, fill=np.nan):
+                    kind_support=None, alleles=None, fill=np.nan,
+                    context=None):
     """Evaluate a DSL *node* against *df* and align the result to ``df.index``.
 
     ``DSLNode.eval`` returns a Series indexed by the peptide-allele
@@ -246,7 +297,10 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
 
     *group_keys*, *default_methods*, *kind_support* and *alleles* are
     the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.
+    its docstring.  Pass *context* instead to reuse a prebuilt
+    :class:`EvalContext` and skip rebuilding the grouping; it must have
+    been built on this same *df*, and it is mutually exclusive with the
+    individual options above.
 
     Returns a ``pd.Series`` with ``df.index`` and a numeric dtype.
     """
@@ -258,9 +312,10 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
                          dtype=float)
 
 
-    ctx = EvalContext(
-        df, group_keys=group_keys, default_methods=default_methods,
-        kind_support=kind_support, alleles=alleles,
+    ctx = _resolve_context(
+        df, context, filter_context=False, group_keys=group_keys,
+        default_methods=default_methods, kind_support=kind_support,
+        alleles=alleles,
     )
     scored = node.eval(ctx).reindex(ctx.group_index)
     aligned = pd.Series(
@@ -274,7 +329,7 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
 
 
 def apply_filter(df, node, *, group_keys=None, default_methods=None,
-                 kind_support=None, alleles=None):
+                 kind_support=None, alleles=None, context=None):
     """Apply a boolean-valued DSL node to *df*.
 
     Keeps all rows for peptide-allele groups whose evaluated value is
@@ -282,15 +337,18 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
 
     *group_keys*, *default_methods*, *kind_support* and *alleles* are
     the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.
+    its docstring.  Pass *context* instead to reuse a prebuilt
+    :class:`EvalContext` and skip rebuilding the grouping; it must have
+    been built on this same *df*, and it is mutually exclusive with the
+    individual options above.
     """
     if node is None or df.empty:
         _check_group_keys(df, group_keys)
         return df if node is None else df.reset_index(drop=True)
 
     _validate_columns(df, node)
-    ctx = EvalContext(
-        df, group_keys=group_keys, filter_context=True,
+    ctx = _resolve_context(
+        df, context, filter_context=True, group_keys=group_keys,
         default_methods=default_methods, kind_support=kind_support,
         alleles=alleles,
     )
@@ -307,7 +365,8 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
 
 
 def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
-               default_methods=None, kind_support=None, alleles=None):
+               default_methods=None, kind_support=None, alleles=None,
+               context=None):
     """Sort groups by one or more DSL nodes (lexicographic fallthrough).
 
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
@@ -322,7 +381,10 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
 
     *group_keys*, *default_methods*, *kind_support* and *alleles* are
     the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.
+    its docstring.  Pass *context* instead to reuse a prebuilt
+    :class:`EvalContext` and skip rebuilding the grouping; it must have
+    been built on this same *df*, and it is mutually exclusive with the
+    individual options above.
     """
     if not sort_nodes or df.empty:
         _check_group_keys(df, group_keys)
@@ -331,9 +393,11 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     for node in sort_nodes:
         _validate_columns(df, node)
 
-    ctx = EvalContext(df, group_keys=group_keys,
-                      default_methods=default_methods,
-                      kind_support=kind_support, alleles=alleles)
+    ctx = _resolve_context(
+        df, context, filter_context=False, group_keys=group_keys,
+        default_methods=default_methods, kind_support=kind_support,
+        alleles=alleles,
+    )
     n_groups = len(ctx.group_index)
     n_keys = len(sort_nodes)
     values_matrix = np.empty((n_groups, n_keys), dtype=float)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -569,6 +569,57 @@ class EvalContext:
         # method per iteration by setting (kind_value, method_name) here.
         self._method_override = None
 
+    def derive(self, **overrides) -> "EvalContext":
+        """A context on the same frame with some options changed.
+
+        The expensive part of a context is frame-derived — the key
+        frame, the unique group index, the row→group codes — and none of
+        it depends on ``default_methods``, ``filter_context`` or
+        ``kind_support``.  So a derived context that leaves ``df``,
+        ``group_keys`` and ``alleles`` alone inherits those caches
+        outright rather than recomputing them, which is what lets
+        :func:`~topiary.ranking.apply_filter` (which needs
+        ``filter_context=True``) and :func:`~topiary.ranking.apply_sort`
+        (which needs it ``False``) share one grouping.
+
+        Overriding a frame-shaping option is allowed but drops the
+        caches, since they would no longer describe the result.
+        """
+        unknown = set(overrides) - {
+            "df", "group_keys", "default_methods", "filter_context",
+            "kind_support", "alleles",
+        }
+        if unknown:
+            raise TypeError(
+                f"Unknown EvalContext option(s): {sorted(unknown)}"
+            )
+        df = overrides.get("df", self.df)
+        group_keys = overrides.get("group_keys", self.group_keys)
+        alleles = overrides.get("alleles", self.alleles)
+        derived = EvalContext(
+            df,
+            group_keys=group_keys,
+            default_methods=overrides.get(
+                "default_methods", self.default_methods or None
+            ),
+            filter_context=overrides.get(
+                "filter_context", self.filter_context
+            ),
+            kind_support=overrides.get("kind_support", self.kind_support),
+            alleles=alleles,
+        )
+        reshaped = (
+            df is not self.df
+            or list(group_keys) != list(self.group_keys)
+            or list(alleles or ()) != list(self.alleles or ())
+        )
+        if not reshaped:
+            derived._key_frame = self._key_frame
+            derived._group_index = self._group_index
+            derived._group_tuples_cache = self._group_tuples_cache
+            derived._group_codes_cache = self._group_codes_cache
+        return derived
+
     @property
     def key_frame(self) -> pd.DataFrame:
         """The group-key columns, with null spellings collapsed.

--- a/topiary/result.py
+++ b/topiary/result.py
@@ -332,7 +332,7 @@ class TopiaryResult:
         kind_support = self.extra.get("kind_support")
         return kind_support if isinstance(kind_support, Mapping) else None
 
-    def filter_by(self, expr):
+    def filter_by(self, expr, *, default_methods=None, group_keys=None):
         """Apply a filter expression. ANDs with any existing filter.
 
         Parameters
@@ -340,6 +340,14 @@ class TopiaryResult:
         expr : str or DSLNode
             A string like ``"affinity <= 500"`` or a DSL node like
             ``Affinity <= 500``.
+        default_methods : dict, optional
+            Per-kind default ``prediction_method_name``, for resolving
+            unqualified references when several methods produce the
+            same kind.
+        group_keys : list of str, optional
+            Override the inferred peptide-allele grouping — for a frame
+            that gained a provenance column the inferred keys would
+            collapse.
 
         Returns
         -------
@@ -370,6 +378,7 @@ class TopiaryResult:
         else:
             filtered_df = apply_filter(
                 df, new_ast, kind_support=self._kind_support(),
+                default_methods=default_methods, group_keys=group_keys,
             )
 
         if self.filter_by_ast is not None:
@@ -385,13 +394,20 @@ class TopiaryResult:
         kwargs["filter_by_ast"] = combined_ast
         return TopiaryResult(filtered_df, **kwargs)
 
-    def sort_by(self, expr):
+    def sort_by(self, expr, *, default_methods=None, group_keys=None):
         """Sort rows by an expression. Replaces any previous sort.
 
         Parameters
         ----------
         expr : str, DSLNode, or list of DSLNode
             Sort expression(s).
+        default_methods : dict, optional
+            Per-kind default ``prediction_method_name``.  Sorting is
+            strict about ambiguity — unlike filtering it does not
+            auto-aggregate across methods — so a frame with two methods
+            for one kind needs this to sort on an unqualified reference.
+        group_keys : list of str, optional
+            Override the inferred peptide-allele grouping.
 
         Returns
         -------
@@ -437,6 +453,7 @@ class TopiaryResult:
         else:
             sorted_df = apply_sort(
                 df, sort_nodes, kind_support=self._kind_support(),
+                default_methods=default_methods, group_keys=group_keys,
             )
 
         kwargs = self._field_kwargs()


### PR DESCRIPTION
Closes #179 and #178 — both follow-ups from #176, and the same refactor seen
from two ends.

## #179: the options were shareable, the work was not

#176 gave `apply_filter` / `apply_sort` / `evaluate_scores` the same
`group_keys` / `default_methods` / `kind_support` / `alleles` kwargs, so
callers could *specify* one grouping. But each call still constructed its own
`EvalContext` and recomputed the grouping — a `drop_duplicates` over the frame
plus a row→group code array. They now take `context=`:

```python
ctx = EvalContext(df, group_keys=gk)
affinity  = evaluate_scores(df, Affinity.value,     context=ctx)
presented = evaluate_scores(df, Presentation.score, context=ctx)
ordered   = apply_sort(df, [Affinity.value],        context=ctx)
```

On a 24k-row frame, three operations: **118 ms → 92 ms**. It scales with the
frame, and a reuse itself is free (~2 µs against ~19 ms to build).

### What is shareable is narrower than the issue's example

The issue proposes threading one context through:

```python
kept   = apply_filter(df, node, group_keys=gk)
kept   = apply_sort(kept, [score], group_keys=gk)
scores = evaluate_scores(kept, score, group_keys=gk)
```

**That cannot share a context, and no API change makes it possible:**
`apply_filter` returns `df[keep].reset_index(drop=True)` and `apply_sort`
returns a reordered frame, so *every step's frame differs from the last*. A
context caches its grouping against one specific frame; reusing it across a
filter would map rows to another frame's groups.

So reuse is for several operations on one *unchanged* frame — several
`evaluate_scores` calls for different score columns, or a filter and a sort
keyed the same way. Rather than leave that as a footnote a caller discovers by
getting wrong answers, passing a stale context raises, and the message names
the cause:

> context was built on a different DataFrame. […] Note that apply_filter and
> apply_sort return new frames — build a context per frame, or share one
> across operations on the same frame.

The check is **identity, not equality**: a copy has its own row order to
account for.

### filter_context, which the issue flagged

`apply_filter` needs `filter_context=True`; `apply_sort` deliberately needs it
`False`. New `EvalContext.derive(**overrides)` returns a context on the same
frame with options changed, **inheriting the frame-derived caches** when `df` /
`group_keys` / `alleles` are untouched and dropping them when they are not.
The expensive part is frame-derived and the flag is not, so `apply_filter`
derives what it needs, reuses the grouping, and never flips the caller's own
context.

## #178: the predictor could not sort at all

`kind_support` turned out to be forwarded already, on both the predictor and
`TopiaryResult` paths. `default_methods` was not — and it is the one that turns
a working configuration into a hard error:

```python
TopiaryPredictor(
    models=[NetMHCpan, MHCflurry], alleles=[...],
    sort_by=Affinity.value,      # ValueError: Ambiguous: multiple models produce pMHC_affinity
)
```

with no way to resolve it through the predictor. It now takes
`default_methods`, forwarded to both filter and sort.

Worth noting *why* this went unnoticed: filtering hides it. `filter_context=True`
auto-aggregates directional comparisons across methods, so
`filter_by=Affinity.value <= 500` works on the same frame that makes
`sort_by=Affinity.value` raise. The failure surfaces on the sort, not on the
filter that looks the same.

`TopiaryResult.filter_by` / `sort_by` also gained `default_methods` and
`group_keys`.

### One thing deliberately not added

**No `group_keys` on `TopiaryPredictor`.** The issue left this open ("worth
deciding whether it belongs on the predictor at all"). It builds its own frame,
so the inferred grouping is right by construction — a knob that can only be set
wrong isn't worth the surface. `TopiaryResult.filter_by` / `sort_by` do take
one, since a caller may have joined columns on after prediction.

## Tests

27 new, in two files.

`tests/test_shared_context.py` (16) — shared results match a fresh context for
all three entry points; the caches are reused rather than rebuilt; a filter
does not flip the caller's `filter_context`; a derived filter context reuses
the grouping; a sort through a filter-context stays strict about ambiguity;
deriving a new grouping drops the stale index; and the refusals — another
frame, an equal-but-distinct copy, `context=` plus options, a non-context.

`tests/test_context_forwarding.py` (11) — the ambiguity error is unchanged
without `default_methods`; forwarding it works on both the predictor and
`TopiaryResult`; and, so the test is not merely "it stopped raising", the two
methods are made to disagree about which peptide is best and the chosen method
decides the order.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1910 passed, 3 skipped

Version 5.29.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
