### PR TITLE
Stop treating a missing value as the text "nan" (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 5.34.0
+
+Two more absent-vs-empty conflations (#223), found by auditing after #214,
+#216 and #219 all turned out to be the same defect: two code paths
+disagreeing about what "nothing" means. Both turned a missing value into
+the literal text `"nan"` and then treated it as data.
+
+**Fixed: a row with no `predictor_version` could be selected as version
+`"nan"`.** 5.31.0 taught the ambiguity check and
+`resolve_default_versions` that a missing version names no version, but
+the *selection* path still compared stringified values — so the two
+disagreed, and `Affinity["netmhcpan", "nan"]` returned the NaN-version
+row. It was self-inconsistent too: the "no such version" error lists
+available versions from `dropna()`, so `"nan"` was never offered, yet
+passing it worked. Selection now goes through the same
+"was a version named at all" test as everything else, and tolerates
+surrounding whitespace the way the resolver does.
+
+**Fixed: `read_pvacseq` fabricated variant ids containing `"nan"`.** The
+coordinate fallback (used when a file has no `Index` column) concatenated
+stringified `Chromosome`/`Start`/`Reference`/`Variant`, so a blank field
+became text inside the identifier:
+
+```
+chr1-154590262-nan-A
+```
+
+Well-formed-looking, wrong, and *stable* — every row sharing that gap
+grouped together under one fabricated id, silently. Such rows now get a
+null `variant` and a warning naming how many and which columns were
+incomplete. An absent identifier is honest; a fabricated one is not, and
+nothing downstream can tell it from a real one. Files with complete
+coordinates, and files with an `Index` column, are unchanged and silent.
+
 ## 5.33.0
 
 **Added: per-peptide allele sets for `EvalContext(alleles=...)` (#219).**

--- a/tests/test_absent_vs_empty_audit.py
+++ b/tests/test_absent_vs_empty_audit.py
@@ -1,0 +1,162 @@
+"""Two more absent-vs-empty conflations (topiary #223).
+
+Found by auditing after #214, #216 and #219 all turned out to be the same
+defect: two code paths disagreeing about what "nothing" means. Both of these
+turn a missing value into the literal text "nan" and then treat it as data.
+"""
+
+import pathlib
+import tempfile
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary import Affinity, evaluate_scores, read_pvacseq, resolve_default_versions
+
+PVACSEQ = pathlib.Path(__file__).parent / "data" / "pvacseq" / "mhc_i_all_epitopes.tsv"
+
+
+def _versioned(pairs):
+    return pd.DataFrame([
+        dict(source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+             allele="HLA-A*02:01", kind="pMHC_affinity", value=value,
+             score=0.5, percentile_rank=1.0,
+             prediction_method_name="netmhcpan", predictor_version=version)
+        for value, version in pairs
+    ])
+
+
+# ---------------------------------------------------------------------------
+# A row with no version cannot be selected by one
+# ---------------------------------------------------------------------------
+#
+# The ambiguity check and resolve_default_versions were taught in 5.31.0 that
+# NaN names no version. The selection path still compared stringified values,
+# so the two disagreed: one said the row names nothing, the other said it
+# names "nan" — and let you address it that way.
+
+
+@pytest.mark.parametrize("missing", [np.nan, None, "", "  ", "nan"],
+                         ids=["nan", "none", "empty", "blank", "literal-nan"])
+def test_a_missing_version_cannot_be_selected_as_nan(missing):
+    df = _versioned([(75.0, "4.2"), (999.0, missing)])
+
+    with pytest.raises(ValueError, match="predictor_version 'nan'"):
+        evaluate_scores(df, Affinity["netmhcpan", "nan"].value)
+
+
+def test_the_available_list_omits_missing_versions():
+    """It already did — the bug was that the omitted one still matched."""
+    df = _versioned([(75.0, "4.2"), (999.0, np.nan)])
+
+    with pytest.raises(ValueError) as excinfo:
+        evaluate_scores(df, Affinity["netmhcpan", "nan"].value)
+
+    assert "Available: ['4.2']" in str(excinfo.value)
+
+
+def test_a_real_version_still_selects():
+    df = _versioned([(75.0, "4.2"), (999.0, np.nan)])
+
+    scores = evaluate_scores(df, Affinity["netmhcpan", "4.2"].value)
+
+    assert scores.dropna().unique().tolist() == [75.0]
+
+
+def test_selection_tolerates_surrounding_whitespace():
+    """The resolver strips, so selection must match on the same shape."""
+    df = _versioned([(75.0, " 4.2 "), (999.0, np.nan)])
+
+    scores = evaluate_scores(df, Affinity["netmhcpan", "4.2"].value)
+
+    assert scores.dropna().unique().tolist() == [75.0]
+
+
+def test_selection_and_the_resolver_agree():
+    """The property the bug violated: one notion of "is this a version"."""
+    df = _versioned([(75.0, "4.1b"), (120.0, "4.2"), (999.0, np.nan)])
+
+    resolved = resolve_default_versions(df)
+    scores = evaluate_scores(df, Affinity.value, default_versions=resolved)
+
+    assert resolved == {("pMHC_affinity", "netmhcpan"): "4.2"}
+    assert scores.dropna().unique().tolist() == [120.0]
+
+
+# ---------------------------------------------------------------------------
+# pVACseq must not fabricate a variant id
+# ---------------------------------------------------------------------------
+#
+# The coordinate fallback concatenated stringified columns, so a blank field
+# became the text "nan" inside the identifier: chr1-154590262-nan-A. Stable,
+# well-formed-looking, and wrong — every row sharing that gap grouped under
+# one fabricated id.
+
+
+def _fallback_file(tmp_path, blank_column=None, blank_row=0):
+    """The fixture without its Index column, so the coordinate id is used."""
+    df = pd.read_csv(PVACSEQ, sep="\t").drop(columns=["Index"])
+    if blank_column is not None:
+        df.loc[df.index[blank_row], blank_column] = None
+    path = tmp_path / "mhc_i_all_epitopes.tsv"
+    df.to_csv(path, sep="\t", index=False)
+    return path
+
+
+def test_a_missing_coordinate_gives_a_null_id_not_a_fabricated_one(tmp_path):
+    path = _fallback_file(tmp_path, blank_column="Reference")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = read_pvacseq(path)
+
+    ids = result.df["variant"]
+    assert ids.isna().any()
+    assert not any("nan" in str(v).lower() for v in ids.dropna())
+
+
+@pytest.mark.parametrize(
+    "column", ["Chromosome", "Start", "Reference", "Variant"],
+)
+def test_any_missing_component_nulls_the_id(tmp_path, column):
+    path = _fallback_file(tmp_path, blank_column=column)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = read_pvacseq(path)
+
+    assert not any(
+        "nan" in str(v).lower() for v in result.df["variant"].dropna()
+    )
+
+
+def test_the_omission_is_announced(tmp_path):
+    """Silently dropping an id would be its own absence bug."""
+    path = _fallback_file(tmp_path, blank_column="Reference")
+
+    with pytest.warns(UserWarning, match="no coordinate variant id"):
+        read_pvacseq(path)
+
+
+def test_complete_coordinates_are_unchanged_and_silent(tmp_path):
+    path = _fallback_file(tmp_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = read_pvacseq(path)
+
+    ids = sorted(result.df["variant"].dropna().unique())
+    assert ids[0].count("-") == 3
+    assert result.df["variant"].notna().all()
+
+
+def test_the_index_column_still_wins_when_present():
+    """The fallback is only for files with no Index; that path is untouched."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = read_pvacseq(PVACSEQ)
+
+    assert not any("-" == str(v)[3] for v in result.df["variant"].dropna()[:1])
+    assert result.df["variant"].notna().all()

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -96,7 +96,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.33.0"
+__version__ = "5.34.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_pvacseq.py
+++ b/topiary/io_pvacseq.py
@@ -48,6 +48,7 @@ should melt them out themselves or re-predict via :class:`TopiaryPredictor`.
 from __future__ import annotations
 
 import re
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -254,6 +255,52 @@ def _first_present_column(df, *candidates):
     return None
 
 
+def _coords_variant_id(df: pd.DataFrame) -> pd.Series:
+    """A ``chr-start-ref-alt`` id, or null where a part is missing.
+
+    Concatenating the stringified columns turns a blank field into the
+    literal text ``nan`` inside the identifier — ``chr1-154590262-nan-A``
+    — which looks well-formed, is wrong, and is *stable*, so every row
+    sharing that gap silently groups together under one fabricated id.
+
+    An absent identifier is honest; a fabricated one is not, and nothing
+    downstream can tell it from a real one. Rows missing any part get
+    ``pd.NA`` and are counted in a warning.
+    """
+    parts = ["Chromosome", "Start", "Reference", "Variant"]
+    text = {}
+    complete = pd.Series(True, index=df.index)
+    for part in parts:
+        column = df[part]
+        known = column.notna() & (
+            column.astype(str).str.strip().str.lower().ne("nan")
+        ) & column.astype(str).str.strip().ne("")
+        complete &= known
+        text[part] = column.astype(str).str.strip()
+
+    ids = (
+        text["Chromosome"] + "-" + text["Start"] + "-"
+        + text["Reference"] + "-" + text["Variant"]
+    ).where(complete, pd.NA)
+
+    missing = int((~complete).sum())
+    if missing:
+        incomplete = sorted(
+            part for part in parts
+            if (df[part].isna() | df[part].astype(str).str.strip().eq("")).any()
+        )
+        warnings.warn(
+            f"{missing} pVACseq row(s) are missing one of "
+            f"{parts} ({incomplete} incomplete), so no coordinate variant "
+            f"id could be built for them and 'variant' is null there. "
+            f"Building one anyway would embed the missing field as the "
+            f"text 'nan', producing an id that looks real and silently "
+            f"groups every row sharing that gap.",
+            UserWarning, stacklevel=3,
+        )
+    return ids
+
+
 def _class_of_allele(allele):
     """Return ``"I"`` / ``"II"`` for an allele string, else ``pd.NA``.
 
@@ -447,12 +494,7 @@ def _parse_all_epitopes(df):
     if "Index" in df.columns:
         out["variant"] = df["Index"]
     elif {"Chromosome", "Start", "Reference", "Variant"} <= set(df.columns):
-        out["variant"] = (
-            df["Chromosome"].astype(str) + "-"
-            + df["Start"].astype(str) + "-"
-            + df["Reference"].astype(str) + "-"
-            + df["Variant"].astype(str)
-        )
+        out["variant"] = _coords_variant_id(df)
 
     for src, dst in _ALL_ANNOTATIONS.items():
         if src in df.columns:

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1624,10 +1624,20 @@ def _filter_kind_method_version(ctx, kind, method, version):
     if version is not None:
         col = "predictor_version"
         if col in sub.columns:
-            version_mask = sub[col].astype(str) == str(version)
+            # Only a row that names a version can be selected by one.
+            # Comparing stringified values would let a missing version
+            # be addressed as "nan" — the same conflation the ambiguity
+            # check and resolve_default_versions were fixed for, and the
+            # two must not disagree about it.
+            named = _known_versions(sub[col])
+            version_mask = named & (
+                sub[col].astype(str).str.strip() == str(version).strip()
+            )
             matched = sub[version_mask]
             if matched.empty:
-                available = sorted(sub[col].dropna().astype(str).unique())
+                available = sorted(
+                    sub[col][named].astype(str).str.strip().unique()
+                )
                 raise ValueError(
                     f"No {_kind_name(kind)} predictions from "
                     f"predictor_version {version!r}. "
@@ -1691,7 +1701,11 @@ def _filter_kind_method_version(ctx, kind, method, version):
         }
         if len(wanted) == 1:
             candidate = next(iter(wanted))
-            matched = sub[sub["predictor_version"].astype(str) == candidate]
+            versions = sub["predictor_version"]
+            matched = sub[
+                _known_versions(versions)
+                & (versions.astype(str).str.strip() == candidate)
+            ]
             if not matched.empty:
                 sub = matched
                 effective_version = candidate


### PR DESCRIPTION
Closes #223.

Both findings from an audit prompted by noticing that #214, #216 and #219 were
the same defect wearing three faces: **two code paths disagreeing about what
"nothing" means.** I swept for the mechanical signatures — `astype(str)` on
nullable columns, `x or default`, `fillna("")` then comparing, key-presence vs
emptiness — and verified every candidate at runtime rather than by reading.

## 1. A row with no version could be selected as version `"nan"`

```python
# rows: netmhcpan 4.2 (75.0), netmhcpan NaN (999.0)
evaluate_scores(df, Affinity["netmhcpan", "nan"].value)   # -> [999.0]
```

**This one is mine, and it is specifically a half-finished fix.** 5.31.0 added
`_known_versions` and taught the ambiguity check and `resolve_default_versions`
that a missing version names no version. The selection path was not changed, so
after that release the two actively disagreed:

- the ambiguity check: this row names no version
- the selection path: this row names `"nan"`, here it is

It was also self-inconsistent in a way that should have been a clue — the "no
such version" error builds `available` from `.dropna()`, so `"nan"` was never
offered as a choice, yet passing it worked.

Selection now runs through the same `_known_versions` test as everything else,
and strips surrounding whitespace the way the resolver already did, so
`" 4.2 "` in the frame matches `"4.2"` from the resolver.

## 2. `read_pvacseq` fabricated variant ids containing `"nan"`

The coordinate fallback — used when a file has no `Index` column — concatenated
stringified `Chromosome`/`Start`/`Reference`/`Variant`:

```python
read_pvacseq(path)["variant"].unique()
# ['chr1-154590262-nan-A', 'chr1-154590262-T-A', ...]
```

No warning. The id looks well-formed, is wrong, and is **stable** — so every
row sharing that gap silently groups under one fabricated identifier, which is
worse than a missing one because nothing downstream can tell it from a real id.

Those rows now get `pd.NA` and a warning naming how many rows and which columns
were incomplete. An absent identifier is honest; a fabricated one is not.

This is the same class as the placeholder-alleles problem vaxrank raised on
#102 — an identifier synthesized from data the source did not supply.
`ProteinFragment.field_provenance` (5.32.0) has `SYNTHESIZED` for exactly this
situation; here there is no fragment to attach it to, so refusing to invent the
id is the honest equivalent.

Files with complete coordinates, and files carrying an `Index` column, are
unchanged and silent — both have tests.

## Checked and ruled out

Recorded so the audit is reproducible rather than a claim:

- `wide.py:161` `fillna("unknown")` on `prediction_method_name` — deliberate,
  documented sentinel, and the real key is recorded in `topiary_model_keys`.
- `cached.py` `astype(str)` on version columns — inside the cache invariant
  check, which explicitly tests for `"nan"` / `"None"` strings a few lines
  above.
- `result.py:170` `value or "unknown"` — a display label, not data.
- `read_lens` → `to_long()` → `to_wide()` — verified clean.

## Tests

17 in `tests/test_absent_vs_empty_audit.py`, parameterized over the five
spellings of a missing version (`NaN`, `None`, `""`, `"  "`, `"nan"`) and each
of the four coordinate components.

The one that matters most asserts the property the bug violated: selection and
the resolver agree on what counts as a version, on a frame carrying two real
versions *and* a missing one.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2050 passed, 3 skipped

Version 5.34.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
