### PR TITLE
Put the genotype in the cache key (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 5.36.0
+
+**Fixed: the genotype is now part of the cache key (#229).**
+`CachedPredictor` keyed on
+`(peptide, allele, peptide_length, kind, n_flank, c_flank)`. MHCflurry
+presentation in haplotype mode scores a peptide against a whole genotype
+and reports the *deconvolved best allele*, so two different genotypes
+that deconvolve to the same best allele collided on every key column —
+and the lookup silently returned one of them.
+
+`_CACHE_COLUMNS` already said why this mattered:
+
+> The genotype a haplotype-mode prediction was scored against; blank for
+> per-allele rows. Without it a cached presentation row reads as a
+> prediction for its deconvolved best allele.
+
+`allele_set` joins the key on exactly the argument already made there for
+`n_flank` / `c_flank`: the same peptide in a different context produces a
+different score, so the context is part of the identity. Blank genotypes
+coexist with populated ones the way absent flanks do, and every spelling
+of "no genotype" — `None`, `NaN`, blank, `"nan"` — is one key rather
+than four.
+
+**Deliberately not in the key:** `source_sequence_name`, `peptide_offset`
+and `sample_name`. Those say where a peptide was *found*, not what was
+predicted about it, and a prediction for one
+(peptide, allele, length, kind, flanks, genotype) is the same prediction
+whichever protein or sample it came from. Keying on them would defeat
+the cache — the same peptide would be re-predicted once per source
+protein.
+
+Caches on disk keep loading; the key gains a dimension, so an entry
+written without a genotype keys as blank, which is what it is.
+
 ## 5.35.1
 
 **Fixed: `CachedPredictor` turned a missing allele into the allele named

--- a/tests/test_cache_key_allele_set.py
+++ b/tests/test_cache_key_allele_set.py
@@ -1,0 +1,158 @@
+"""The genotype belongs in the cache key (topiary #229).
+
+`_CACHE_COLUMNS` already said why:
+
+    # The genotype a haplotype-mode prediction was scored against; blank
+    # for per-allele rows. Without it a cached presentation row reads as
+    # a prediction for its deconvolved best allele.
+
+and then `allele_set` was not in `_KEY_COLS`. The reasoning was written down
+and not applied one field over — the third instance of that shape this week.
+
+It is exactly the argument the key already makes for `n_flank`/`c_flank`: the
+same peptide in two different contexts produces different scores, so the
+context is part of the identity.
+"""
+
+import numpy as np
+import pandas as pd
+
+from topiary import CachedPredictor
+
+GENOTYPE_A = "HLA-A*02:01,HLA-B*07:02"
+GENOTYPE_B = "HLA-A*02:01,HLA-B*44:02"
+
+
+def _row(**kwargs):
+    row = dict(
+        peptide="SIINFEKL", peptide_length=8, allele="HLA-A*02:01",
+        kind="pMHC_presentation", value=None, score=0.5,
+        percentile_rank=None, prediction_method_name="mhcflurry",
+        predictor_version="2.1",
+    )
+    row.update(kwargs)
+    return row
+
+
+def _cache(rows):
+    return CachedPredictor(pd.DataFrame(rows))
+
+
+# ---------------------------------------------------------------------------
+# Two genotypes are two predictions
+# ---------------------------------------------------------------------------
+
+
+def test_two_genotypes_sharing_a_best_allele_are_two_entries():
+    """MHCflurry haplotype mode reports the deconvolved best allele, so two
+    genotypes collide on every other key column. They are two questions."""
+    cache = _cache([
+        _row(score=0.9, allele_set=GENOTYPE_A),
+        _row(score=0.3, allele_set=GENOTYPE_B),
+    ])
+
+    assert len(cache._df) == 2
+    assert len(cache._index) == 2
+    assert sorted(cache._df["score"]) == [0.3, 0.9]
+
+
+def test_each_genotype_is_addressable():
+    cache = _cache([
+        _row(score=0.9, allele_set=GENOTYPE_A),
+        _row(score=0.3, allele_set=GENOTYPE_B),
+    ])
+
+    keys = set(cache._index)
+    assert CachedPredictor._row_key_from_values(
+        "SIINFEKL", "HLA-A*02:01", 8, "pMHC_presentation",
+        None, None, GENOTYPE_A,
+    ) in keys
+    assert CachedPredictor._row_key_from_values(
+        "SIINFEKL", "HLA-A*02:01", 8, "pMHC_presentation",
+        None, None, GENOTYPE_B,
+    ) in keys
+
+
+def test_a_per_allele_row_coexists_with_a_genotype_row():
+    """Blank genotype is its own entry, the way absent flanks are."""
+    cache = _cache([
+        _row(score=0.5, allele_set=""),
+        _row(score=0.9, allele_set=GENOTYPE_A),
+    ])
+
+    assert len(cache._index) == 2
+
+
+# ---------------------------------------------------------------------------
+# One spelling of "no genotype"
+# ---------------------------------------------------------------------------
+#
+# Adding a dimension to a key is a chance to add the absent-vs-empty bug on a
+# new axis, which is what #229 warned about. Every spelling of "no genotype"
+# has to be the same key.
+
+
+def test_every_spelling_of_no_genotype_is_one_key():
+    keys = {
+        CachedPredictor._row_key_from_values(
+            "SIINFEKL", "HLA-A*02:01", 8, "k", None, None, spelling,
+        )
+        for spelling in (None, np.nan, "", "   ", "nan", "None")
+    }
+
+    assert len(keys) == 1
+
+
+def test_a_frame_with_no_genotype_column_still_keys():
+    """allele_set is optional; the key shape must be stable without it."""
+    cache = _cache([_row(score=0.5)])
+
+    assert len(cache._index) == 1
+
+
+def test_two_spellings_of_no_genotype_do_not_split_the_cache():
+    cache = _cache([
+        _row(score=0.5, peptide="SIINFEKL", allele_set=None),
+        _row(score=0.7, peptide="KLQAAMAV", allele_set="nan"),
+    ])
+
+    assert set(cache._df["allele_set"]) == {""}
+    assert len(cache._index) == 2
+
+
+# ---------------------------------------------------------------------------
+# What stays out of the key, and why
+# ---------------------------------------------------------------------------
+#
+# Provenance says where a peptide was found, not what was predicted about it.
+# Keying on it would defeat the cache: the same peptide would be re-predicted
+# once per source protein.
+
+
+def test_provenance_does_not_split_a_prediction():
+    cache = _cache([
+        _row(score=0.5, source_sequence_name="BRAF", peptide_offset=1),
+        _row(score=0.5, source_sequence_name="KRAS", peptide_offset=9),
+    ])
+
+    assert len(cache._index) == 1
+
+
+def test_sample_name_does_not_split_a_prediction():
+    """Same peptide, same allele, same model — the same prediction."""
+    cache = _cache([
+        _row(score=0.5, sample_name="S1"),
+        _row(score=0.5, sample_name="S2"),
+    ])
+
+    assert len(cache._index) == 1
+
+
+def test_flanks_still_split_a_prediction():
+    """The precedent allele_set follows — unchanged."""
+    cache = _cache([
+        _row(score=0.5, n_flank="AAA", c_flank="CCC"),
+        _row(score=0.9, n_flank="GGG", c_flank="TTT"),
+    ])
+
+    assert len(cache._index) == 2

--- a/tests/test_cached_predictor.py
+++ b/tests/test_cached_predictor.py
@@ -49,6 +49,20 @@ def _df(rows):
 # ---------------------------------------------------------------------------
 
 
+def _key(peptide, allele="HLA-A*02:01", length=9, kind="pMHC_affinity",
+         n_flank=None, c_flank=None, allele_set=None):
+    """The cache key, asked of the builder rather than hand-written.
+
+    Spelling the tuple out in a test pins the key's *shape*, so adding a
+    dimension to the key breaks every such test for no behavioral reason
+    — and passes just as happily if the key is wrong. Ask the thing
+    under test what its key is; assert that the entry is indexed.
+    """
+    return CachedPredictor._row_key_from_values(
+        peptide, allele, length, kind, n_flank, c_flank, allele_set,
+    )
+
+
 class TestConstruction:
     def test_from_dataframe_minimal(self):
         cache = CachedPredictor.from_dataframe(_df([_row()]))
@@ -127,7 +141,7 @@ class TestPredictPeptides:
             _row(peptide="SIINFEKLA", kind="pMHC_affinity"),
             _row(peptide="SIINFEKLA", kind="pMHC_presentation"),
         ]))
-        key = ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
+        key = _key("SIINFEKLA")
         assert isinstance(cache._index[key], int)
         assert cache._prefix_index[("SIINFEKLA", "HLA-A*02:01", 9)] == [0, 1]
 
@@ -144,7 +158,7 @@ class TestPredictPeptides:
             _row(peptide="SIINFEKLA", kind="pMHC_affinity"),
             _row(peptide="SIINFEKLA", kind="pMHC_presentation"),
         ]))
-        key = ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
+        key = _key("SIINFEKLA")
         assert cache._index[key] == 0
 
     def test_miss_raises_without_fallback(self):
@@ -248,9 +262,7 @@ class TestFallback:
         cache.predict_peptides_dataframe(["GILGFVFTL"])
         # Second call should NOT hit fallback (we can verify by
         # observing the cache's internal df grew and contains it).
-        assert (
-            "GILGFVFTL", "HLA-A*02:01", 9, "pMHC_affinity", "", "",
-        ) in cache._index
+        assert _key("GILGFVFTL") in cache._index
         assert len(cache._df) == 2
 
     def test_fallback_version_mismatch_rejects(self):
@@ -288,7 +300,7 @@ class TestFallback:
         # overwrite the 42.0 sentinel.
         cache.predict_peptides_dataframe(["SIINFEKLA"])
         preserved_idx = cache._index[
-            ("SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "")
+            _key("SIINFEKLA")
         ]
         preserved = cache._df.iloc[preserved_idx]
         assert preserved["affinity"] == 42.0
@@ -349,9 +361,7 @@ class TestEmptyCacheWithFallback:
             fallback=_matched_fallback(name="random", version="3.0"),
         )
         cache.predict_peptides_dataframe(["SIINFEKLA"])
-        assert (
-            "SIINFEKLA", "HLA-A*02:01", 9, "pMHC_affinity", "", "",
-        ) in cache._index
+        assert _key("SIINFEKLA") in cache._index
 
     def test_empty_df_value_and_no_fallback_still_raises(self):
         empty = pd.DataFrame(columns=list(_row().keys()))

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -107,7 +107,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.35.1"
+__version__ = "5.36.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -37,7 +37,7 @@ from typing import Callable, Iterable, List, Mapping, Optional, Union
 import pandas as pd
 
 from .predictor import _backfill_value_from_score
-from .ranking import stated_values
+from .ranking import is_stated, stated_values
 
 
 # Columns a cache row must carry so the core invariant and lookup work.
@@ -77,9 +77,23 @@ _CACHE_COLUMNS = (
 #   different scores.  Absent flanks (None) coexist cleanly with
 #   populated flanks — predictors that don't use flanks just produce
 #   a single (None, None) entry per (peptide, allele, kind).
+# - allele_set: the genotype a haplotype-mode prediction was scored
+#   against.  Exactly the flank argument one field over: the same
+#   peptide scored against two different genotypes produces different
+#   scores, and MHCflurry presentation in haplotype mode reports the
+#   deconvolved best allele — so two genotypes sharing a best allele
+#   collide on every other key column.  Blank for per-allele rows,
+#   which coexist with genotype rows the way absent flanks do.
+#
+# Deliberately *not* in the key: source_sequence_name, peptide_offset,
+# sample_name.  Those say where a peptide was found, not what was
+# predicted about it, and a prediction for (peptide, allele, length,
+# kind, flanks, genotype) is the same prediction whichever protein or
+# sample it came from.  Keying on them would defeat the cache — the
+# same peptide would be re-predicted once per source protein.
 _KEY_COLS = (
     "peptide", "allele", "peptide_length", "kind",
-    "n_flank", "c_flank",
+    "n_flank", "c_flank", "allele_set",
 )
 
 
@@ -212,6 +226,17 @@ class CachedPredictor:
                 out[flank_col] = ""
             else:
                 out[flank_col] = out[flank_col].map(_flank_key)
+        # allele_set is part of the key for the same reason and gets the
+        # same treatment: materialize it so the key shape is well
+        # defined whether or not the source had a genotype column, and
+        # collapse every spelling of "no genotype" onto one so two
+        # spellings are not two cache entries.
+        if "allele_set" not in out.columns:
+            out["allele_set"] = ""
+        else:
+            out["allele_set"] = out["allele_set"].where(
+                stated_values(out["allele_set"]), ""
+            ).astype(str).str.strip()
         out["peptide"] = out["peptide"].astype(str)
         # allele *is* legitimately absent — an allele-free kind
         # (proteasome_cleavage, antigen_processing) has no allele. But
@@ -265,6 +290,7 @@ class CachedPredictor:
             row["kind"],
             row.get("n_flank"),
             row.get("c_flank"),
+            row.get("allele_set"),
         )
 
     @staticmethod
@@ -275,8 +301,16 @@ class CachedPredictor:
         kind,
         n_flank,
         c_flank,
+        allele_set=None,
     ):
-        """Composite cache key from already-extracted row values."""
+        """Composite cache key from already-extracted row values.
+
+        ``allele_set`` goes through the same not-stated rule the rest of
+        topiary uses, so a genotype column that has been through
+        ``astype(str)`` — carrying ``"nan"`` where it carried ``NaN`` —
+        keys the same as a genuinely blank one. Two spellings of "no
+        genotype" must not be two cache entries.
+        """
         return (
             str(peptide),
             str(allele),
@@ -284,6 +318,7 @@ class CachedPredictor:
             str(kind),
             _flank_key(n_flank),
             _flank_key(c_flank),
+            str(allele_set).strip() if is_stated(allele_set) else "",
         )
 
     @classmethod
@@ -300,6 +335,11 @@ class CachedPredictor:
             if "c_flank" in df.columns
             else repeat(None, n)
         )
+        allele_sets = (
+            df["allele_set"].to_numpy(copy=False)
+            if "allele_set" in df.columns
+            else repeat(None, n)
+        )
         for values in zip(
             df["peptide"].to_numpy(copy=False),
             df["allele"].to_numpy(copy=False),
@@ -307,6 +347,7 @@ class CachedPredictor:
             df["kind"].to_numpy(copy=False),
             n_flanks,
             c_flanks,
+            allele_sets,
         ):
             yield cls._row_key_from_values(*values)
 


### PR DESCRIPTION
Closes #229. Replaces the closed #228, which tried to police the collisions
instead of removing them.

## The bug

`CachedPredictor` keyed on
`(peptide, allele, peptide_length, kind, n_flank, c_flank)`. MHCflurry
presentation in haplotype mode scores a peptide against a *whole genotype* and
reports the deconvolved best allele — so two different genotypes that
deconvolve to the same best allele collide on every key column:

```python
CachedPredictor(two_genotypes_one_best_allele).predict_peptides_dataframe([...])
# one score returned, the other silently discarded
```

**`_CACHE_COLUMNS` already said why this mattered**, twelve lines above the key
that omits it:

> The genotype a haplotype-mode prediction was scored against; blank for
> per-allele rows. Without it a cached presentation row reads as a prediction
> for its deconvolved best allele.

The reasoning was written down and not applied one field over — the third
instance of that exact shape this week (the others: the cache's null guard
covering three columns and not the other two, and a downstream consumer's sort
docstring explaining nan-safety for float keys but not the version key beside
it).

## The fix

`allele_set` joins the key on precisely the argument the key already makes for
`n_flank` / `c_flank`, quoted from its own comment: *"the same peptide at two
different protein contexts produces different scores."* Same peptide, two
genotypes, two scores. Context is part of identity.

Blank genotypes coexist with populated ones the way absent flanks already do.

**Every spelling of "no genotype" is one key**, not four. Adding a dimension to
a key is a fresh chance to introduce the absent-vs-empty bug on a new axis —
which #229 explicitly warned about — so `allele_set` goes through the same
`is_stated` rule as everything else, and is materialized in `_normalize` the way
the flanks are so the key shape is stable whether or not the source had the
column.

## What stays out, and why

`source_sequence_name`, `peptide_offset`, `sample_name`. The #228 review read
their omission as data loss; it isn't. They say where a peptide was *found*, not
what was predicted about it, and a prediction for one
`(peptide, allele, length, kind, flanks, genotype)` is the same prediction
whichever protein or sample it came from. **Keying on them would defeat the
cache** — the same peptide would be re-predicted once per source protein. Two
tests pin that.

## Why not #228's approach

#228 refused duplicate keys at load. That was a workaround on a wrong key, and
it introduced silent data loss in three ways (rows differing only in `affinity`
merged; rows differing only in provenance or `sample_name` dropped) while
refusing the legitimate haplotype rows this PR now stores correctly. Fixing the
key removes the collisions rather than policing them.

The remaining case — a caller supplying two genuinely contradictory rows for one
key — is unaddressed here and stays open on #229, along with `concat` and the
constructor still disagreeing about identical duplicates. Both want one
implementation of "which keys collide and what do we say", and that is a
separate change.

## Tests

9 in `tests/test_cache_key_allele_set.py`: two genotypes stored as two entries
and each addressable; a per-allele row coexisting with a genotype row; every
spelling of no-genotype collapsing to one key; a frame with no `allele_set`
column keying stably; provenance and `sample_name` *not* splitting a prediction;
flanks still splitting one.

Also updates five tests in `test_cached_predictor.py` that hand-wrote the key
tuple. They pinned the key's *shape*, so they broke on a new dimension for no
behavioral reason — and would have passed just as happily against a wrong key.
They ask the key builder now.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2103 passed, 3 skipped

Version 5.36.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
