### PR TITLE
Add default_versions to resolve an ambiguous predictor version (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ turned into a hard error". Keeping both versions of a multi-version LENS
 table (#208) is what made it reachable: a consumer's default scoring
 expression could not run on that input at all.
 
+**An unknown version is not a version.** A missing `predictor_version` —
+NaN, `None`, blank, or no column at all — is the absence of a version
+claim, and both the ambiguity check and the resolver now treat it that
+way. Previously a frame with one real version alongside rows recording
+none raised `Ambiguous: ... (netmhcpan 4.2, netmhcpan nan)`, naming a
+version no caller could pass, while `resolve_default_versions` dropped
+the NaN and reported no choice to make — so feeding the resolver's own
+answer back in still crashed. A genuine disagreement between two real
+versions still raises, and the message no longer invents a third.
+
 `packaging` is now a declared dependency. It was already present
 transitively, but the version ordering depends on it, and a fallback that
 quietly demotes every version to string order is not a fallback worth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 5.31.0
+
+**Added: `default_versions` and `resolve_default_versions` (#214).**
+`default_methods` answered "which model, when a kind has several".
+Nothing answered "which version, when a model has several", so an
+unqualified reference on a multi-version frame raised with no configured
+way through:
+
+```python
+EvalContext(df, default_versions={("pMHC_affinity", "netmhcpan"): "4.2"})
+resolve_default_versions(df)          # {("pMHC_affinity", "netmhcpan"): "4.2"}
+validate_default_versions(df, mapping)
+```
+
+Keyed on `(kind, model)` because a version is only meaningful within a
+model — `"4.2"` says nothing on its own. Forwarded by `apply_filter`,
+`apply_sort` and `evaluate_scores` like the other context options.
+
+`resolve_default_versions(df, prefer="newest")` orders by PEP 440, which
+is the only ordering where `4.10` beats `4.9`; `prefer="oldest"` serves a
+pipeline pinned to an older validated model. Versions that aren't PEP 440
+(a build tag, a date, a git hash) sort *before* everything that parses,
+so "newest" means a real release rather than whichever string sorted
+last, with the string as a deterministic tiebreak.
+
+Unconfigured behavior is unchanged — an ambiguous version still raises,
+and the error now names `default_versions` alongside the bracket form.
+
+**This was our own gap, made worse by our own fix.** 5.28.2 added the
+version-ambiguity raise so two versions of one model could no longer be
+silently resolved to whichever row came first. That was right, but it
+shipped without the way through — in the same release series whose notes
+described the identical problem one level up as "a working configuration
+turned into a hard error". Keeping both versions of a multi-version LENS
+table (#208) is what made it reachable: a consumer's default scoring
+expression could not run on that input at all.
+
+`packaging` is now a declared dependency. It was already present
+transitively, but the version ordering depends on it, and a fallback that
+quietly demotes every version to string order is not a fallback worth
+having.
+
 ## 5.30.0
 
 **Added: `read_lens(..., binding_metrics=...)` (#211).** The binding-column

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,6 +307,7 @@ options, all forwarded to `EvalContext`:
 |--------|---------|
 | `group_keys` | Explicit group identity columns; default infers them from the DataFrame |
 | `default_methods` | Per-kind default `prediction_method_name` for unqualified references |
+| `default_versions` | Per-`(kind, model)` default `predictor_version`, when one model has several |
 | `kind_support` | Per-(model, kind) metadata from `TopiaryPredictor.kind_support` |
 | `alleles` | Alleles every peptide is evaluated against, so allele-free evidence reaches a genotype |
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -63,6 +63,21 @@ validate_default_methods(df, user_supplied)     # catches a typo at config time
 
 `resolve_default_methods` returns an entry only for kinds that actually have a choice, and resolves by `CANONICAL_METHOD_PREFERENCE` — a **tie-break convention, not a quality ranking**. It orders general-purpose predictors ahead of ones whose output for a kind is secondary to their main job, then anything unlisted alphabetically, so the answer is always deterministic. Pass your own `preference=` to override it, or qualify the reference (`Affinity["netmhcpan"]`) if you care which model answers.
 
+### Versions
+
+The same question one level down: when one model produced a kind at several versions, an unqualified reference is ambiguous and raises. `default_versions` answers it, keyed on `(kind, model)` — a version means nothing without the model it belongs to:
+
+```python
+from topiary import resolve_default_versions, validate_default_versions
+
+versions = resolve_default_versions(df)   # {("pMHC_affinity", "netmhcpan"): "4.2"}
+evaluate_scores(df, node, default_versions=versions)
+```
+
+`resolve_default_versions` orders by PEP 440, so `4.10` beats `4.9`; pass `prefer="oldest"` for a pipeline pinned to an older validated model. A version that isn't PEP 440 — a build tag, a date, a git hash — sorts before everything that parses, so "newest" means a real release rather than whichever string happened to sort last.
+
+Like `default_methods`, it only speaks where there is a real choice: a model present at one version is omitted.
+
 `validate_default_methods` exists because `EvalContext` only consults a default when a kind is *actually* ambiguous — so an entry naming a model that never ran sits inert until the day two models do produce that kind, and then starts deciding.
 
 One thing is deliberately *not* shared: on a frame where several methods produce the same kind, `apply_filter` auto-aggregates an unqualified reference across them (`nanmin` for `<`/`<=`, `nanmax` for `>`/`>=`), while `apply_sort` and `evaluate_scores` stay strict and raise on the ambiguity. Pass `default_methods={"affinity": "mhcflurry"}` (or qualify the reference, `Affinity["mhcflurry"]`) to get one answer from all three.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ mhctools>=3.14.1
 varcode>=4.18.0
 gtfparse>=0.0.4
 mhcnames
+# PEP 440 ordering for resolve_default_versions
+packaging
 argcomplete>=1.10

--- a/tests/test_default_versions.py
+++ b/tests/test_default_versions.py
@@ -10,6 +10,7 @@ That is the same gap as the sort ambiguity fixed in 5.29.0, one level down:
 raising is right, having no way to answer is not.
 """
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -260,3 +261,99 @@ def test_a_shared_context_applies_its_default_versions():
     scores = evaluate_scores(df, Affinity.value, context=ctx)
 
     assert scores.dropna().unique().tolist() == [120.0]
+
+
+# ---------------------------------------------------------------------------
+# Unknown versions: an absent version is not a version
+# ---------------------------------------------------------------------------
+#
+# Plenty of frames simply do not record predictor_version -- a reader that
+# has no version column, a source that reports one for some rows and not
+# others. Treating a missing value as a version called "nan" invents a
+# second version, then raises an ambiguity error naming a version the
+# caller cannot possibly pass. It also made resolve_default_versions and
+# the DSL disagree: the resolver dropped the NaN and reported no choice
+# to make, while the DSL raised, so feeding the resolver's own answer
+# back in still crashed.
+
+
+@pytest.mark.parametrize("versions", [
+    (np.nan, np.nan),
+    ("4.2", np.nan),
+    ("4.2", None),
+    ("4.2", ""),
+    ("4.2", "   "),
+    ("4.2", "nan"),
+    ("", ""),
+], ids=["all-nan", "partial-nan", "none", "empty", "whitespace",
+        "literal-nan-string", "all-empty"])
+def test_an_unknown_version_is_not_an_ambiguity(versions):
+    scores = evaluate_scores(_frame(versions=versions), Affinity.value)
+
+    assert scores.notna().any()
+
+
+@pytest.mark.parametrize("versions", [
+    (np.nan, np.nan), ("4.2", np.nan), ("4.2", ""), ("4.2", "nan"),
+], ids=["all-nan", "partial-nan", "empty", "literal-nan-string"])
+def test_the_resolver_reports_no_choice_for_unknown_versions(versions):
+    assert resolve_default_versions(_frame(versions=versions)) == {}
+
+
+def test_a_frame_with_no_version_column_evaluates():
+    df = _frame().drop(columns=["predictor_version"])
+
+    assert evaluate_scores(df, Affinity.value).notna().any()
+
+
+@pytest.mark.parametrize("versions", [
+    (np.nan, np.nan), ("4.2", np.nan), ("4.2", ""),
+], ids=["all-nan", "partial-nan", "empty"])
+def test_the_resolver_and_the_dsl_agree(versions):
+    """The documented loop must not crash on a frame the resolver passed on."""
+    df = _frame(versions=versions)
+
+    scores = evaluate_scores(
+        df, Affinity.value, default_versions=resolve_default_versions(df),
+    )
+
+    assert scores.notna().any()
+
+
+def test_two_real_versions_still_raise_when_some_rows_have_none():
+    """An unknown version does not mask a genuine disagreement."""
+    df = _frame(versions=("4.1b", "4.2", np.nan), values=(75.0, 120.0, 99.0))
+
+    with pytest.raises(ValueError, match="more than one predictor version"):
+        evaluate_scores(df, Affinity.value)
+
+
+def test_the_error_never_names_a_missing_version():
+    """It told the caller to pass 'nan', which is not a version."""
+    df = _frame(versions=("4.1b", "4.2", np.nan), values=(75.0, 120.0, 99.0))
+
+    with pytest.raises(ValueError) as excinfo:
+        evaluate_scores(df, Affinity.value)
+
+    message = str(excinfo.value)
+    assert "netmhcpan 4.1b" in message and "netmhcpan 4.2" in message
+    assert "nan" not in message.lower().split("default_versions")[0]
+
+
+def test_a_resolved_default_still_works_alongside_unknown_versions():
+    df = _frame(versions=("4.1b", "4.2", np.nan), values=(75.0, 120.0, 99.0))
+
+    scores = evaluate_scores(
+        df, Affinity.value, default_versions=resolve_default_versions(df),
+    )
+
+    assert scores.dropna().unique().tolist() == [120.0]
+
+
+def test_validate_does_not_offer_a_blank_as_available():
+    df = _frame(versions=("4.2", ""))
+
+    with pytest.raises(ValueError) as excinfo:
+        validate_default_versions(df, {("pMHC_affinity", "netmhcpan"): "9.9"})
+
+    assert "Available: ['4.2']" in str(excinfo.value)

--- a/tests/test_default_versions.py
+++ b/tests/test_default_versions.py
@@ -1,0 +1,262 @@
+"""Resolving an ambiguous predictor version (topiary #214).
+
+`default_methods` answers "which model, when a kind has several". Nothing
+answered "which version, when a model has several" — so once 5.28.2 started
+keeping both versions of a multi-version LENS table rather than dropping one,
+every unqualified reference on that frame raised with no configured way
+through, and a consumer's default scoring expression could not run at all.
+
+That is the same gap as the sort ambiguity fixed in 5.29.0, one level down:
+raising is right, having no way to answer is not.
+"""
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    Affinity,
+    EvalContext,
+    apply_filter,
+    apply_sort,
+    evaluate_scores,
+    resolve_default_versions,
+    validate_default_versions,
+)
+from topiary.ranking import parse
+
+
+def _frame(versions=("4.1b", "4.2"), values=(75.0, 120.0), method="netmhcpan"):
+    return pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=value,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name=method, predictor_version=version)
+        for version, value in zip(versions, values)
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured behavior is unchanged: raising is still the default
+# ---------------------------------------------------------------------------
+
+
+def test_an_unqualified_reference_still_raises():
+    with pytest.raises(ValueError, match="more than one predictor version"):
+        parse("affinity.value").eval(EvalContext(_frame()))
+
+
+def test_the_error_points_at_default_versions():
+    """It named only the bracket form, which is per-reference, not configured."""
+    with pytest.raises(ValueError, match="default_versions="):
+        evaluate_scores(_frame(), Affinity.value)
+
+
+# ---------------------------------------------------------------------------
+# A configured default resolves it, the way default_methods does one level up
+# ---------------------------------------------------------------------------
+
+
+def test_a_default_version_resolves_the_reference():
+    scores = evaluate_scores(
+        _frame(), Affinity.value,
+        default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+    assert scores.dropna().unique().tolist() == [120.0]
+
+
+def test_the_other_version_is_selectable():
+    """Not "it stopped raising" — the named version is the one that answers."""
+    scores = evaluate_scores(
+        _frame(), Affinity.value,
+        default_versions={("pMHC_affinity", "netmhcpan"): "4.1b"},
+    )
+
+    assert scores.dropna().unique().tolist() == [75.0]
+
+
+def test_a_short_kind_alias_works_as_a_key():
+    scores = evaluate_scores(
+        _frame(), Affinity.value,
+        default_versions={("affinity", "netmhcpan"): "4.2"},
+    )
+
+    assert scores.dropna().unique().tolist() == [120.0]
+
+
+def test_sorting_works_with_a_default_version():
+    ordered = apply_sort(
+        _frame(), [Affinity.value],
+        default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+    assert len(ordered) == 2
+
+
+def test_filtering_works_with_a_default_version():
+    kept = apply_filter(
+        _frame(), Affinity.value <= 100,
+        default_versions={("pMHC_affinity", "netmhcpan"): "4.1b"},
+    )
+
+    assert len(kept) == 2
+
+
+def test_an_explicit_version_still_wins():
+    """A reference that pins a version is not overridden by a default."""
+    scores = evaluate_scores(
+        _frame(), Affinity["netmhcpan", "4.1b"].value,
+        default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+    assert scores.dropna().unique().tolist() == [75.0]
+
+
+def test_a_default_for_another_kind_does_not_apply():
+    with pytest.raises(ValueError, match="more than one predictor version"):
+        evaluate_scores(
+            _frame(), Affinity.value,
+            default_versions={("pMHC_stability", "netmhcpan"): "4.2"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# resolve_default_versions
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_picks_the_newest():
+    assert resolve_default_versions(_frame()) == {
+        ("pMHC_affinity", "netmhcpan"): "4.2",
+    }
+
+
+def test_resolve_can_pick_the_oldest():
+    """A pipeline pinned to an older validated model wants the opposite."""
+    assert resolve_default_versions(_frame(), prefer="oldest") == {
+        ("pMHC_affinity", "netmhcpan"): "4.1b",
+    }
+
+
+def test_resolve_orders_by_pep_440_not_by_string():
+    """The whole point of PEP 440 here: 4.10 is newer than 4.9."""
+    df = _frame(versions=("4.9", "4.10"))
+
+    assert resolve_default_versions(df) == {
+        ("pMHC_affinity", "netmhcpan"): "4.10",
+    }
+
+
+def test_resolve_omits_a_model_with_one_version():
+    """It only speaks where there is a real choice."""
+    assert resolve_default_versions(_frame().head(1)) == {}
+
+
+def test_resolve_keys_each_model_separately():
+    """A version means nothing across models, so each gets its own answer."""
+    df = pd.concat([
+        _frame(),
+        _frame(versions=("2.0", "2.1"), values=(10.0, 20.0),
+               method="mhcflurry"),
+    ], ignore_index=True)
+
+    assert resolve_default_versions(df) == {
+        ("pMHC_affinity", "netmhcpan"): "4.2",
+        ("pMHC_affinity", "mhcflurry"): "2.1",
+    }
+
+
+def test_resolve_is_deterministic_on_unparseable_versions():
+    df = _frame(versions=("nightly-a", "nightly-b"))
+
+    assert resolve_default_versions(df) == {
+        ("pMHC_affinity", "netmhcpan"): "nightly-b",
+    }
+
+
+def test_a_real_release_beats_an_unparseable_one():
+    """'newest' should mean a release, not whichever string sorted last."""
+    df = _frame(versions=("zzz-nightly", "4.2"))
+
+    assert resolve_default_versions(df) == {
+        ("pMHC_affinity", "netmhcpan"): "4.2",
+    }
+
+
+def test_resolve_rejects_an_unknown_preference():
+    with pytest.raises(ValueError, match="newest.*oldest"):
+        resolve_default_versions(_frame(), prefer="best")
+
+
+def test_resolve_handles_a_frame_without_versions():
+    df = _frame().drop(columns=["predictor_version"])
+
+    assert resolve_default_versions(df) == {}
+
+
+def test_the_resolver_output_feeds_straight_back_in():
+    """The intended loop: resolve, then evaluate."""
+    df = _frame()
+
+    scores = evaluate_scores(
+        df, Affinity.value, default_versions=resolve_default_versions(df),
+    )
+
+    assert scores.dropna().unique().tolist() == [120.0]
+
+
+# ---------------------------------------------------------------------------
+# Validation and shape
+# ---------------------------------------------------------------------------
+
+
+def test_validate_catches_a_version_that_never_ran():
+    with pytest.raises(ValueError, match="predictor_version '9.9'"):
+        validate_default_versions(
+            _frame(), {("pMHC_affinity", "netmhcpan"): "9.9"},
+        )
+
+
+def test_validate_accepts_a_real_version():
+    validate_default_versions(
+        _frame(), {("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+
+def test_a_bare_kind_key_is_refused():
+    """A version is only meaningful within a model, so the pair is required."""
+    with pytest.raises(TypeError, match=r"\(kind, model\) pairs"):
+        EvalContext(_frame(), default_versions={"pMHC_affinity": "4.2"})
+
+
+def test_an_unknown_kind_is_refused():
+    with pytest.raises(ValueError, match="not a known kind"):
+        EvalContext(_frame(), default_versions={("banana", "netmhcpan"): "4.2"})
+
+
+def test_a_non_string_version_is_refused():
+    with pytest.raises(TypeError, match="must be a version string"):
+        EvalContext(
+            _frame(), default_versions={("pMHC_affinity", "netmhcpan"): 4.2},
+        )
+
+
+def test_a_context_carries_default_versions_through_derive():
+    ctx = EvalContext(
+        _frame(), default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+    derived = ctx.derive(filter_context=True)
+
+    assert derived.default_versions == ctx.default_versions
+
+
+def test_a_shared_context_applies_its_default_versions():
+    df = _frame()
+    ctx = EvalContext(
+        df, default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+    )
+
+    scores = evaluate_scores(df, Affinity.value, context=ctx)
+
+    assert scores.dropna().unique().tolist() == [120.0]

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -21,7 +21,9 @@ from .ranking import (
     MHC_DEPENDENCE_VALUES,
     mhc_dependence,
     resolve_default_methods,
+    resolve_default_versions,
     validate_default_methods,
+    validate_default_versions,
     KindAccessor,
     Len,
     LogisticExpr,
@@ -86,7 +88,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.30.0"
+__version__ = "5.31.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -114,7 +116,9 @@ __all__ = [
     "MHC_DEPENDENCE_VALUES",
     "mhc_dependence",
     "resolve_default_methods",
+    "resolve_default_versions",
     "validate_default_methods",
+    "validate_default_versions",
     "KindAccessor",
     "Len",
     "LogisticExpr",

--- a/topiary/ranking/__init__.py
+++ b/topiary/ranking/__init__.py
@@ -54,7 +54,9 @@ from .nodes import (
     MHC_DEPENDENCE_VALUES,
     mhc_dependence,
     resolve_default_methods,
+    resolve_default_versions,
     validate_default_methods,
+    validate_default_versions,
     _kind_matches,
     _kind_name,
     _kind_short_name,
@@ -139,5 +141,7 @@ __all__ = [
     "MHC_DEPENDENCE_VALUES",
     "mhc_dependence",
     "resolve_default_methods",
+    "resolve_default_versions",
     "validate_default_methods",
+    "validate_default_versions",
 ]

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -226,7 +226,8 @@ def _resolve_sort_direction(node, sort_direction):
 
 
 def _resolve_context(df, context, *, filter_context, group_keys,
-                     default_methods, kind_support, alleles):
+                     default_methods, kind_support, alleles,
+                     default_versions):
     """Build the context for an entry point, or adopt the caller's.
 
     A context caches its grouping against one specific frame, so reusing
@@ -241,7 +242,7 @@ def _resolve_context(df, context, *, filter_context, group_keys,
         return EvalContext(
             df, group_keys=group_keys, filter_context=filter_context,
             default_methods=default_methods, kind_support=kind_support,
-            alleles=alleles,
+            alleles=alleles, default_versions=default_versions,
         )
     if not isinstance(context, EvalContext):
         raise TypeError(
@@ -252,6 +253,7 @@ def _resolve_context(df, context, *, filter_context, group_keys,
         name for name, value in (
             ("group_keys", group_keys),
             ("default_methods", default_methods),
+            ("default_versions", default_versions),
             ("kind_support", kind_support),
             ("alleles", alleles),
         ) if value is not None
@@ -277,7 +279,7 @@ def _resolve_context(df, context, *, filter_context, group_keys,
 
 def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
                     kind_support=None, alleles=None, fill=np.nan,
-                    context=None):
+                    context=None, default_versions=None):
     """Evaluate a DSL *node* against *df* and align the result to ``df.index``.
 
     ``DSLNode.eval`` returns a Series indexed by the peptide-allele
@@ -295,9 +297,9 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
     callers pick semantics — ``.fillna(0.0)`` for additive scoring,
     ``.fillna(-inf)`` for ranking.
 
-    *group_keys*, *default_methods*, *kind_support* and *alleles* are
-    the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.  Pass *context* instead to reuse a prebuilt
+    *group_keys*, *default_methods*, *default_versions*, *kind_support*
+    and *alleles* are the shared context options, forwarded to
+    :class:`EvalContext` — see its docstring.  Pass *context* instead to reuse a prebuilt
     :class:`EvalContext` and skip rebuilding the grouping; it must have
     been built on this same *df*, and it is mutually exclusive with the
     individual options above.
@@ -315,7 +317,7 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
     ctx = _resolve_context(
         df, context, filter_context=False, group_keys=group_keys,
         default_methods=default_methods, kind_support=kind_support,
-        alleles=alleles,
+        alleles=alleles, default_versions=default_versions,
     )
     scored = node.eval(ctx).reindex(ctx.group_index)
     aligned = pd.Series(
@@ -329,15 +331,16 @@ def evaluate_scores(df, node, *, group_keys=None, default_methods=None,
 
 
 def apply_filter(df, node, *, group_keys=None, default_methods=None,
-                 kind_support=None, alleles=None, context=None):
+                 kind_support=None, alleles=None, context=None,
+                 default_versions=None):
     """Apply a boolean-valued DSL node to *df*.
 
     Keeps all rows for peptide-allele groups whose evaluated value is
     truthy.  ``None`` for *node* is a no-op.
 
-    *group_keys*, *default_methods*, *kind_support* and *alleles* are
-    the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.  Pass *context* instead to reuse a prebuilt
+    *group_keys*, *default_methods*, *default_versions*, *kind_support*
+    and *alleles* are the shared context options, forwarded to
+    :class:`EvalContext` — see its docstring.  Pass *context* instead to reuse a prebuilt
     :class:`EvalContext` and skip rebuilding the grouping; it must have
     been built on this same *df*, and it is mutually exclusive with the
     individual options above.
@@ -350,7 +353,7 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
     ctx = _resolve_context(
         df, context, filter_context=True, group_keys=group_keys,
         default_methods=default_methods, kind_support=kind_support,
-        alleles=alleles,
+        alleles=alleles, default_versions=default_versions,
     )
     # Reindex defensively so a misbehaving node (index mismatch) surfaces
     # as NaN → False rather than silently picking up rows from a
@@ -366,7 +369,7 @@ def apply_filter(df, node, *, group_keys=None, default_methods=None,
 
 def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
                default_methods=None, kind_support=None, alleles=None,
-               context=None):
+               context=None, default_versions=None):
     """Sort groups by one or more DSL nodes (lexicographic fallthrough).
 
     *sort_nodes* is a list of DSLNode.  Each node's direction is inferred
@@ -379,9 +382,9 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     promotes nor penalizes it and the remaining keys decide.  Ties keep
     the order the groups appear in the frame.
 
-    *group_keys*, *default_methods*, *kind_support* and *alleles* are
-    the shared context options, forwarded to :class:`EvalContext` — see
-    its docstring.  Pass *context* instead to reuse a prebuilt
+    *group_keys*, *default_methods*, *default_versions*, *kind_support*
+    and *alleles* are the shared context options, forwarded to
+    :class:`EvalContext` — see its docstring.  Pass *context* instead to reuse a prebuilt
     :class:`EvalContext` and skip rebuilding the grouping; it must have
     been built on this same *df*, and it is mutually exclusive with the
     individual options above.
@@ -396,7 +399,7 @@ def apply_sort(df, sort_nodes, sort_direction="auto", *, group_keys=None,
     ctx = _resolve_context(
         df, context, filter_context=False, group_keys=group_keys,
         default_methods=default_methods, kind_support=kind_support,
-        alleles=alleles,
+        alleles=alleles, default_versions=default_versions,
     )
     n_groups = len(ctx.group_index)
     n_keys = len(sort_nodes)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -43,6 +43,7 @@ from difflib import get_close_matches
 from typing import Optional
 
 import numpy as np
+from packaging.version import InvalidVersion, Version
 import pandas as pd
 from mhctools import MHC_DEPENDENCE_VALUES, Kind
 
@@ -412,6 +413,151 @@ def resolve_default_methods(df, preference=None):
     return resolved
 
 
+def resolve_default_versions(df, prefer="newest"):
+    """Pick one ``predictor_version`` per (kind, model) that has several.
+
+    The version-level counterpart of :func:`resolve_default_methods`, and
+    for the same reason: raising on ambiguity is the right default, but a
+    consumer needs one supported way to say "use the newest" rather than
+    each inventing its own preference table and disagreeing about what
+    newest means.
+
+    Ordering is PEP 440 where the versions parse as PEP 440, which is the
+    only ordering under which ``4.10`` beats ``4.9``; anything unparseable
+    sorts before everything that parses, and ties break on the string, so
+    the answer is always deterministic. Pass ``prefer="oldest"`` for a
+    pipeline pinned to an older validated model.
+
+    Pairs with a single version are omitted: the result only speaks where
+    there is a real choice. Returns a mapping suitable for
+    ``default_versions=``.
+    """
+    if prefer not in ("newest", "oldest"):
+        raise ValueError(
+            f"prefer must be 'newest' or 'oldest', got {prefer!r}"
+        )
+    if df is None or df.empty:
+        return {}
+    needed = {"kind", "prediction_method_name", "predictor_version"}
+    if not needed.issubset(df.columns):
+        return {}
+
+    resolved = {}
+    grouped = df.dropna(subset=["prediction_method_name"]).groupby(
+        ["kind", "prediction_method_name"], sort=False, dropna=True,
+    )
+    for (kind_value, method), group in grouped:
+        versions = sorted({
+            str(v) for v in group["predictor_version"].dropna().unique()
+        })
+        if len(versions) < 2:
+            continue
+        ordered = sorted(versions, key=_version_sort_key)
+        resolved[(str(kind_value), str(method))] = (
+            ordered[-1] if prefer == "newest" else ordered[0]
+        )
+    return resolved
+
+
+def _version_sort_key(version):
+    """PEP 440 order where possible, deterministic where not.
+
+    ``packaging`` is imported at module scope rather than here so a
+    missing install fails loudly. Catching ImportError alongside
+    InvalidVersion would silently demote *every* version to string
+    order, which is the ordering this function exists to avoid.
+    """
+    try:
+        return (1, Version(str(version)), "")
+    except InvalidVersion:
+        # Not PEP 440 (a build tag, a date, a git hash). Sorting these
+        # before every parseable version keeps "newest" meaning a real
+        # release rather than whichever string happened to sort last.
+        return (0, _UNPARSEABLE_VERSION, str(version))
+
+
+class _UnparseableVersion:
+    """Sorts equal to itself, so the string tiebreak decides."""
+
+    __slots__ = ()
+
+    def __lt__(self, other):
+        return False
+
+    def __gt__(self, other):
+        return False
+
+    def __eq__(self, other):
+        return isinstance(other, _UnparseableVersion)
+
+    def __hash__(self):
+        return hash(_UnparseableVersion)
+
+
+_UNPARSEABLE_VERSION = _UnparseableVersion()
+
+
+def _normalize_default_versions(mapping):
+    """Canonicalize ``default_versions`` keys to ``(kind, model)`` pairs."""
+    aliases = _build_kind_aliases()
+    out = {}
+    for key, version in mapping.items():
+        if (
+            not isinstance(key, tuple)
+            or len(key) != 2
+        ):
+            raise TypeError(
+                f"default_versions keys must be (kind, model) pairs, "
+                f"got {key!r}. A version is only meaningful within a "
+                f"model, so the model has to be named."
+            )
+        kind_key, method = key
+        if not isinstance(version, str):
+            raise TypeError(
+                f"default_versions[{key!r}] must be a version string, "
+                f"got {type(version).__name__}"
+            )
+        if not isinstance(method, str):
+            raise TypeError(
+                f"default_versions[{key!r}] model must be a string, "
+                f"got {type(method).__name__}"
+            )
+        kind_value = _canonical_kind_key(kind_key, aliases, "default_versions")
+        out[(kind_value, method)] = version
+    return out
+
+
+def validate_default_versions(df, default_versions):
+    """Raise if *default_versions* names a (kind, model) or version *df* lacks.
+
+    Same rationale as :func:`validate_default_methods`: a default is only
+    consulted when a reference is actually ambiguous, so an entry naming
+    a model or version that never ran sits inert until the day it starts
+    deciding.
+    """
+    normalized = _normalize_default_versions(default_versions)
+    if df is None or df.empty:
+        return
+    needed = {"kind", "prediction_method_name", "predictor_version"}
+    if not needed.issubset(df.columns):
+        return
+    for (kind_value, method), version in normalized.items():
+        rows = df[
+            (df["kind"] == kind_value)
+            & (df["prediction_method_name"] == method)
+        ]
+        if rows.empty:
+            continue
+        available = sorted({
+            str(v) for v in rows["predictor_version"].dropna().unique()
+        })
+        if version not in available:
+            raise ValueError(
+                f"No {kind_value} predictions from {method} at "
+                f"predictor_version {version!r}. Available: {available}"
+            )
+
+
 def validate_default_methods(df, default_methods):
     """Raise if *default_methods* names a kind or model *df* doesn't have.
 
@@ -455,24 +601,28 @@ def _normalize_default_methods(mapping):
                 f"default_methods[{key!r}] must be a method name string, "
                 f"got {type(method).__name__}"
             )
-        kind = aliases.get(_kind_name(key).lower())
-        if kind is None:
-            # Surface the canonical kind values and every DSL short
-            # alias so a user who typed 'banana' sees that 'ba' /
-            # 'affinity' / 'pMHC_affinity' all map to the same kind.
-            # The alias dict is lower-cased for case-insensitive
-            # lookup; skip lower-case duplicates of canonicals to
-            # keep the list readable.
-            canonical = {_kind_value(k) for k in aliases.values()}
-            canonical_lower = {c.lower() for c in canonical}
-            shorts = {a for a in aliases.keys() if a not in canonical_lower}
-            accepted = sorted(shorts | canonical)
-            raise ValueError(
-                f"default_methods key {key!r} is not a known kind. "
-                f"Accepted spellings: {accepted}"
-            )
-        out[_kind_value(kind)] = method
+        out[_canonical_kind_key(key, aliases, "default_methods")] = method
     return out
+
+
+def _canonical_kind_key(key, aliases, label):
+    """A kind spelling → its canonical ``kind`` value, or a helpful raise."""
+    kind = aliases.get(_kind_name(key).lower())
+    if kind is None:
+        # Surface the canonical kind values and every DSL short alias so
+        # a user who typed 'banana' sees that 'ba' / 'affinity' /
+        # 'pMHC_affinity' all map to the same kind. The alias dict is
+        # lower-cased for case-insensitive lookup; skip lower-case
+        # duplicates of canonicals to keep the list readable.
+        canonical = {_kind_value(k) for k in aliases.values()}
+        canonical_lower = {c.lower() for c in canonical}
+        shorts = {a for a in aliases.keys() if a not in canonical_lower}
+        accepted = sorted(shorts | canonical)
+        raise ValueError(
+            f"{label} key {key!r} is not a known kind. "
+            f"Accepted spellings: {accepted}"
+        )
+    return _kind_value(kind)
 
 
 class EvalContext:
@@ -524,6 +674,21 @@ class EvalContext:
                     "pMHC_stability": "netmhcstabpan",
                 },
             )
+    default_versions : dict, optional
+        Per-(kind, model) default ``predictor_version``, for resolving
+        unqualified references when one model produced the same kind at
+        several versions.  Keyed on the pair because a version is only
+        meaningful within a model: ``4.2`` says nothing on its own.
+        Keys accept the same kind spellings as *default_methods*::
+
+            EvalContext(
+                df,
+                default_versions={("pMHC_affinity", "netmhcpan"): "4.2"},
+            )
+
+        :func:`resolve_default_versions` builds one for the common
+        "newest wins" case.  Without this kwarg an ambiguous version
+        raises, as an ambiguous method does.
     filter_context : bool, optional
         When true, directional ``Comparison`` nodes
         (``<``, ``<=``, ``>``, ``>=``) with unqualified same-kind refs
@@ -534,15 +699,15 @@ class EvalContext:
     """
 
     __slots__ = (
-        "df", "group_keys", "default_methods", "filter_context",
-        "kind_support", "alleles",
+        "df", "group_keys", "default_methods", "default_versions",
+        "filter_context", "kind_support", "alleles",
         "_group_index", "_key_frame", "_group_tuples_cache",
         "_group_codes_cache", "_method_override",
     )
 
     def __init__(
         self, df, group_keys=None, default_methods=None, filter_context=False,
-        kind_support=None, alleles=None,
+        kind_support=None, alleles=None, default_versions=None,
     ):
         self.df = df
         if group_keys is None:
@@ -551,6 +716,10 @@ class EvalContext:
             self.group_keys = _normalize_group_keys(df, group_keys)
         self.default_methods = (
             _normalize_default_methods(default_methods) if default_methods else {}
+        )
+        self.default_versions = (
+            _normalize_default_versions(default_versions)
+            if default_versions else {}
         )
         self.filter_context = filter_context
         # mhctools >=3.13.7 per-(model, kind) metadata. Optional; when
@@ -586,8 +755,8 @@ class EvalContext:
         caches, since they would no longer describe the result.
         """
         unknown = set(overrides) - {
-            "df", "group_keys", "default_methods", "filter_context",
-            "kind_support", "alleles",
+            "df", "group_keys", "default_methods", "default_versions",
+            "filter_context", "kind_support", "alleles",
         }
         if unknown:
             raise TypeError(
@@ -601,6 +770,9 @@ class EvalContext:
             group_keys=group_keys,
             default_methods=overrides.get(
                 "default_methods", self.default_methods or None
+            ),
+            default_versions=overrides.get(
+                "default_versions", self.default_versions or None
             ),
             filter_context=overrides.get(
                 "filter_context", self.filter_context
@@ -1301,8 +1473,32 @@ def _filter_kind_method_version(ctx, kind, method, version):
     # versions. Without this the groupby below would silently take
     # whichever row came first, which is an arbitrary choice between two
     # real predictions rather than an answer.
+    # A configured default resolves the version the same way
+    # ``default_methods`` resolves the model one level up.
+    effective_version = version
     if (
-        version is None
+        effective_version is None
+        and ctx.default_versions
+        and "prediction_method_name" in sub.columns
+        and "predictor_version" in sub.columns
+    ):
+        methods_here = {
+            str(m) for m in sub["prediction_method_name"].dropna().unique()
+        }
+        wanted = {
+            ctx.default_versions[(kind_val, method)]
+            for method in methods_here
+            if (kind_val, method) in ctx.default_versions
+        }
+        if len(wanted) == 1:
+            candidate = next(iter(wanted))
+            matched = sub[sub["predictor_version"].astype(str) == candidate]
+            if not matched.empty:
+                sub = matched
+                effective_version = candidate
+
+    if (
+        effective_version is None
         and "predictor_version" in sub.columns
         and "prediction_method_name" in sub.columns
     ):
@@ -1330,7 +1526,9 @@ def _filter_kind_method_version(ctx, kind, method, version):
                 f"Ambiguous: {_kind_name(kind)} is present at more than "
                 f"one predictor version ({listed}). Use "
                 f"{_kind_short_name(kind)}['modelname', 'version'] "
-                f"to pick one."
+                f"to pick one, or pass default_versions="
+                f"{{{(kind_val, 'modelname')!r}: 'version'}} to "
+                f"EvalContext (resolve_default_versions(df) builds one)."
             )
 
     return sub

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -447,9 +447,10 @@ def resolve_default_versions(df, prefer="newest"):
         ["kind", "prediction_method_name"], sort=False, dropna=True,
     )
     for (kind_value, method), group in grouped:
-        versions = sorted({
-            str(v) for v in group["predictor_version"].dropna().unique()
-        })
+        known = group["predictor_version"][
+            _known_versions(group["predictor_version"])
+        ]
+        versions = sorted({str(v).strip() for v in known.unique()})
         if len(versions) < 2:
             continue
         ordered = sorted(versions, key=_version_sort_key)
@@ -457,6 +458,18 @@ def resolve_default_versions(df, prefer="newest"):
             ordered[-1] if prefer == "newest" else ordered[0]
         )
     return resolved
+
+
+def _known_versions(values) -> pd.Series:
+    """The entries of *values* that actually name a version.
+
+    A missing ``predictor_version`` — NaN, None, or blank — is the
+    absence of a version claim, not a version called "nan". Treating it
+    as one produces a phantom second version, and then an ambiguity
+    error naming a version the caller cannot possibly pass.
+    """
+    text = values.astype(str).str.strip()
+    return values.notna() & (text != "") & (text.str.lower() != "nan")
 
 
 def _version_sort_key(version):
@@ -549,7 +562,9 @@ def validate_default_versions(df, default_versions):
         if rows.empty:
             continue
         available = sorted({
-            str(v) for v in rows["predictor_version"].dropna().unique()
+            str(v).strip() for v in rows["predictor_version"][
+                _known_versions(rows["predictor_version"])
+            ].unique()
         })
         if version not in available:
             raise ValueError(
@@ -1502,22 +1517,30 @@ def _filter_kind_method_version(ctx, kind, method, version):
         and "predictor_version" in sub.columns
         and "prediction_method_name" in sub.columns
     ):
-        pairs = sub[["prediction_method_name", "predictor_version"]].astype(str)
-        counted = sub[list(ctx.group_keys)].copy()
+        # Only rows that name a version can disagree about one. A frame
+        # that simply does not record versions is not ambiguous, and
+        # neither is one version plus rows that record none — otherwise
+        # every reader that leaves predictor_version empty would start
+        # raising, with nothing the caller could pass to resolve it.
+        named = sub[_known_versions(sub["predictor_version"])]
+        pairs = named[
+            ["prediction_method_name", "predictor_version"]
+        ].astype(str)
+        counted = named[list(ctx.group_keys)].copy()
         counted["_pair"] = (
             pairs["prediction_method_name"] + "\x00"
             + pairs["predictor_version"]
         )
         pairs_per_group = counted.groupby(
             ctx.group_keys, sort=False, dropna=False,
-        )["_pair"].nunique()
-        if (pairs_per_group > 1).any():
+        )["_pair"].nunique() if not counted.empty else pd.Series(dtype=int)
+        if len(pairs_per_group) and (pairs_per_group > 1).any():
             listed = ", ".join(
                 f"{m} {v}" for m, v in sorted(
                     {
                         (m, v) for m, v in zip(
-                            sub["prediction_method_name"],
-                            sub["predictor_version"].astype(str),
+                            named["prediction_method_name"],
+                            named["predictor_version"].astype(str),
                         ) if pd.notna(m)
                     }
                 )


### PR DESCRIPTION
Closes #214.

## This gap was ours, and our own fix opened it

5.28.2 added the version-ambiguity raise so a frame carrying one model at two
versions could no longer resolve an unqualified reference to whichever row came
first. That part was right. But it shipped **without the way through** — and it
shipped in the same release series whose notes described the identical problem
one level up as *"a working configuration turned into a hard error"*. Same
sentence, one level down, written days apart.

Keeping both versions of a multi-version LENS table (#208) is what made such a
frame reachable at all, so the two changes together turned a real input into one
a default configuration cannot score:

```python
parse("affinity.value").eval(ctx)
# ValueError: Ambiguous: pMHC_affinity is present at more than one predictor
#   version (netmhcpan 4.1b, netmhcpan 4.2)
parse("affinity['netmhcpan'].value").eval(ctx)                  # same
EvalContext(df, default_methods={"pMHC_affinity": "netmhcpan"}) # doesn't help
```

## The mechanism

```python
EvalContext(df, default_versions={("pMHC_affinity", "netmhcpan"): "4.2"})

resolve_default_versions(df)                    # {("pMHC_affinity", "netmhcpan"): "4.2"}
resolve_default_versions(df, prefer="oldest")   # {("pMHC_affinity", "netmhcpan"): "4.1b"}
validate_default_versions(df, mapping)
```

Keyed on `(kind, model)` as the issue asked, because a version is only
meaningful within a model — `"4.2"` says nothing on its own. Forwarded by
`apply_filter` / `apply_sort` / `evaluate_scores` alongside the other context
options, carried through `EvalContext.derive`, and accepting the same kind
spellings as `default_methods` (`"affinity"` as well as `"pMHC_affinity"`).

Unconfigured behavior is unchanged — an ambiguous version still raises. The
error message now names `default_versions` as well as the bracket form, since
the bracket form is per-reference and the complaint was about configuring it
once.

## On "newest wins"

The issue asked for this to be decided rather than assumed. `prefer="newest"` is
the default and `prefer="oldest"` is supported, because a pipeline pinned to an
older validated model wants the opposite and the explicit mapping matters more
than the default does.

Ordering is **PEP 440**, which is the only ordering under which `4.10` beats
`4.9` — there's a test for exactly that, since string sort gets it wrong.

A version that isn't PEP 440 — a build tag, a date, a git hash — sorts *before*
everything that parses, so "newest" means a real release rather than whichever
string happened to sort last, with the raw string as a deterministic tiebreak
among unparseable ones. `("zzz-nightly", "4.2")` resolves to `4.2`.

## `packaging` becomes a declared dependency

My first version imported it inside the sort key with `except Exception`. That
catches `ImportError` and `InvalidVersion` together, so a missing `packaging`
would have silently demoted *every* version to string order — the ordering the
function exists to avoid, failing invisibly. It's now a module-level import with
`InvalidVersion` caught alone, and declared in `requirements.txt`; it was already
present transitively, but "already there" isn't a dependency declaration.

## Tests

45 in `tests/test_default_versions.py`: the unconfigured raise is unchanged and
its message names the new option; a default resolves the reference, **and the
other version is selectable** (so the test isn't just "it stopped raising"); a
short kind alias works as a key; filter, sort and score all honour it; an
explicitly pinned reference is not overridden; a default for another kind does
not apply; newest and oldest; `4.10` over `4.9`; single-version models omitted;
each model keyed separately; unparseable versions deterministic and losing to a
real release; validation catching a version that never ran; the four shape
refusals; and `derive` plus a shared context carrying it.

## Unknown versions, which this first got wrong

A frame that doesn't record `predictor_version` is ordinary — a reader with no
version column, or a source that reports one for some rows and not others. The
ambiguity check compared versions as strings, so a missing value became a
version named `"nan"`:

```
Ambiguous: pMHC_affinity is present at more than one predictor version
(netmhcpan 4.2, netmhcpan nan). Use ... default_versions=...
```

telling the caller to pass a version that does not exist — **#214's own shape
again, a raise with no way through.**

Worse, the resolver disagreed with the check. `resolve_default_versions` dropped
the NaN, saw one version, and reported no choice to make. So the loop this PR
documents:

```python
evaluate_scores(df, node, default_versions=resolve_default_versions(df))
```

still crashed on precisely the frames the resolver had passed on. The two halves
of the feature contradicted each other.

Both now share one notion of whether a row names a version at all — not NaN, not
`None`, not blank, not the string `"nan"`. Seven unknown-version shapes are
parameterized in the tests, plus the property that matters: **the resolver and
the DSL agree.** A genuine disagreement between two real versions still raises,
unaffected by rows recording none, and the message lists only versions that
exist.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1984 passed, 3 skipped

Version 5.31.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG

