### PR TITLE
Treat an empty bucket as empty, and refuse a colliding wide column (#216, #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 5.31.1
+
+**Fixed: `SelfProteome.nearest` crashed when a peptide-length bucket was
+empty (#216).** A proteome whose sources are all shorter than the peptide
+window raised `ValueError: attempt to get argmin of an empty sequence`
+instead of reporting no match:
+
+```python
+SelfProteome.from_fasta("short.fasta").nearest(["SIINFEKLA"])
+```
+
+`_build_index` created an entry for every requested peptide length whether
+or not any source was long enough to fill it, and `nearest` guarded on
+*key presence* rather than emptiness — so an empty-but-present bucket
+skipped the graceful path and reached `argmin` over a zero-width axis.
+
+The same fact already had a correct answer by another route: a query whose
+length the proteome has no bucket for returns a clean empty row. Absent and
+empty mean the same thing here — "no self peptide of this length to compare
+against" — and now give the same answer. Unfillable lengths are also no
+longer recorded, so `peptide_lengths` stops claiming coverage the proteome
+does not have.
+
+This is reachable through `from_fasta` and `from_peptides`, the
+caller-supplied paths.
+
+**Fixed: `to_wide` silently emitted `_x` / `_y` columns (#217).** The
+annotation columns carried through from the long frame were merged against
+the generated `{model_key}_{kind}_{field}` columns with pandas' default
+suffixes. A name present on both sides renamed *both* to `_x` / `_y`: the
+canonical name then did not exist at all, `from_wide` found no value for
+it, and the prediction was lost with nothing said.
+
+```python
+to_wide(long_df)          # long_df carries an annotation "netmhcpan_affinity_value"
+# ['netmhcpan_affinity_value_x', ..., 'netmhcpan_affinity_value_y']
+from_wide(wide)["value"]  # [nan] — the 75.0 that went in is gone
+```
+
+Now refused, naming the offending column. This is the same silent
+round-trip loss as #208 and #211, one layer up at the point where the
+column names are finally assembled — and `_x` / `_y` were pandas merge
+artifacts leaking into a schema that never documented them. The realistic
+`read_lens` → `to_long` → `to_wide` path was never affected, since
+`to_long` consumes the prediction columns rather than leaving them behind
+as annotations.
+
 ## 5.31.0
 
 **Added: `default_versions` and `resolve_default_versions` (#214).**

--- a/tests/test_empty_and_collision_guards.py
+++ b/tests/test_empty_and_collision_guards.py
@@ -1,0 +1,156 @@
+"""Two silent-failure guards (topiary #216, #217).
+
+Both are the same species as the bugs this area keeps producing: a case
+where *absent* and *empty* were treated as different things, and a case
+where a frame silently ended up holding data it could not read back.
+"""
+
+import pathlib
+
+import pandas as pd
+import pytest
+
+from topiary import SelfProteome, from_wide, read_lens, to_wide
+
+LENS_FIXTURE = pathlib.Path(__file__).parent / "data" / "lens" / "sample_v1_4.tsv"
+
+
+def _long(extra=None):
+    row = dict(
+        source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+        allele="HLA-A*02:01", kind="pMHC_affinity", value=75.0, score=0.5,
+        percentile_rank=1.0, prediction_method_name="netmhcpan",
+        predictor_version="1",
+    )
+    if extra:
+        row.update(extra)
+    return pd.DataFrame([row])
+
+
+# ---------------------------------------------------------------------------
+# #216: an empty length bucket answers like an absent one
+# ---------------------------------------------------------------------------
+#
+# nearest() guarded on key presence, not emptiness, and _build_index created
+# a bucket for every requested peptide length whether or not any source was
+# long enough to fill it. So a proteome of short sequences reached
+# `dists.argmin(axis=1)` over a zero-width axis and raised
+# "attempt to get argmin of an empty sequence" — while the same fact reached
+# by a different route (a query length the proteome has no bucket for)
+# already returned a clean empty row.
+
+
+def test_a_proteome_of_short_sequences_reports_no_match():
+    proteome = SelfProteome.from_peptides({"a": "SIIN", "b": "KLQA"})
+
+    result = proteome.nearest(["SIINFEKLA"]).to_dict("records")[0]
+
+    assert result["self_nearest_peptide"] is None
+    assert result["self_nearest_edit_distance"] is None
+
+
+def test_the_same_holds_for_a_fasta_proteome(tmp_path):
+    """from_fasta is the caller-supplied path, so it is the one that bites."""
+    path = tmp_path / "short.fasta"
+    path.write_text(">a\nSIIN\n>b\nKLQA\n")
+
+    result = SelfProteome.from_fasta(path).nearest(["SIINFEKLA"])
+
+    assert result.to_dict("records")[0]["self_nearest_peptide"] is None
+
+
+def test_peptide_lengths_does_not_claim_coverage_it_lacks():
+    """An empty bucket made the proteome advertise lengths it had none of."""
+    proteome = SelfProteome.from_peptides({"a": "SIIN"})
+
+    assert proteome.peptide_lengths == []
+    assert proteome.n_reference_peptides == 0
+
+
+def test_an_absent_length_and_an_empty_one_agree():
+    """The two routes to "nothing to compare against" give one answer."""
+    populated = SelfProteome.from_peptides({"src": "SIINFEKLBKLQAAMAVM"})
+    empty = SelfProteome.from_peptides({"a": "SIIN"})
+
+    # A query longer than any bucket the populated proteome has.
+    absent = populated.nearest(["SIINFEKLAKQW"]).to_dict("records")[0]
+    unfilled = empty.nearest(["SIINFEKLA"]).to_dict("records")[0]
+
+    assert absent["self_nearest_peptide"] is None
+    assert unfilled["self_nearest_peptide"] is None
+
+
+def test_a_populated_proteome_is_unaffected():
+    proteome = SelfProteome.from_peptides({"src": "SIINFEKLBKLQAAMAVM"})
+
+    result = proteome.nearest(["SIINFEKLA"]).to_dict("records")[0]
+
+    assert result["self_nearest_peptide"] == "SIINFEKLB"
+    assert result["self_nearest_edit_distance"] == 1
+    assert proteome.peptide_lengths == [8, 9, 10, 11]
+
+
+def test_a_partially_fillable_proteome_keeps_the_lengths_it_has():
+    """Only the unfillable lengths drop out, not the whole index."""
+    proteome = SelfProteome.from_peptides(
+        {"src": "SIINFEKLB"}, peptide_lengths=(9, 10, 11),
+    )
+
+    assert proteome.peptide_lengths == [9]
+    assert proteome.nearest(
+        ["SIINFEKLA"]
+    ).to_dict("records")[0]["self_nearest_peptide"] == "SIINFEKLB"
+
+
+# ---------------------------------------------------------------------------
+# #217: to_wide must not silently produce _x / _y columns
+# ---------------------------------------------------------------------------
+#
+# The annotation columns were merged against the generated prediction
+# columns with pandas' default suffixes, so a name on both sides became
+# _x / _y: the canonical name ceased to exist, and from_wide returned NaN
+# for a prediction that was in the input.
+
+
+def test_a_colliding_annotation_column_is_refused():
+    with pytest.raises(ValueError, match="would collide"):
+        to_wide(_long({"netmhcpan_affinity_value": 999.0}))
+
+
+def test_the_error_names_the_offending_column():
+    with pytest.raises(ValueError) as excinfo:
+        to_wide(_long({"netmhcpan_affinity_value": 999.0}))
+
+    assert "netmhcpan_affinity_value" in str(excinfo.value)
+
+
+def test_no_x_y_columns_can_reach_the_frame():
+    """_x / _y are pandas merge artifacts, not part of the wide schema."""
+    with pytest.raises(ValueError):
+        to_wide(_long({"netmhcpan_affinity_value": 999.0}))
+
+    wide = to_wide(_long({"tpm": 12.0}))
+    assert not any(
+        c.endswith("_x") or c.endswith("_y") for c in wide.columns
+    )
+
+
+def test_an_unrelated_annotation_column_still_passes_through():
+    wide = to_wide(_long({"tpm": 12.0}))
+
+    assert "tpm" in wide.columns
+    assert from_wide(wide)["value"].tolist() == [75.0]
+
+
+def test_the_lens_round_trip_is_unaffected():
+    """The realistic pipeline: it consumed the columns, so it never collided."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = read_lens(LENS_FIXTURE)
+
+    wide = to_wide(result.to_long().df)
+
+    assert wide.columns.is_unique
+    assert "netmhcpan_affinity_value" in wide.columns

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -88,7 +88,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.31.0"
+__version__ = "5.31.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -301,7 +301,12 @@ class SelfProteome:
 
         results: List[Optional[dict]] = [None] * len(peptides)
         for L, items in by_length.items():
-            if L not in self._reference_arrays:
+            # Emptiness, not key presence: a bucket with no peptides
+            # answers the query exactly as an absent one does — there is
+            # no self peptide of this length to compare against — and
+            # sending it on reaches ``argmin`` over a zero-width axis.
+            reference = self._reference_arrays.get(L)
+            if reference is None or len(reference) == 0:
                 for idx, pep in items:
                     results[idx] = self._empty_row(pep, metric)
                 continue
@@ -810,6 +815,13 @@ def _build_index(records, peptide_lengths):
     reference_arrays: Dict[int, np.ndarray] = {}
     for L, pep_dict in peptides_by_length.items():
         peps = list(pep_dict.keys())
+        if not peps:
+            # A requested length no source sequence was long enough to
+            # yield. Recording an empty bucket would make
+            # ``peptide_lengths`` claim a coverage the proteome does not
+            # have, and makes "no bucket" and "empty bucket" two
+            # different answers to one question.
+            continue
         reference_peptides[L] = peps
         reference_arrays[L] = _encode_peptides(peps, L) if peps else (
             np.empty((0, L), dtype=np.int8)

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -252,6 +252,23 @@ def to_wide(df):
         aggfunc="first",
     ).reset_index()
     wide_values.columns.name = None
+    # An annotation column carried through from the long frame can be
+    # named exactly like a column about to be generated. pandas would
+    # rename *both* sides to _x / _y, silently: the canonical name would
+    # then not exist at all, from_wide would find no value for it, and
+    # the prediction would be lost with nothing said — the same silent
+    # round-trip loss as #208 and #211, one layer up, at the point where
+    # the names are finally assembled. Refuse it, naming the columns.
+    generated = set(wide_values.columns) - {"_topiary_group_id"}
+    clash = sorted(set(group_index.columns) & generated)
+    if clash:
+        raise ValueError(
+            f"Column name(s) {clash} already exist on the frame and would "
+            f"collide with the wide-form prediction column(s) to_wide "
+            f"generates for the same name. Rename or drop them before "
+            f"converting; keeping both is not possible, since a wide "
+            f"frame addresses a prediction by exactly that name."
+        )
     wide = (
         group_index
         .merge(wide_values, on="_topiary_group_id", how="left")


### PR DESCRIPTION
Closes #216 and #217.

Both found by auditing for the pattern the last few releases kept producing:
**a case where *absent* and *empty* were treated as different things**, and **a
case where a frame silently held data it could not read back**. Same two species
as #208, #211 and #214.

## #216 — `SelfProteome.nearest` crashed on an empty length bucket

```python
SelfProteome.from_fasta("short.fasta").nearest(["SIINFEKLA"])
# ValueError: attempt to get argmin of an empty sequence
```

`_build_index` created an entry for **every** requested `peptide_lengths` value
whether or not any source sequence was long enough to fill it:

```
reference_arrays keys: [8, 9, 10, 11]
  length 9: shape (0, 9)      # present, but empty
```

and `nearest` guarded on **key presence** rather than emptiness, so the graceful
path was skipped and `dists.argmin(axis=1)` ran over a zero-width axis.

What makes it a defect rather than a missing feature: **the same question
already had a correct answer by another route.** A query whose *length* the
proteome has no bucket for returns a clean empty row. "No self peptide of this
length to compare against" is one fact; it returned `None` down one path and
crashed down the other, purely because an empty bucket existed in one case.

Now both give the same answer. Unfillable lengths are no longer recorded either,
so `peptide_lengths` stops advertising coverage the proteome does not have
(`from_peptides({"a": "SIIN"}).peptide_lengths` was `[8, 9, 10, 11]`, now `[]`).

Reachable through `from_fasta` and `from_peptides` — the caller-supplied paths
#124 and #190 are built around, so a consumer bringing a small or curated
reference set is exactly who hits it, and what they get is an opaque numpy error
far from the cause.

## #217 — `to_wide` silently emitted `_x` / `_y` columns

```python
# long_df carries an annotation column named "netmhcpan_affinity_value"
wide = to_wide(long_df)
[c for c in wide.columns if "affinity" in c]
# ['netmhcpan_affinity_value_x', 'netmhcpan_affinity_rank',
#  'netmhcpan_affinity_score', 'netmhcpan_affinity_value_y']

wide["netmhcpan_affinity_value"]      # KeyError — the canonical name is gone
from_wide(wide)["value"]              # [nan]   — the 75.0 that went in is lost
```

`wide.py` merged the passthrough annotation columns against the generated
`{model_key}_{kind}_{field}` columns with no `suffixes=`, so pandas renamed
**both** sides. No warning anywhere.

This is #208's and #211's sentence one layer up — a wide frame holding data
`to_long()` cannot read back — at the point where the column names are finally
assembled. Both of those were fixed by refusing the collision and naming the
columns; this does the same. Separately, `_x` / `_y` are pandas merge artifacts
leaking into a public schema that never documented, produced, or could parse
them.

**Scope, honestly stated:** the trigger is narrow and I checked before claiming
otherwise. The realistic pipeline is safe — `read_lens` → `to_long()` →
`to_wide()` round-trips cleanly, because `to_long` consumes the prediction
columns rather than leaving them behind as annotations. This is a latent trap,
not something firing today. It is worth closing because it is the exact failure
mode this area keeps reproducing, and because the guard is four lines.

## Tests

11 in `tests/test_empty_and_collision_guards.py`.

#216: short-sequence proteomes report no match via both `from_peptides` and
`from_fasta`; `peptide_lengths` no longer claims empty lengths; **the absent
route and the empty route give the same answer** (the property the bug
violated); a partially fillable proteome keeps the lengths it does have; a
populated proteome is unchanged.

#217: the collision is refused and the error names the column; no `_x`/`_y` can
reach a frame; an unrelated annotation column still passes through and
round-trips; the LENS pipeline is unaffected.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 1995 passed, 3 skipped

Version 5.31.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
