### PR TITLE
Add read-level evidence and per-field knownness to ProteinFragment (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 5.32.0
+
+**Added: read-level evidence and per-field knownness on `ProteinFragment`
+(#102).** The first half of the multi-source fragment work — consumer
+requirements from vaxrank, which would drop its own
+`MutantProteinFragment` and read topiary's. isovar integration is not part
+of this; see the issue.
+
+Four RNA read-count fields, none derivable from the aggregate expression
+the fragment already carried:
+
+```python
+n_overlapping_reads
+n_alt_reads
+n_ref_reads
+n_alt_reads_supporting_protein_sequence   # this assembled sequence, not just the allele
+```
+
+**`None` means unknown, and is not `0`.** A source with no read data
+leaves them `None`; a source that looked and found nothing sets `0`.
+Collapsing the two would let a consumer read "no RNA support" out of "this
+source cannot answer" — and the distinction survives a TSV round trip,
+since a distinction that does not serialize is decorative.
+
+`field_provenance` states how real a populated field is, mapping a field
+name to `"measured"`, `"approximated"` or `"synthesized"`:
+
+```python
+ProteinFragment(
+    ...,
+    variant="chr1:100:N>N",
+    n_alt_reads=12,
+    field_provenance={"variant": SYNTHESIZED, "n_alt_reads": APPROXIMATED},
+)
+```
+
+This covers what a bare `None` cannot say. A LENS or pVACseq read count is
+real but *estimated* (CDS-overlapping reads; depth × VAF). A placeholder
+ref/alt invented because the source supplied none has a value that means
+nothing, and anything doing variant-effect annotation on it must refuse
+rather than compute. Read it through `provenance_of`, `is_known`,
+`is_approximate` and `is_usable_as_biology` rather than the dict. A
+provenance entry naming a field that does not exist, or a label outside
+the vocabulary, is refused — a typo would sit inert and quietly stop
+protecting the field it was written for.
+
+**Fixed: `ProteinFragment.from_dict` hardcoded its field list**, so it
+rejected every field added after that list was written. It now derives the
+set from the dataclass and cannot drift again.
+
 ## 5.31.0
 
 **Added: `default_versions` and `resolve_default_versions` (#214).**

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -42,6 +42,75 @@ Output DataFrame columns, beyond the standard prediction fields:
 | `wt_value`, `wt_score`, `wt_affinity`, `wt_percentile_rank`, `wt_prediction_method_name`, `wt_predictor_version` | Populated when `TopiaryPredictor(predict_wt=True)` scores non-null `wt_peptide` values with the configured MHC model(s). Rows without a length-compatible WT peptide keep NaN values. |
 | *(each annotation key)* | Flattened from every fragment's `annotations` dict. Underscore-prefixed keys (e.g. `_subsequence_offset`) are reserved for internal plumbing and never surface as columns. |
 
+## RNA evidence, and knowing which fields are real
+
+Beyond `gene_expression` / `transcript_expression`, a fragment can carry
+read-level evidence:
+
+| Field | Meaning |
+|---|---|
+| `n_overlapping_reads` | Reads spanning the variant position |
+| `n_alt_reads` | Reads supporting the variant allele |
+| `n_ref_reads` | Reads supporting the reference allele |
+| `n_alt_reads_supporting_protein_sequence` | Reads supporting *this assembled protein sequence*, not merely the allele |
+
+These are not derivable from a TPM, which is why they are fields rather than
+annotations.
+
+**`None` is unknown; it is not `0`.** A source with no read data leaves them
+`None`. A source that looked and found no support sets `0`. A consumer must be
+able to tell those apart, so ask `fragment.is_known("n_alt_reads")` rather than
+testing truthiness — and the distinction survives writing to and reading from a
+TSV.
+
+Different sources populate different subsets, and some of them *estimate*. So a
+fragment can also say how real each populated field is:
+
+```python
+from topiary import ProteinFragment, APPROXIMATED, SYNTHESIZED
+
+ProteinFragment(
+    fragment_id="...",
+    sequence="...",
+    variant="chr1:100:N>N",       # invented by the loader; not real alleles
+    n_alt_reads=12,               # reconstructed as depth x VAF, not counted
+    field_provenance={"variant": SYNTHESIZED, "n_alt_reads": APPROXIMATED},
+)
+```
+
+| Provenance | Meaning |
+|---|---|
+| `"measured"` | Observed directly from data |
+| `"approximated"` | Derived or estimated — e.g. read counts as depth × VAF |
+| `"synthesized"` | A placeholder the loader invented because the source supplied none |
+
+A field not named in the mapping is unqualified: it means what it says.
+
+Read it through the accessors rather than the dict:
+
+| Call | Answers |
+|---|---|
+| `is_known(name)` | Does the field carry a value at all? |
+| `provenance_of(name)` | How real is it, or `None` if unqualified |
+| `is_approximate(name)` | Was it estimated rather than observed? |
+| `is_usable_as_biology(name)` | May it be interpreted as a fact about the sample? |
+
+`is_usable_as_biology` is the one that matters for correctness: it is `False`
+for an absent field *and* for a synthesized one. Anything that annotates variant
+effects, reannotates transcripts, or otherwise treats a value as biology must
+check it and refuse rather than compute on a placeholder.
+
+The point of all this is that **a consumer never branches on `source_type`**.
+Every source produces the same shape; they differ only in which fields are
+populated and how real those fields are:
+
+```python
+def rna_support(fragment):
+    if not fragment.is_usable_as_biology("n_alt_reads"):
+        return None
+    return fragment.n_alt_reads
+```
+
 ## source_type vocabulary (recommended, not enforced)
 
 Free-form string. Topiary never interprets it; used for display and DSL filtering. Colon subtyping is convention.

--- a/tests/test_fragment_evidence.py
+++ b/tests/test_fragment_evidence.py
@@ -1,0 +1,242 @@
+"""Read-level evidence and per-field knownness on ProteinFragment (topiary #102).
+
+Consumer requirements from vaxrank, for the multi-source fragment abstraction.
+Two of the three are here; isovar integration is deliberately not (see the PR).
+
+The property under test throughout is the one that makes a multi-source
+abstraction usable at all: **every source produces the same shape, differing
+only in which fields are populated** — so a consumer never branches on
+`source_type`, and can always tell a field that is real from one that merely
+has a value.
+"""
+
+import pathlib
+
+import pytest
+
+from topiary import (
+    APPROXIMATED,
+    MEASURED,
+    PROVENANCE_VALUES,
+    SYNTHESIZED,
+    ProteinFragment,
+    read_fragments,
+    write_fragments,
+)
+
+
+def _fragment(**kwargs):
+    kwargs.setdefault("fragment_id", "f1")
+    kwargs.setdefault("sequence", "SIINFEKLA")
+    return ProteinFragment(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Read-level evidence is not derivable from aggregate expression
+# ---------------------------------------------------------------------------
+
+
+def test_read_counts_are_carried():
+    f = _fragment(
+        n_overlapping_reads=40, n_alt_reads=12, n_ref_reads=28,
+        n_alt_reads_supporting_protein_sequence=9,
+    )
+
+    assert f.n_overlapping_reads == 40
+    assert f.n_alt_reads == 12
+    assert f.n_ref_reads == 28
+    assert f.n_alt_reads_supporting_protein_sequence == 9
+
+
+def test_reads_supporting_the_protein_sequence_are_separate_from_alt_reads():
+    """Reads supporting *this assembled sequence*, not merely the allele."""
+    f = _fragment(n_alt_reads=12, n_alt_reads_supporting_protein_sequence=9)
+
+    assert f.n_alt_reads != f.n_alt_reads_supporting_protein_sequence
+
+
+def test_read_counts_default_to_unknown():
+    """A source with no read data says nothing rather than saying zero."""
+    f = _fragment()
+
+    assert f.n_alt_reads is None
+    assert not f.is_known("n_alt_reads")
+
+
+# ---------------------------------------------------------------------------
+# Absent is not zero — the requirement that matters most
+# ---------------------------------------------------------------------------
+
+
+def test_zero_and_unknown_are_different():
+    """"No RNA support" and "this source cannot answer" are not one claim."""
+    looked = _fragment(n_alt_reads=0)
+    cannot_answer = _fragment(n_alt_reads=None)
+
+    assert looked.n_alt_reads == 0
+    assert looked.is_known("n_alt_reads")
+    assert cannot_answer.n_alt_reads is None
+    assert not cannot_answer.is_known("n_alt_reads")
+
+
+def test_zero_survives_a_file_round_trip_as_zero(tmp_path):
+    """The distinction has to survive serialization, or it is decorative."""
+    path = tmp_path / "frags.tsv"
+    write_fragments(
+        [_fragment(fragment_id="zero", n_alt_reads=0),
+         _fragment(fragment_id="unknown", n_alt_reads=None)],
+        path,
+    )
+
+    back = {f.fragment_id: f for f in read_fragments(path)}
+
+    assert back["zero"].n_alt_reads == 0
+    assert back["unknown"].n_alt_reads is None
+
+
+def test_is_known_rejects_a_field_that_does_not_exist():
+    with pytest.raises(ValueError, match="not a ProteinFragment field"):
+        _fragment().is_known("n_alt_readz")
+
+
+# ---------------------------------------------------------------------------
+# Per-field provenance: populated is not the same as trustworthy
+# ---------------------------------------------------------------------------
+
+
+def test_an_unqualified_field_has_no_provenance():
+    f = _fragment(n_alt_reads=12)
+
+    assert f.provenance_of("n_alt_reads") is None
+    assert f.is_usable_as_biology("n_alt_reads")
+
+
+def test_an_approximated_count_is_marked():
+    """LENS and pVACseq estimate read counts differently; both estimate."""
+    f = _fragment(n_alt_reads=12, field_provenance={"n_alt_reads": APPROXIMATED})
+
+    assert f.is_approximate("n_alt_reads")
+    assert f.is_usable_as_biology("n_alt_reads")   # an estimate is still data
+
+
+def test_a_synthesized_field_must_not_be_read_as_biology():
+    """vaxrank's placeholder_alleles, generalized: refuse rather than compute."""
+    f = _fragment(variant="chr1:100:N>N",
+                  field_provenance={"variant": SYNTHESIZED})
+
+    assert f.variant is not None            # it has a value
+    assert f.is_known("variant")            # ... and the value is present
+    assert not f.is_usable_as_biology("variant")   # ... but means nothing
+
+
+def test_a_measured_field_is_usable():
+    f = _fragment(n_alt_reads=12, field_provenance={"n_alt_reads": MEASURED})
+
+    assert f.is_usable_as_biology("n_alt_reads")
+    assert not f.is_approximate("n_alt_reads")
+
+
+def test_an_absent_field_is_not_usable_as_biology():
+    assert not _fragment().is_usable_as_biology("n_alt_reads")
+
+
+def test_provenance_survives_a_file_round_trip(tmp_path):
+    path = tmp_path / "frags.tsv"
+    write_fragments(
+        [_fragment(variant="chr1:100:N>N", n_alt_reads=12,
+                   field_provenance={"variant": SYNTHESIZED,
+                                     "n_alt_reads": APPROXIMATED})],
+        path,
+    )
+
+    back = list(read_fragments(path))[0]
+
+    assert not back.is_usable_as_biology("variant")
+    assert back.is_approximate("n_alt_reads")
+
+
+# ---------------------------------------------------------------------------
+# A provenance claim that cannot mean anything is refused
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_field_name_is_refused():
+    """A typo would sit inert and stop protecting the field it names."""
+    with pytest.raises(ValueError, match="not a ProteinFragment field"):
+        _fragment(field_provenance={"n_alt_readz": MEASURED})
+
+
+def test_an_unknown_provenance_value_is_refused():
+    with pytest.raises(ValueError, match="use one of"):
+        _fragment(field_provenance={"n_alt_reads": "probably fine"})
+
+
+def test_the_vocabulary_is_exactly_three_values():
+    assert PROVENANCE_VALUES == {MEASURED, APPROXIMATED, SYNTHESIZED}
+
+
+# ---------------------------------------------------------------------------
+# Shape conformance across sources
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_accepts_every_field_the_dataclass_has():
+    """It hardcoded its field list, so new fields were rejected on load."""
+    full = _fragment(
+        n_overlapping_reads=40, n_alt_reads=12, n_ref_reads=28,
+        n_alt_reads_supporting_protein_sequence=9,
+        field_provenance={"n_alt_reads": APPROXIMATED},
+    )
+
+    assert ProteinFragment.from_dict(full.to_dict()) == full
+    assert ProteinFragment.from_dict(full.to_dict()).n_alt_reads == 12
+
+
+def test_the_degenerate_fragment_flows_through_unchanged(tmp_path):
+    """pVACseq's shape: no source context at all.
+
+    vaxrank proposed this as the conformance test for the abstraction — a
+    peptide with no surrounding sequence, an interval spanning all of it,
+    no read data and no reference. If that cannot round-trip, the shape is
+    wrong.
+    """
+    degenerate = ProteinFragment(
+        fragment_id="pvacseq__deadbeef",
+        source_type="variant:snv",
+        sequence="SIINFEKLA",
+        target_intervals=[(0, 9)],
+    )
+
+    path = tmp_path / "degenerate.tsv"
+    write_fragments([degenerate], path)
+    back = list(read_fragments(path))[0]
+
+    assert back.sequence == degenerate.sequence
+    assert back.target_intervals == [(0, 9)]
+    assert back.reference_sequence is None
+    # Every evidence field says "unknown", and says it the same way a
+    # richly populated fragment would.
+    for name in ("n_alt_reads", "n_ref_reads", "n_overlapping_reads",
+                 "n_alt_reads_supporting_protein_sequence",
+                 "gene_expression", "transcript_expression"):
+        assert not back.is_known(name)
+        assert not back.is_usable_as_biology(name)
+
+
+def test_a_consumer_need_not_branch_on_source_type():
+    """The whole point: one code path reads every source."""
+    isovar_like = _fragment(fragment_id="a", n_alt_reads=12)
+    lens_like = _fragment(
+        fragment_id="b", n_alt_reads=8,
+        field_provenance={"n_alt_reads": APPROXIMATED},
+    )
+    varcode_like = _fragment(fragment_id="c")
+
+    def support(fragment):
+        if not fragment.is_usable_as_biology("n_alt_reads"):
+            return None
+        return fragment.n_alt_reads
+
+    assert [support(f) for f in (isovar_like, lens_like, varcode_like)] == [
+        12, 8, None,
+    ]

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -70,7 +70,14 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 from .cached import CachedPredictor, mhcflurry_composite_version
-from .protein_fragment import ProteinFragment, make_fragment_id
+from .protein_fragment import (
+    APPROXIMATED,
+    MEASURED,
+    PROVENANCE_VALUES,
+    SYNTHESIZED,
+    ProteinFragment,
+    make_fragment_id,
+)
 from .self_proteome import SelfProteome
 from .io import Metadata, read_csv, read_tsv, to_csv, to_tsv
 from .io_protein_fragment import read_fragments, write_fragments, iter_fragments
@@ -88,7 +95,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.31.0"
+__version__ = "5.32.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -162,6 +169,10 @@ __all__ = [
     "protein_subsequences_around_mutations",
     "ProteinFragment",
     "make_fragment_id",
+    "MEASURED",
+    "APPROXIMATED",
+    "SYNTHESIZED",
+    "PROVENANCE_VALUES",
     "read_fragments",
     "write_fragments",
     "iter_fragments",

--- a/topiary/io_protein_fragment.py
+++ b/topiary/io_protein_fragment.py
@@ -36,6 +36,11 @@ _COLUMNS = [
     "transcript_name",
     "gene_expression",
     "transcript_expression",
+    "n_overlapping_reads",
+    "n_alt_reads",
+    "n_ref_reads",
+    "n_alt_reads_supporting_protein_sequence",
+    "field_provenance",
     "annotations",
 ]
 
@@ -50,7 +55,7 @@ def _fragment_to_row(f: ProteinFragment) -> dict:
         val = getattr(f, col)
         if col == "target_intervals":
             row[col] = json.dumps([list(p) for p in val]) if val is not None else ""
-        elif col == "annotations":
+        elif col in ("annotations", "field_provenance"):
             row[col] = json.dumps(val or {}, sort_keys=True)
         elif val is None:
             row[col] = ""
@@ -87,9 +92,22 @@ def _row_to_fragment(row: dict) -> ProteinFragment:
     ann_raw = _clean("annotations")
     annotations = json.loads(ann_raw) if ann_raw else {}
 
+    prov_raw = _clean("field_provenance")
+    field_provenance = json.loads(prov_raw) if prov_raw else {}
+
     def _num(col):
         v = _clean(col)
         return float(v) if v is not None else None
+
+    def _count(col):
+        """An int, or None for a blank cell.
+
+        Blank means the source did not report a count, which is not the
+        same as reporting zero — so it must not become 0 on the way
+        through a file.
+        """
+        v = _clean(col)
+        return int(float(v)) if v is not None else None
 
     def _str(col):
         v = _clean(col)
@@ -115,6 +133,13 @@ def _row_to_fragment(row: dict) -> ProteinFragment:
         transcript_name=_str("transcript_name"),
         gene_expression=_num("gene_expression"),
         transcript_expression=_num("transcript_expression"),
+        n_overlapping_reads=_count("n_overlapping_reads"),
+        n_alt_reads=_count("n_alt_reads"),
+        n_ref_reads=_count("n_ref_reads"),
+        n_alt_reads_supporting_protein_sequence=_count(
+            "n_alt_reads_supporting_protein_sequence"
+        ),
+        field_provenance=field_provenance,
         annotations=annotations,
     )
 

--- a/topiary/protein_fragment.py
+++ b/topiary/protein_fragment.py
@@ -25,6 +25,22 @@ from typing import Iterable, Optional
 # =============================================================================
 
 
+#: How real a field's value is, for :attr:`ProteinFragment.field_provenance`.
+#:
+#: A field not named in the mapping is unqualified — it means what it
+#: says. These qualify a field that *has* a value, which is the case a
+#: bare ``None`` cannot express: "populated but estimated" and
+#: "populated but invented" are neither absent nor trustworthy.
+MEASURED = "measured"
+APPROXIMATED = "approximated"
+SYNTHESIZED = "synthesized"
+
+PROVENANCE_VALUES = frozenset({MEASURED, APPROXIMATED, SYNTHESIZED})
+
+#: Provenance values a consumer must not interpret as biology.
+_NOT_BIOLOGY = frozenset({SYNTHESIZED})
+
+
 @dataclass(frozen=True, eq=False)
 class ProteinFragment:
     """A protein/peptide sequence with source-type, target-region, and
@@ -76,6 +92,38 @@ class ProteinFragment:
         Ensembl id.
     gene_expression, transcript_expression : float, optional
         Expression evidence carried forward into prediction rows.
+    n_overlapping_reads, n_alt_reads, n_ref_reads, \
+n_alt_reads_supporting_protein_sequence : int, optional
+        RNA read-level evidence.  Not derivable from the aggregate
+        expression fields above, and separately useful: a consumer that
+        weights a candidate by depth of support needs the counts, not a
+        TPM.  ``n_alt_reads_supporting_protein_sequence`` is deliberately
+        distinct from ``n_alt_reads`` — it counts reads supporting *this
+        assembled protein sequence*, not merely the variant allele.
+
+        ``None`` means **unknown**, and is not the same as ``0``.  A
+        source with no read data leaves these ``None``; a source that
+        looked and found no support sets ``0``.  Collapsing the two
+        would let a consumer read "no RNA support" out of "this source
+        cannot answer".
+    field_provenance : dict, optional
+        Per-field statement of how real a value is, mapping a field name
+        to one of :data:`PROVENANCE_VALUES`:
+
+        - ``"measured"`` — observed directly from data.
+        - ``"approximated"`` — derived or estimated, e.g. read counts
+          reconstructed as depth × VAF rather than counted.
+        - ``"synthesized"`` — a placeholder the loader invented because
+          the source did not supply one.  **Anything interpreting such a
+          field as biology must refuse rather than compute.**
+
+        A field absent from this mapping is unqualified: it means what
+        it says.  This exists so a consumer can tell a populated field
+        that is real from one that merely has a value — which a
+        multi-source abstraction cannot express any other way, since
+        every source populates a different subset and some of them
+        estimate.  Use :meth:`provenance_of`, :meth:`is_known` and
+        :meth:`is_usable_as_biology` rather than reading the dict.
     annotations : dict
         Tool-specific signals that don't fit the above fields.
         Serialized as JSON in TSV IO; carried through prediction as
@@ -106,6 +154,13 @@ class ProteinFragment:
     gene_expression: Optional[float] = None
     transcript_expression: Optional[float] = None
 
+    n_overlapping_reads: Optional[int] = None
+    n_alt_reads: Optional[int] = None
+    n_ref_reads: Optional[int] = None
+    n_alt_reads_supporting_protein_sequence: Optional[int] = None
+
+    field_provenance: dict = field(default_factory=dict)
+
     annotations: dict = field(default_factory=dict)
 
     # ------------------------------------------------------------------
@@ -123,6 +178,75 @@ class ProteinFragment:
 
     def __hash__(self):
         return hash(self.fragment_id)
+
+    def __post_init__(self):
+        """Reject a provenance mapping that cannot mean anything.
+
+        A typo'd field name or an unknown label would sit inert and
+        silently stop protecting the field it was written to protect,
+        which is worse than not writing it.
+        """
+        if not self.field_provenance:
+            return
+        if not isinstance(self.field_provenance, dict):
+            raise TypeError(
+                f"field_provenance must be a dict of field name -> "
+                f"provenance, got {type(self.field_provenance).__name__}"
+            )
+        known = {f.name for f in dataclasses.fields(self)}
+        for name, value in self.field_provenance.items():
+            if name not in known:
+                raise ValueError(
+                    f"field_provenance names {name!r}, which is not a "
+                    f"ProteinFragment field. Use annotations for "
+                    f"tool-specific signals."
+                )
+            if value not in PROVENANCE_VALUES:
+                raise ValueError(
+                    f"field_provenance[{name!r}] is {value!r}; use one of "
+                    f"{sorted(PROVENANCE_VALUES)}."
+                )
+
+    # ------------------------------------------------------------------
+    # Knownness
+    # ------------------------------------------------------------------
+
+    def provenance_of(self, name: str) -> Optional[str]:
+        """How real *name*'s value is, or ``None`` if unqualified."""
+        return self.field_provenance.get(name)
+
+    def is_known(self, name: str) -> bool:
+        """Whether *name* carries a value at all.
+
+        The distinction this exists for: ``n_alt_reads == 0`` means the
+        source looked and found no support; ``n_alt_reads is None``
+        means the source cannot answer. Both are legitimate and they are
+        not the same claim.
+        """
+        if name not in {f.name for f in dataclasses.fields(self)}:
+            raise ValueError(
+                f"{name!r} is not a ProteinFragment field."
+            )
+        return getattr(self, name) is not None
+
+    def is_approximate(self, name: str) -> bool:
+        """Whether *name*'s value was derived rather than observed."""
+        return self.provenance_of(name) == APPROXIMATED
+
+    def is_usable_as_biology(self, name: str) -> bool:
+        """Whether *name* may be interpreted as a fact about the sample.
+
+        False for a field that is absent, and for one whose value the
+        loader synthesized because the source supplied none — a
+        placeholder ref/alt, say, which anything doing variant effect
+        annotation must refuse rather than compute on. An approximated
+        value is usable but should be understood as an estimate; ask
+        :meth:`is_approximate` when that matters.
+        """
+        return (
+            self.is_known(name)
+            and self.provenance_of(name) not in _NOT_BIOLOGY
+        )
 
     # ------------------------------------------------------------------
     # Properties
@@ -183,13 +307,9 @@ class ProteinFragment:
         annotations.  Unknown keys are rejected to catch typos — pass
         them through ``annotations`` instead.
         """
-        known = {
-            "fragment_id", "source_type", "sequence",
-            "reference_sequence", "germline_sequence", "target_intervals",
-            "variant", "effect", "effect_type",
-            "gene", "gene_id", "transcript_id", "transcript_name",
-            "gene_expression", "transcript_expression", "annotations",
-        }
+        # Derived, not restated: a hand-maintained copy of the field
+        # list silently rejects every field added after it was written.
+        known = {f.name for f in dataclasses.fields(cls)}
         unknown = set(d.keys()) - known
         if unknown:
             raise ValueError(
@@ -215,6 +335,13 @@ class ProteinFragment:
             transcript_name=d.get("transcript_name"),
             gene_expression=d.get("gene_expression"),
             transcript_expression=d.get("transcript_expression"),
+            n_overlapping_reads=d.get("n_overlapping_reads"),
+            n_alt_reads=d.get("n_alt_reads"),
+            n_ref_reads=d.get("n_ref_reads"),
+            n_alt_reads_supporting_protein_sequence=d.get(
+                "n_alt_reads_supporting_protein_sequence"
+            ),
+            field_provenance=dict(d.get("field_provenance") or {}),
             annotations=dict(d.get("annotations") or {}),
         )
 


### PR DESCRIPTION
Toward #102. **Scope: the fragment shape only** — vaxrank's consumer
requirements 1 and 2. isovar integration is deliberately not here; see "What
this does not do" at the bottom.

## Why this half first

vaxrank's requirements comment on #102 names three things that are not
cosmetic. The third (isovar, optional in the strong sense) is the largest and
depends on the first two being settled, because the whole premise is that
**every source produces the same shape, differing only in which fields are
populated** — fields isovar alone can fill must be *absent-but-declared*
everywhere else, rather than the fragment having a different shape when isovar
is installed. So the shape comes first, and it is testable without isovar at
all.

## 1. Read-level evidence

```python
n_overlapping_reads
n_alt_reads
n_ref_reads
n_alt_reads_supporting_protein_sequence
```

Not derivable from the aggregate expression the fragment already carried — a
consumer weighting a candidate by depth of support needs counts, not a TPM.
`n_alt_reads_supporting_protein_sequence` is kept distinct from `n_alt_reads`
because it counts reads supporting *this assembled protein sequence*, not
merely the variant allele — a distinction only the assembler can make.

## 2. Absent is not zero — the requirement that matters most

`None` means unknown. `0` means the source looked and found no support. A
consumer must be able to tell them apart:

```python
fragment.is_known("n_alt_reads")     # not `if fragment.n_alt_reads:`
```

**And the distinction survives a TSV round trip** — there is a test for
exactly that, because a distinction that does not serialize is decorative.

### Provenance: populated is not the same as trustworthy

`None` cannot express two cases that matter. A LENS or pVACseq read count is
real but *estimated* (CDS-overlapping reads; depth × VAF). A placeholder
ref/alt invented because the source supplied none has a value that means
nothing. `field_provenance` says which:

```python
ProteinFragment(
    ...,
    variant="chr1:100:N>N",
    n_alt_reads=12,
    field_provenance={"variant": SYNTHESIZED, "n_alt_reads": APPROXIMATED},
)
```

| Provenance | Meaning |
|---|---|
| `measured` | Observed directly |
| `approximated` | Derived or estimated |
| `synthesized` | A placeholder the loader invented |

Read through accessors, not the dict: `is_known`, `provenance_of`,
`is_approximate`, and `is_usable_as_biology` — the last being the one that
matters for correctness, since it is `False` for an absent field *and* a
synthesized one. That is vaxrank's `placeholder_alleles` generalized: anything
interpreting a field as biology can refuse rather than compute.

A provenance entry naming a field that does not exist, or a label outside the
vocabulary, is **refused**. A typo would sit inert and quietly stop protecting
the field it was written for, which is worse than not writing it.

## A latent bug this surfaced

`ProteinFragment.from_dict` hardcoded its own copy of the field list, so it
rejected any field added after that list was written — these four would have
been the first casualties, and silently, since the failure is "unknown field"
on load rather than at definition. It now derives the set from
`dataclasses.fields` and cannot drift again.

## Tests

18 in `tests/test_fragment_evidence.py`, including the two vaxrank asked for by
name:

- **The degenerate pVACseq fragment flows through unchanged** — a peptide with
  no source context, an interval spanning all of it, no read data, no
  reference. They proposed this as the conformance test for the abstraction,
  and it checks that every evidence field says "unknown" *the same way a richly
  populated fragment would*.
- **A consumer need not branch on `source_type`** — one function reads an
  isovar-like, a LENS-like and a varcode-only fragment and gets `[12, 8, None]`.

Plus: zero vs unknown, both in memory and across a file; a synthesized field
being known but not usable as biology; an approximated one being usable but
marked; the two validation refusals; and `from_dict` accepting every field the
dataclass has.

## What this does not do

- **No isovar integration.** The adapter and the optional-dependency wiring are
  the natural follow-up. topiary's existing pattern for "optional in the strong
  sense" is already there — `pirlygenes` is absent from `requirements.txt` and
  imported lazily behind a version-checked guard — so isovar would follow it.
- **No population of the new fields by existing readers.** `read_lens` and
  `read_pvacseq` can both approximate read counts (differently), and doing so
  is a separate change with its own correctness questions — notably that both
  would need `field_provenance={"n_alt_reads": APPROXIMATED}` to be honest.
- **No `supporting_reference_transcripts`** and no WT-comparator work
  (vaxrank's "smaller notes").

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2002 passed, 3 skipped

Version 5.32.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
