### PR TITLE
Refuse a cache key that has two different answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ one peptide into a single key with two values — so the fix for one
 silent-pick created the conditions for another, which is why it is worth
 closing rather than leaving as a caller error.
 
+The check runs *after* the single-model invariant. A cache spanning two
+models also has two rows per key, and "this cache spans two models" is
+the useful thing to say about it — checking duplicates first answered
+that frame with a message about duplicate keys instead.
+
 **A note on caches written before 5.35.1.** They repair themselves:
 `_normalize` runs on every load, so split allele buckets merge and no
 rows are lost. What does *not* repair itself is a cache whose split

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 5.36.0
+
+**Fixed: a `CachedPredictor` key with two answers silently returned one
+of them.** `CachedPredictor.concat` already guarded overlapping keys and
+raised by default, offering `on_overlap='last'/'first'/callable` to
+resolve. The plain constructor did not — so the same question had two
+answers depending on which door the rows came in, and a lookup on a
+duplicated key returned one value with nothing said.
+
+Both doors now agree. Rows that share a cache key but carry different
+predictions are refused, with the offending key named and the message
+pointing at `on_overlap`. Identical duplicates are dropped rather than
+refused: a file listing the same prediction twice is not a
+contradiction.
+
+This became directly reachable in 5.35.1. Collapsing every spelling of a
+missing allele onto one made a frame carrying `None` *and* `"nan"` for
+one peptide into a single key with two values — so the fix for one
+silent-pick created the conditions for another, which is why it is worth
+closing rather than leaving as a caller error.
+
+**A note on caches written before 5.35.1.** They repair themselves:
+`_normalize` runs on every load, so split allele buckets merge and no
+rows are lost. What does *not* repair itself is a cache whose split
+buckets held different values for what is now one key — that now raises
+on load rather than silently answering, which is the intended outcome. A
+rebuild is only needed if you cannot deduplicate the source rows.
+
 ## 5.35.1
 
 **Fixed: `CachedPredictor` turned a missing allele into the allele named

--- a/tests/test_cache_duplicate_keys.py
+++ b/tests/test_cache_duplicate_keys.py
@@ -121,3 +121,34 @@ def test_concat_can_still_be_told_which_wins():
     )
 
     assert merged._df["score"].tolist() == [0.9]
+
+
+# ---------------------------------------------------------------------------
+# Each guard owns its own case
+# ---------------------------------------------------------------------------
+
+
+def test_a_multi_model_cache_gets_the_multi_model_error():
+    """A cache spanning two models also has two rows per key.
+
+    `_unique_version_pair` already owns that case and names it precisely.
+    Running the duplicate check first would answer "duplicate key" to a
+    frame whose actual problem is that it holds two models — a worse
+    message for a case that has a good one.
+    """
+    df = pd.DataFrame([
+        dict(peptide="SIINFEKLA", peptide_length=9, allele="HLA-A*02:01",
+             kind="pMHC_affinity", value=value, score=0.5,
+             percentile_rank=1.0, prediction_method_name=method,
+             predictor_version="1.0")
+        for method, value in (("netmhcpan", 75.0), ("mhcflurry", 120.0))
+    ])
+
+    with pytest.raises(ValueError, match="span multiple"):
+        CachedPredictor(df)
+
+
+def test_a_single_model_cache_still_reaches_the_duplicate_check():
+    """The ordering must not shadow the check it was reordered around."""
+    with pytest.raises(ValueError, match="more than once with different"):
+        CachedPredictor(_rows([("HLA-A*02:01", 0.1), ("HLA-A*02:01", 0.9)]))

--- a/tests/test_cache_duplicate_keys.py
+++ b/tests/test_cache_duplicate_keys.py
@@ -1,0 +1,123 @@
+"""A cache key with two answers has no defined result (topiary).
+
+`CachedPredictor.concat` already guarded overlapping keys and raised by
+default. The plain constructor did not — so the same question had two
+answers depending on which door the rows came in, and a lookup on a
+duplicated key returned one value with nothing said.
+
+Reachable directly: after blank alleles were collapsed onto one spelling in
+5.35.1, a frame carrying two spellings of "no allele" for one peptide became
+exactly this case. Found while checking whether that fix could merge two
+rows into one key.
+"""
+
+import pandas as pd
+import pytest
+
+from topiary import CachedPredictor
+
+
+def _rows(pairs, peptide="SIINFEKLA"):
+    return pd.DataFrame([
+        dict(peptide=peptide, peptide_length=9, allele=allele,
+             kind="proteasome_cleavage", value=value, score=value,
+             percentile_rank=1.0, prediction_method_name="netchop",
+             predictor_version="1.0")
+        for allele, value in pairs
+    ])
+
+
+# ---------------------------------------------------------------------------
+# A key with two answers is refused
+# ---------------------------------------------------------------------------
+
+
+def test_two_predictions_for_one_key_are_refused():
+    with pytest.raises(ValueError, match="more than once with different"):
+        CachedPredictor(_rows([("HLA-A*02:01", 0.1), ("HLA-A*02:01", 0.9)]))
+
+
+def test_two_spellings_of_no_allele_are_refused_when_they_disagree():
+    """The case 5.35.1's collapse made reachable: "None" and "nan" are one
+    key now, so two different scores under them are one key with two
+    answers."""
+    with pytest.raises(ValueError, match="more than once with different"):
+        CachedPredictor(_rows([("None", 0.1), ("nan", 0.9)]))
+
+
+def test_the_error_names_the_offending_key():
+    with pytest.raises(ValueError) as excinfo:
+        CachedPredictor(_rows([("HLA-A*02:01", 0.1), ("HLA-A*02:01", 0.9)]))
+
+    message = str(excinfo.value)
+    assert "SIINFEKLA" in message
+    assert "on_overlap" in message      # points at the resolution concat offers
+
+
+# ---------------------------------------------------------------------------
+# What is not a conflict
+# ---------------------------------------------------------------------------
+
+
+def test_identical_duplicates_are_dropped_not_refused():
+    """A file listing the same prediction twice is not a contradiction."""
+    cache = CachedPredictor(
+        _rows([("HLA-A*02:01", 0.5), ("HLA-A*02:01", 0.5)])
+    )
+
+    assert len(cache._df) == 1
+
+
+def test_two_spellings_of_no_allele_agreeing_collapse_quietly():
+    cache = CachedPredictor(_rows([("None", 0.5), ("nan", 0.5)]))
+
+    assert len(cache._df) == 1
+    assert set(cache._df["allele"]) == {""}
+
+
+def test_distinct_alleles_are_untouched():
+    cache = CachedPredictor(
+        _rows([("HLA-A*02:01", 0.1), ("HLA-B*07:02", 0.9)])
+    )
+
+    assert len(cache._df) == 2
+
+
+def test_distinct_peptides_are_untouched():
+    cache = pd.concat([
+        _rows([("HLA-A*02:01", 0.1)], peptide="SIINFEKLA"),
+        _rows([("HLA-A*02:01", 0.9)], peptide="KLQAAMAVL"),
+    ], ignore_index=True)
+
+    assert len(CachedPredictor(cache)._df) == 2
+
+
+def test_a_single_row_cache_is_fine():
+    assert len(CachedPredictor(_rows([("HLA-A*02:01", 0.5)]))._df) == 1
+
+
+# ---------------------------------------------------------------------------
+# The two doors now agree
+# ---------------------------------------------------------------------------
+
+
+def test_the_constructor_and_concat_agree_about_a_conflicting_key():
+    """concat raised and the constructor silently picked; both raise now."""
+    left = _rows([("HLA-A*02:01", 0.1)])
+    right = _rows([("HLA-A*02:01", 0.9)])
+
+    with pytest.raises(ValueError):
+        CachedPredictor.concat([CachedPredictor(left), CachedPredictor(right)])
+    with pytest.raises(ValueError):
+        CachedPredictor(pd.concat([left, right], ignore_index=True))
+
+
+def test_concat_can_still_be_told_which_wins():
+    left = _rows([("HLA-A*02:01", 0.1)])
+    right = _rows([("HLA-A*02:01", 0.9)])
+
+    merged = CachedPredictor.concat(
+        [CachedPredictor(left), CachedPredictor(right)], on_overlap="last",
+    )
+
+    assert merged._df["score"].tolist() == [0.9]

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -107,7 +107,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.35.1"
+__version__ = "5.36.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -150,8 +150,13 @@ class CachedPredictor:
             return
 
         self._df = self._normalize(df)
+        # Order matters: a frame spanning two models also has two rows
+        # per key, and _unique_version_pair names that case precisely.
+        # Checking duplicates first would answer a multi-model cache
+        # with a message about duplicate keys instead.
         self.prediction_method_name, self.predictor_version = \
             self._unique_version_pair(self._df)
+        self._df = self._reject_conflicting_duplicates(self._df)
         self._index, self._prefix_index = self._build_index(self._df)
 
     # --- normalization + invariants ---------------------------------
@@ -231,7 +236,7 @@ class CachedPredictor:
         # compares the same shape on both sides of a round-trip.
         out["prediction_method_name"] = out["prediction_method_name"].astype(str)
         out["predictor_version"] = out["predictor_version"].astype(str)
-        return CachedPredictor._reject_conflicting_duplicates(out)
+        return out
 
     @staticmethod
     def _reject_conflicting_duplicates(out: pd.DataFrame) -> pd.DataFrame:
@@ -247,6 +252,11 @@ class CachedPredictor:
 
         Identical duplicates are dropped rather than refused: a file
         listing the same prediction twice is not a contradiction.
+
+        Runs after :meth:`_unique_version_pair`, which owns the
+        multi-model case — a cache holding two models also has two rows
+        per key, and "this cache spans two models" is the useful thing
+        to say about it.
         """
         key_cols = [c for c in _KEY_COLS if c in out.columns]
         if not key_cols or out.empty:

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -231,7 +231,55 @@ class CachedPredictor:
         # compares the same shape on both sides of a round-trip.
         out["prediction_method_name"] = out["prediction_method_name"].astype(str)
         out["predictor_version"] = out["predictor_version"].astype(str)
-        return out
+        return CachedPredictor._reject_conflicting_duplicates(out)
+
+    @staticmethod
+    def _reject_conflicting_duplicates(out: pd.DataFrame) -> pd.DataFrame:
+        """Refuse two rows that share a cache key but disagree.
+
+        ``concat`` already guards this and raises by default; the plain
+        constructor did not, so the same question had two answers
+        depending on which door the rows came in. A lookup on a
+        duplicated key silently returned one of the values with nothing
+        said — and after blank alleles were collapsed onto one spelling
+        (5.35.1) a frame carrying two spellings of "no allele" for one
+        peptide became exactly that case.
+
+        Identical duplicates are dropped rather than refused: a file
+        listing the same prediction twice is not a contradiction.
+        """
+        key_cols = [c for c in _KEY_COLS if c in out.columns]
+        if not key_cols or out.empty:
+            return out
+        dup_mask = out.duplicated(subset=key_cols, keep=False)
+        if not dup_mask.any():
+            return out
+
+        value_cols = [
+            c for c in ("value", "score", "percentile_rank",
+                        "prediction_method_name", "predictor_version")
+            if c in out.columns
+        ]
+        deduped = out.drop_duplicates(subset=key_cols + value_cols)
+        conflicting = deduped.duplicated(subset=key_cols, keep=False)
+        if conflicting.any():
+            sample = (
+                deduped[conflicting][key_cols].drop_duplicates()
+                .head(3).to_dict("records")
+            )
+            n_keys = int(
+                deduped[conflicting][key_cols].drop_duplicates().shape[0]
+            )
+            raise ValueError(
+                f"CachedPredictor: {n_keys} cache key(s) appear more than "
+                f"once with different predictions. A cache is a lookup "
+                f"table, so a key with two answers has no defined result "
+                f"— one value would be returned and the other silently "
+                f"ignored. Sample: {sample}. Deduplicate the rows, or use "
+                f"CachedPredictor.concat(..., on_overlap='last'/'first') "
+                f"to say which wins."
+            )
+        return deduped.reset_index(drop=True)
 
     @staticmethod
     def _unique_version_pair(df: pd.DataFrame) -> tuple:


### PR DESCRIPTION
Found by asking whether 5.35.1's own fix could cause the next problem. It
could.

## Two doors, one question, different answers

`CachedPredictor.concat` guards overlapping keys and raises by default, with
`on_overlap='last'/'first'/callable` to resolve. The plain constructor did not
check at all:

```python
CachedPredictor(two_rows_one_key).predict_peptides_dataframe(["SIINFEKLA"])
# [0.9]     <- the other row's 0.1 silently ignored, no warning
```

Same for two identical real alleles, so this is not exotic — a cache is a
lookup table, and a key with two answers has no defined result.

## Why now

5.35.1 collapsed every spelling of a missing allele onto one, so a frame
carrying `None` **and** `"nan"` for one peptide became a *single* key holding
two values. The fix for one silent pick created the conditions for another.
That is what makes this worth closing rather than filing as caller error.

## The fix

Both doors agree now. Rows sharing a key with different predictions are
refused, naming the offending key and pointing at `on_overlap`. **Identical
duplicates are dropped rather than refused** — a file listing the same
prediction twice is not a contradiction, and raising there would break ordinary
inputs for no benefit.

## Caches on disk, checked rather than assumed

The downstream consumer asked me to be loud about rebuilding stale caches,
since they expose this as `--prediction-cache`. I checked before repeating that
advice, and it is stronger than necessary:

- **A pre-5.35.1 cache repairs itself on load.** `_normalize` runs on every
  construction, so split allele buckets merge and no rows are lost — verified
  on a file written with `"None"` / `"nan"` / `""` alleles.
- What does *not* repair itself is a cache whose split buckets held **different
  values** for what is now one key. That now raises on load rather than
  silently answering, which is the intended outcome.

So: a rebuild is only needed if the source rows cannot be deduplicated. The
changelog says this rather than "rebuild everything".

## Tests

10 in `tests/test_cache_duplicate_keys.py`: conflicting keys refused (both for
a real allele and for the two blank spellings that 5.35.1 made collide); the
error naming the key and pointing at `on_overlap`; identical duplicates dropped
quietly; agreeing blank spellings collapsing quietly; distinct alleles and
distinct peptides untouched; a single-row cache fine; **the constructor and
`concat` now agreeing on the same conflicting input**; and `concat` still able
to be told which wins.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2103 passed, 3 skipped

Version 5.36.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
