### PR TITLE
Collapse the spellings of a missing allele in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 5.35.1
+
+**Fixed: `CachedPredictor` turned a missing allele into the allele named
+`"None"`** — the cache axis of the defect 5.35.0 centralized.
+
+`_normalize` rejects null identity columns for `prediction_method_name`,
+`predictor_version` and `kind`, with a comment saying why, then applied
+`astype(str)` to `allele` and `peptide` without the same guard. The
+reasoning was written down and not applied one field over.
+
+Two consequences. The cache keys on
+`(peptide, allele, peptide_length, kind)`, so `None`, `NaN` and `""`
+were three different keys, and one predictor's allele-free evidence sat
+in three buckets while still looking present in the store. And
+`.alleles` — the mhctools surface answering "what can this predict for"
+— reported the string `"None"` as a queryable allele.
+
+An allele-free row is legitimate (`proteasome_cleavage` and the other
+peptide-level kinds have no allele), so `allele` collapses every
+spelling onto `""`, the way `n_flank` / `c_flank` already did, and
+`.alleles` excludes allele-free rows. A missing `peptide` *is* rejected
+— there is no such thing as a peptide-free prediction.
+
+Found by following a downstream report of the identical shape in their
+own store, where the same spellings split one predictor's evidence
+across four buckets.
+
 ## 5.35.0
 
 **Changed: `_fragment_from_effect` is now public as `fragment_from_effect`.**

--- a/tests/test_cache_allele_nulls.py
+++ b/tests/test_cache_allele_nulls.py
@@ -1,0 +1,110 @@
+"""A spelling of "nothing" must not become an allele (topiary, cache axis).
+
+Found by following a report from a downstream consumer, who hit the same
+shape in their own store: one predictor's unversioned evidence split across
+four buckets because NaN, "nan", None and "" were four different keys.
+
+`CachedPredictor._normalize` rejected null identity columns for
+prediction_method_name, predictor_version and kind — with a comment saying
+why — and then applied `astype(str)` to `allele` and `peptide` without the
+same guard. The reasoning was written down and not applied one field over.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary import CachedPredictor
+
+
+def _row(allele, peptide="SIINFEKLA", kind="proteasome_cleavage"):
+    return dict(
+        peptide=peptide, peptide_length=9, allele=allele, kind=kind,
+        value=0.9, score=0.9, percentile_rank=1.0,
+        prediction_method_name="netchop", predictor_version="1.0",
+    )
+
+
+def _cache(rows):
+    return CachedPredictor(pd.DataFrame(rows))
+
+
+# ---------------------------------------------------------------------------
+# Every spelling of "no allele" is one bucket
+# ---------------------------------------------------------------------------
+
+
+def test_the_spellings_of_a_missing_allele_collapse():
+    """None, NaN and "" are one key, not three.
+
+    The cache keys on (peptide, allele, peptide_length, kind), so three
+    spellings meant one predictor's allele-free evidence sat in three
+    buckets while still looking present in the store.
+    """
+    cache = _cache([
+        _row(None, "AAAAAAAAA"), _row(np.nan, "CCCCCCCCC"), _row("", "DDDDDDDDD"),
+    ])
+
+    assert set(cache._df["allele"]) == {""}
+
+
+def test_an_allele_free_row_is_still_accepted():
+    """Rejecting it would break caching for proteasome_cleavage and friends."""
+    cache = _cache([_row(None)])
+
+    assert len(cache._df) == 1
+
+
+def test_a_real_allele_is_untouched():
+    cache = _cache([_row("HLA-A*02:01")])
+
+    assert set(cache._df["allele"]) == {"HLA-A*02:01"}
+
+
+# ---------------------------------------------------------------------------
+# .alleles is what the cache can answer for
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_allele_is_not_reported_as_an_allele():
+    """It surfaced as the literal string "None" through the mhctools
+    protocol, offering callers an allele they cannot predict for."""
+    cache = _cache([_row("HLA-A*02:01"), _row(None, "KLQAAMAVL")])
+
+    assert cache.alleles == ["HLA-A*02:01"]
+
+
+@pytest.mark.parametrize("missing", [None, np.nan, "", "  "],
+                         ids=["none", "nan", "empty", "blank"])
+def test_no_spelling_of_missing_reaches_the_allele_list(missing):
+    cache = _cache([_row("HLA-A*02:01"), _row(missing, "KLQAAMAVL")])
+
+    assert cache.alleles == ["HLA-A*02:01"]
+
+
+def test_an_all_allele_free_cache_reports_no_alleles():
+    cache = _cache([_row(None), _row(np.nan, "KLQAAMAVL")])
+
+    assert cache.alleles == []
+
+
+# ---------------------------------------------------------------------------
+# peptide is never legitimately absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", [None, np.nan, ""],
+                         ids=["none", "nan", "empty"])
+def test_a_missing_peptide_is_refused(missing):
+    """Unlike allele, there is no such thing as a peptide-free prediction;
+    astype(str) would have made it the peptide named "None"."""
+    with pytest.raises(ValueError, match="'peptide' must be a non-empty"):
+        _cache([_row("HLA-A*02:01", peptide=missing)])
+
+
+def test_the_existing_identity_guards_still_hold():
+    for column in ("prediction_method_name", "predictor_version", "kind"):
+        rows = [_row("HLA-A*02:01")]
+        rows[0][column] = None
+        with pytest.raises(ValueError, match=column):
+            _cache(rows)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -107,7 +107,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.35.0"
+__version__ = "5.35.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -191,6 +191,16 @@ class CachedPredictor:
                 f"(peptide, allele, peptide_length, kind); missing "
                 f"kind would collide across kinds."
             )
+        # peptide is the other half of the cache key and is never
+        # legitimately absent — reject it the same way rather than
+        # letting astype(str) turn it into the string "None".
+        na_mask = ~stated_values(df["peptide"])
+        if na_mask.any():
+            raise ValueError(
+                f"CachedPredictor: column 'peptide' must be a non-empty "
+                f"string on every row (got {int(na_mask.sum())} "
+                f"null/empty value(s))."
+            )
         keep = [c for c in _CACHE_COLUMNS if c in df.columns]
         out = df[keep].copy()
         # n_flank / c_flank are part of the composite key — backfill
@@ -203,7 +213,17 @@ class CachedPredictor:
             else:
                 out[flank_col] = out[flank_col].map(_flank_key)
         out["peptide"] = out["peptide"].astype(str)
-        out["allele"] = out["allele"].astype(str)
+        # allele *is* legitimately absent — an allele-free kind
+        # (proteasome_cleavage, antigen_processing) has no allele. But
+        # astype(str) would spell each absence differently: None becomes
+        # "None", NaN becomes "nan", and "" stays "". Since the cache
+        # keys on (peptide, allele, peptide_length, kind), that splits
+        # one predictor's allele-free evidence across three buckets and
+        # surfaces "None" from .alleles as if it were an allele. Collapse
+        # every spelling onto one, the way n_flank/c_flank are.
+        out["allele"] = out["allele"].where(
+            stated_values(out["allele"]), ""
+        ).astype(str)
         out["peptide_length"] = out["peptide_length"].astype(int)
         out["kind"] = out["kind"].astype(str)
         # Version strings may look numeric ("1.0") and get coerced by
@@ -316,7 +336,14 @@ class CachedPredictor:
 
     @property
     def alleles(self):
-        a = set(self._df["allele"].unique().tolist())
+        """Alleles this cache can answer for.
+
+        Allele-free rows are excluded: a row with no allele is not a
+        row about an allele, and reporting its blank key here would
+        offer callers an allele they cannot predict for.
+        """
+        column = self._df["allele"]
+        a = set(column[stated_values(column)].unique().tolist())
         if self.fallback is not None:
             a.update(getattr(self.fallback, "alleles", []))
         return sorted(a)


### PR DESCRIPTION
The cache axis of the defect 5.35.0 centralized — found by following a
downstream report rather than by sweeping.

## What was wrong

`CachedPredictor._normalize` rejects null identity columns for
`prediction_method_name`, `predictor_version` and `kind`, with a comment
explaining that a silent `None`/`NaN` would mask the version invariant. It then
applies `astype(str)` to `allele` and `peptide` with no such guard.

**The reasoning was written down and not applied one field over.**

```python
CachedPredictor(df_with_one_allele_free_row).alleles
# ['HLA-A*02:01', 'None']    <- the string "None", offered as a queryable allele
```

Two consequences:

- The cache keys on `(peptide, allele, peptide_length, kind)`, so `None`, `NaN`
  and `""` were **three different keys**. One predictor's allele-free evidence
  sat in three buckets while still looking present in the store — unreachable
  but not missing.
- `.alleles` is the mhctools protocol surface answering "what can this predict
  for". It reported `"None"`, offering a caller an allele it cannot predict for.

## The fix, and why it is not a rejection

An allele-free row is **legitimate** — `proteasome_cleavage`,
`antigen_processing` and the other peptide-level kinds have no allele, and
caching them is the point. So `allele` collapses every spelling onto `""`, the
way `n_flank` / `c_flank` already did, and `.alleles` excludes allele-free rows.

A missing `peptide` **is** rejected: there is no such thing as a peptide-free
prediction, so the only thing `astype(str)` could produce there is a peptide
named `"None"`.

## Provenance of the find

A downstream consumer reported the identical shape in their own store — `NaN`,
`"nan"`, `None` and `""` becoming four version buckets for one predictor, plus
a `TypeError` sorting a mixed str/None version key. Their framing: their sort
docstring already explained why float keys need a nan-safe wrapper, and the same
reasoning was not applied to the version field beside it.

I checked topiary for both. The version sort key is total —
`(0, sentinel, str(value))` makes everything comparable — so there is no crash
here. This cache guard is the same omission in a different place.

## Tests

13 in `tests/test_cache_allele_nulls.py`: the spellings collapsing to one key;
an allele-free row still accepted; a real allele untouched; `.alleles` excluding
every spelling of missing (parameterized); an all-allele-free cache reporting no
alleles; a missing peptide refused (parameterized); and the three existing
identity guards still holding.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2103 passed, 3 skipped

Version 5.35.1.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
