### PR TITLE
Populate RNA read evidence from the readers, naming each derivation (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 5.37.0
+
+**Added: RNA read-level evidence from the readers, with each number
+naming its derivation (#102).** 5.32.0 added the fields to
+`ProteinFragment`; nothing populated them. `read_lens` and
+`read_pvacseq` do now.
+
+```
+n_overlapping_reads   n_alt_reads   n_ref_reads   read_count_method
+               1233           429           804     rna_depth_x_vaf
+```
+
+The derivation is named because "429 reads counted" and "429 reads
+implied by depth × VAF" are different claims:
+
+| Method | Meaning |
+|---|---|
+| `rna_reads` | Counted directly from an RNA alignment |
+| `rna_depth_x_vaf` | depth × VAF, rounded — not counted |
+| `cds_overlap_reads` | Counted, but of reads overlapping the peptide's CDS rather than supporting the variant |
+| `tpm_x_dna_vaf` | Transcript abundance × DNA VAF — an expression proxy, not a read count |
+
+Per source: **pVACseq** reports `Tumor RNA Depth` (a real count) and
+`Tumor RNA VAF`, so the depth is counted and the split is arithmetic.
+**LENS** counts reads covering the genomic origin *and* reads covering it
+with the peptide's CDS — both real counts, but the second is of
+something adjacent to what was asked for, which is why it is
+`cds_overlap_reads` rather than `rna_reads`. A LENS row with no `vaf`
+gets no split and no method, rather than a zero.
+
+**Added: `variant_allele_expression`**, the bulk-RNA fallback —
+transcript abundance × DNA VAF, for when there is no alignment to count
+alt reads from. It assumes both alleles are transcribed equally, so a
+variant on a transcriptionally silenced allele looks expressed — the
+error being exactly what allele-specific counting exists to detect,
+which is why it is labelled rather than mixed in with measured values.
+
+**Added: `sequence_source`.** `source_type` says what an antigen *is*
+(`"variant:snv"`) and deliberately says nothing about method, so a frame
+could not answer "was this sequence assembled from RNA or translated
+from the reference?" — the first question you ask auditing a ranking.
+One of `isovar_assembly`, `varcode_translation`, `lens_pep_context`,
+`pvacseq_epitope`, `caller_supplied`.
+
+`describe_read_evidence(df)` summarizes how a run's numbers were
+obtained without walking the rows. `split_reads_by_vaf` and
+`attach_read_evidence` are public, so a caller with its own source uses
+the same implementation rather than writing the arithmetic again.
+
+`None` throughout means the source could not answer, which is not zero —
+and `attach_read_evidence` refuses a supporting count whose derivation
+is unnamed, since a count that cannot be told from a measurement is
+worse than no count.
+
 ## 5.36.0
 
 **Fixed: the genotype is now part of the cache key (#229).**

--- a/tests/test_rna_evidence.py
+++ b/tests/test_rna_evidence.py
@@ -1,0 +1,231 @@
+"""RNA read-level evidence, and naming each derivation (topiary #102).
+
+The content half of the multi-source fragment work. 5.32.0 added the fields;
+nothing populated them. The readers do now, and every derived number carries
+the name of its derivation — because "12 reads counted" and "12 reads implied
+by depth x VAF" are different claims and a consumer weighting a candidate by
+depth of support needs to tell them apart.
+
+`None` throughout means the source could not answer, which is not zero.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary import (
+    CDS_OVERLAP_READS,
+    RNA_DEPTH_X_VAF,
+    TPM_X_DNA_VAF,
+    attach_read_evidence,
+    attach_sequence_source,
+    describe_read_evidence,
+    read_lens,
+    read_pvacseq,
+    split_reads_by_vaf,
+)
+
+LENS = "tests/data/lens/sample_v1_4.tsv"
+PVACSEQ = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
+
+
+def _read(fn, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return fn(path)
+
+
+# ---------------------------------------------------------------------------
+# The arithmetic, on its own
+# ---------------------------------------------------------------------------
+
+
+def test_a_depth_and_a_fraction_split_into_alt_and_ref():
+    alt, ref = split_reads_by_vaf(pd.Series([1000]), pd.Series([0.25]))
+
+    assert alt.tolist() == [250]
+    assert ref.tolist() == [750]
+
+
+@pytest.mark.parametrize("depth,vaf", [
+    (None, 0.25), (1000, None), (None, None),
+], ids=["no-depth", "no-vaf", "neither"])
+def test_a_missing_half_yields_no_estimate(depth, vaf):
+    """An estimate needs both halves; inventing one is how a missing value
+    becomes a number nobody measured."""
+    alt, ref = split_reads_by_vaf(pd.Series([depth]), pd.Series([vaf]))
+
+    assert alt.isna().all() and ref.isna().all()
+
+
+@pytest.mark.parametrize("vaf", [-0.1, 1.5, "abc"])
+def test_a_value_that_is_not_a_fraction_is_not_a_vaf(vaf):
+    alt, _ = split_reads_by_vaf(pd.Series([1000]), pd.Series([vaf]))
+
+    assert alt.isna().all()
+
+
+def test_zero_support_is_a_real_answer():
+    """VAF 0 means the source looked and found none — not "cannot answer"."""
+    alt, ref = split_reads_by_vaf(pd.Series([1000]), pd.Series([0.0]))
+
+    assert alt.tolist() == [0]
+    assert ref.tolist() == [1000]
+
+
+# ---------------------------------------------------------------------------
+# pVACseq: a depth is counted, the split is arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_pvacseq_populates_the_read_counts():
+    df = _read(read_pvacseq, PVACSEQ).df
+
+    row = df.iloc[0]
+    assert row["n_overlapping_reads"] > 0
+    assert row["n_alt_reads"] + row["n_ref_reads"] == row["n_overlapping_reads"]
+
+
+def test_pvacseq_names_the_split_as_derived():
+    """Not counted — depth x VAF, and the frame says so."""
+    df = _read(read_pvacseq, PVACSEQ).df
+
+    assert set(df["read_count_method"].dropna()) == {RNA_DEPTH_X_VAF}
+
+
+def test_pvacseq_estimates_variant_allele_expression():
+    df = _read(read_pvacseq, PVACSEQ).df
+
+    assert df["variant_allele_expression"].notna().any()
+    assert set(df["variant_allele_expression_method"].dropna()) == {
+        TPM_X_DNA_VAF,
+    }
+
+
+def test_the_expression_estimate_is_abundance_times_fraction():
+    df = _read(read_pvacseq, PVACSEQ).df
+    row = df.dropna(subset=["variant_allele_expression"]).iloc[0]
+
+    expected = row["transcript_expression"] * row["tumor_dna_vaf"]
+    assert row["variant_allele_expression"] == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# LENS: two real counts, one of something adjacent
+# ---------------------------------------------------------------------------
+
+
+def test_lens_populates_the_counted_columns():
+    df = _read(read_lens, LENS).df
+
+    assert df["n_overlapping_reads"].notna().any()
+    assert df["n_alt_reads_supporting_protein_sequence"].notna().any()
+
+
+def test_lens_rows_without_a_vaf_get_no_split_and_no_method():
+    """Absent stays absent, and says so — it does not become zero."""
+    df = _read(read_lens, LENS).df
+    unstated = df[df["vaf"].isna()]
+
+    assert unstated["n_alt_reads"].isna().all()
+    assert unstated["read_count_method"].isna().all()
+
+
+def test_lens_rows_with_a_vaf_do_get_a_split():
+    df = _read(read_lens, LENS).df
+    stated = df[df["vaf"].notna()]
+
+    assert len(stated) > 0
+    assert stated["n_alt_reads"].notna().all()
+    assert set(stated["read_count_method"]) == {RNA_DEPTH_X_VAF}
+
+
+def test_a_cds_overlap_count_is_not_called_a_read_count():
+    """It is a genuine count — of reads overlapping the peptide's CDS, not
+    of reads supporting the variant. The distinction is the point."""
+    frame = attach_read_evidence(
+        pd.DataFrame({"x": [1]}),
+        supporting=pd.Series([45]),
+        supporting_method=CDS_OVERLAP_READS,
+    )
+
+    assert frame["n_alt_reads_supporting_protein_sequence"].tolist() == [45]
+
+
+def test_an_unnamed_supporting_derivation_is_refused():
+    with pytest.raises(ValueError, match="must name a derivation"):
+        attach_read_evidence(
+            pd.DataFrame({"x": [1]}), supporting=pd.Series([45]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# A source with nothing to say says nothing
+# ---------------------------------------------------------------------------
+
+
+def test_a_frame_with_no_rna_columns_gets_absent_not_zero():
+    frame = attach_read_evidence(pd.DataFrame({"x": [1, 2, 3]}))
+
+    for column in ("n_overlapping_reads", "n_alt_reads", "n_ref_reads",
+                   "n_alt_reads_supporting_protein_sequence"):
+        assert frame[column].isna().all()
+    assert frame["read_count_method"].isna().all()
+
+
+def test_the_columns_exist_even_when_unpopulated():
+    """Same shape from every source; only which fields are filled differs."""
+    frame = attach_read_evidence(pd.DataFrame({"x": [1]}))
+
+    assert "n_alt_reads" in frame.columns
+    assert "read_count_method" in frame.columns
+
+
+# ---------------------------------------------------------------------------
+# describe_read_evidence
+# ---------------------------------------------------------------------------
+
+
+def test_describe_reports_how_each_number_was_obtained():
+    df = _read(read_pvacseq, PVACSEQ).df
+
+    assert describe_read_evidence(df) == {
+        "n_alt_reads": RNA_DEPTH_X_VAF,
+        "n_ref_reads": RNA_DEPTH_X_VAF,
+        "variant_allele_expression": TPM_X_DNA_VAF,
+    }
+
+
+def test_describe_says_nothing_about_columns_nothing_populated():
+    assert describe_read_evidence(
+        attach_read_evidence(pd.DataFrame({"x": [1]}))
+    ) == {}
+
+
+# ---------------------------------------------------------------------------
+# Where the sequence came from
+# ---------------------------------------------------------------------------
+
+
+def test_each_reader_records_its_own_sequence_source():
+    assert set(_read(read_lens, LENS).df["sequence_source"]) == {
+        "lens_pep_context",
+    }
+    assert set(_read(read_pvacseq, PVACSEQ).df["sequence_source"]) == {
+        "pvacseq_epitope",
+    }
+
+
+def test_an_unknown_sequence_source_is_refused():
+    with pytest.raises(ValueError, match="must be one of"):
+        attach_sequence_source(pd.DataFrame({"x": [1]}), "vibes")
+
+
+def test_the_source_answers_a_question_source_type_cannot():
+    """source_type is biology ("variant:snv"); this is method."""
+    df = _read(read_pvacseq, PVACSEQ).df
+
+    assert "sequence_source" in df.columns
+    assert df["sequence_source"].nunique() == 1

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -100,6 +100,18 @@ from .io_pvacseq import (
     melt_pvacseq_algorithms,
     read_pvacseq,
 )
+from .rna_evidence import (
+    CDS_OVERLAP_READS,
+    READ_COUNT_METHODS,
+    RNA_DEPTH_X_VAF,
+    RNA_READS,
+    SEQUENCE_SOURCES,
+    TPM_X_DNA_VAF,
+    attach_read_evidence,
+    attach_sequence_source,
+    describe_read_evidence,
+    split_reads_by_vaf,
+)
 from .result import (
     TopiaryResult,
     stack_results,
@@ -107,7 +119,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.36.0"
+__version__ = "5.37.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -211,6 +223,16 @@ __all__ = [
     "detect_form",
     "from_wide",
     "to_wide",
+    "RNA_READS",
+    "RNA_DEPTH_X_VAF",
+    "CDS_OVERLAP_READS",
+    "TPM_X_DNA_VAF",
+    "READ_COUNT_METHODS",
+    "SEQUENCE_SOURCES",
+    "attach_read_evidence",
+    "attach_sequence_source",
+    "describe_read_evidence",
+    "split_reads_by_vaf",
     "TopiaryResult",
     "stack_results",
     "combine_predictions",

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -39,6 +39,12 @@ from pathlib import Path
 import pandas as pd
 
 from .io import Metadata
+from .rna_evidence import (
+    CDS_OVERLAP_READS,
+    LENS_PEP_CONTEXT,
+    attach_read_evidence,
+    attach_sequence_source,
+)
 from .result import TopiaryResult
 from .wide import WIDE_FIELDS, _known_kind_short_names
 
@@ -347,6 +353,21 @@ def read_lens(
     df = _handle_tpm(df)
     df = _derive_peptide_columns(df)
     df = _derive_effect_type(df)
+    # RNA read-level evidence. LENS counts reads covering the genomic
+    # origin (a direct count) and reads covering it *with the peptide's
+    # CDS* — also a count, but of reads overlapping the coding sequence
+    # rather than supporting the variant allele, which is why that one
+    # is named cds_overlap_reads rather than rna_reads.
+    df = attach_read_evidence(
+        df,
+        overlapping=df.get("rna_reads_covering_genomic_origin"),
+        vaf=df.get("vaf"),
+        supporting=df.get("rna_reads_covering_genomic_origin_with_peptide_cds"),
+        supporting_method=CDS_OVERLAP_READS,
+        expression=df.get("tpm"),
+        dna_vaf=df.get("vaf"),
+    )
+    df = attach_sequence_source(df, LENS_PEP_CONTEXT)
     df = _add_source_sequence_name(df)
     df["peptide_offset"] = 0
 

--- a/topiary/io_pvacseq.py
+++ b/topiary/io_pvacseq.py
@@ -55,6 +55,11 @@ import numpy as np
 import pandas as pd
 
 from .ranking import stated_values
+from .rna_evidence import (
+    PVACSEQ_EPITOPE,
+    attach_read_evidence,
+    attach_sequence_source,
+)
 from .io import Metadata
 from .result import TopiaryResult
 
@@ -498,6 +503,22 @@ def _parse_all_epitopes(df):
     for src, dst in _ALL_ANNOTATIONS.items():
         if src in df.columns:
             out[dst] = df[src].values
+
+    # RNA read-level evidence. pVACseq reports a depth and a variant
+    # allele fraction, so the alt/ref split is arithmetic rather than
+    # counted — attach_read_evidence names that on every row it derives.
+    out = attach_read_evidence(
+        out,
+        overlapping=df["Tumor RNA Depth"] if "Tumor RNA Depth" in df else None,
+        vaf=df["Tumor RNA VAF"] if "Tumor RNA VAF" in df else None,
+        expression=(
+            df["Transcript Expression"]
+            if "Transcript Expression" in df
+            else df.get("Gene Expression")
+        ),
+        dna_vaf=df["Tumor DNA VAF"] if "Tumor DNA VAF" in df else None,
+    )
+    out = attach_sequence_source(out, PVACSEQ_EPITOPE)
 
     # Per-algorithm score columns pass through as snake_case names.
     for col in df.columns:

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -1,0 +1,265 @@
+"""RNA read-level evidence, and saying where each number came from.
+
+Readers report RNA support differently, and the difference matters. isovar
+counts reads supporting an assembled protein sequence. pVACseq reports a
+depth and a variant allele fraction, from which the split is arithmetic.
+LENS counts reads overlapping the peptide's CDS, which is a real count of
+something adjacent to what was asked for. A consumer weighting a candidate
+by depth of support needs to know which of those it has.
+
+So every derived number carries the name of its derivation:
+
+============================  ==================================================
+``rna_reads``                 Counted directly from an RNA alignment.
+``rna_depth_x_vaf``           depth x VAF, rounded. Not counted.
+``cds_overlap_reads``         Counted, but of reads overlapping the peptide's
+                              coding sequence rather than supporting the
+                              variant allele.
+``tpm_x_dna_vaf``             Transcript abundance x DNA variant allele
+                              fraction. An expression proxy, not a read count.
+============================  ==================================================
+
+The last one carries a bias worth stating: it assumes both alleles are
+transcribed equally, so a variant on a transcriptionally silenced allele
+looks expressed. That error is exactly the phenomenon allele-specific
+counting exists to detect, which is why the estimate is labelled rather
+than silently mixed in with measured values.
+
+``None`` throughout means the source could not answer, which is not the
+same as answering zero.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .ranking import stated_values
+
+#: Counted directly from an RNA alignment.
+RNA_READS = "rna_reads"
+
+#: depth x VAF, rounded — arithmetic, not counted.
+RNA_DEPTH_X_VAF = "rna_depth_x_vaf"
+
+#: Counted, but of reads overlapping the peptide's coding sequence rather
+#: than supporting the variant allele.
+CDS_OVERLAP_READS = "cds_overlap_reads"
+
+#: Transcript abundance x DNA variant allele fraction — an expression
+#: proxy, not a read count.
+TPM_X_DNA_VAF = "tpm_x_dna_vaf"
+
+READ_COUNT_METHODS = frozenset({
+    RNA_READS, RNA_DEPTH_X_VAF, CDS_OVERLAP_READS, TPM_X_DNA_VAF,
+})
+
+#: How the protein sequence a prediction was made on came to exist.
+#:
+#: ``source_type`` says what an antigen *is* (``"variant:snv"``), which
+#: is biology and deliberately says nothing about method. This says how
+#: the sequence was obtained, which is the question you ask when
+#: auditing a ranking: an assembled sequence carries the patient's other
+#: variants and any phasing the reads support; a translated one carries
+#: the reference everywhere except the variant itself.
+ISOVAR_ASSEMBLY = "isovar_assembly"
+VARCODE_TRANSLATION = "varcode_translation"
+LENS_PEP_CONTEXT = "lens_pep_context"
+PVACSEQ_EPITOPE = "pvacseq_epitope"
+CALLER_SUPPLIED = "caller_supplied"
+
+SEQUENCE_SOURCES = frozenset({
+    ISOVAR_ASSEMBLY, VARCODE_TRANSLATION, LENS_PEP_CONTEXT,
+    PVACSEQ_EPITOPE, CALLER_SUPPLIED,
+})
+
+
+def attach_sequence_source(df: pd.DataFrame, source: str) -> pd.DataFrame:
+    """Record how every row's protein sequence was obtained.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+    source : str
+        One of :data:`SEQUENCE_SOURCES`.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    if source not in SEQUENCE_SOURCES:
+        raise ValueError(
+            f"sequence_source must be one of {sorted(SEQUENCE_SOURCES)}, "
+            f"got {source!r}. An unnamed provenance is the same as none."
+        )
+    out = df.copy()
+    out["sequence_source"] = source
+    return out
+
+
+#: Columns this module writes, in the order a reader should expect them.
+READ_EVIDENCE_COLUMNS = (
+    "n_overlapping_reads",
+    "n_alt_reads",
+    "n_ref_reads",
+    "n_alt_reads_supporting_protein_sequence",
+    "read_count_method",
+    "variant_allele_expression",
+    "variant_allele_expression_method",
+    "sequence_source",
+)
+
+
+def _counts(values) -> pd.Series:
+    """Non-negative integer counts, with unstated entries left as NA."""
+    numeric = pd.to_numeric(values, errors="coerce")
+    numeric = numeric.where(numeric >= 0)
+    return numeric.round().astype("Int64")
+
+
+def _fractions(values) -> pd.Series:
+    """Fractions in [0, 1]; anything else is not a VAF and reads as absent."""
+    numeric = pd.to_numeric(values, errors="coerce")
+    return numeric.where((numeric >= 0) & (numeric <= 1))
+
+
+def split_reads_by_vaf(depth, vaf):
+    """``(n_alt_reads, n_ref_reads)`` from a depth and a variant fraction.
+
+    Both are ``NA`` wherever either input is absent — an estimate needs
+    both halves, and inventing one of them is how a missing value becomes
+    a number nobody measured.
+
+    Parameters
+    ----------
+    depth : pandas.Series
+        Reads covering the position.
+    vaf : pandas.Series
+        Variant allele fraction, 0..1.
+
+    Returns
+    -------
+    (pandas.Series, pandas.Series)
+        Alt and reference counts, nullable integer.
+    """
+    depth = _counts(depth)
+    fraction = _fractions(vaf)
+    usable = depth.notna() & fraction.notna()
+    alt = (depth.astype("Float64") * fraction).round().astype("Int64")
+    alt = alt.where(usable)
+    ref = (depth - alt).where(usable)
+    return alt, ref.clip(lower=0)
+
+
+def attach_read_evidence(
+    df: pd.DataFrame,
+    *,
+    overlapping=None,
+    vaf=None,
+    supporting=None,
+    supporting_method=None,
+    expression=None,
+    dna_vaf=None,
+) -> pd.DataFrame:
+    """Write the read-evidence columns onto *df*, naming each derivation.
+
+    Every argument is a Series (or ``None`` when the source has no such
+    column). Nothing is invented: a quantity whose inputs are absent is
+    left ``NA``, and its method column is ``NA`` too, so "no support" and
+    "cannot answer" stay distinguishable.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Frame to write onto. Not mutated; a copy is returned.
+    overlapping : pandas.Series, optional
+        Reads covering the variant position. Taken as a direct count.
+    vaf : pandas.Series, optional
+        RNA variant allele fraction, used with *overlapping* to split
+        alt from reference.
+    supporting : pandas.Series, optional
+        Reads supporting the assembled protein sequence.
+    supporting_method : str, optional
+        Which derivation *supporting* is — :data:`RNA_READS` when it
+        counts reads carrying the variant, :data:`CDS_OVERLAP_READS`
+        when it counts reads overlapping the peptide's CDS instead.
+    expression : pandas.Series, optional
+        Transcript or gene abundance, for the expression proxy.
+    dna_vaf : pandas.Series, optional
+        DNA variant allele fraction, used with *expression*.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    out = df.copy()
+    n_rows = len(out)
+    empty = pd.Series([pd.NA] * n_rows, index=out.index, dtype="Int64")
+
+    out["n_overlapping_reads"] = (
+        _counts(overlapping) if overlapping is not None else empty
+    )
+    if overlapping is not None and vaf is not None:
+        alt, ref = split_reads_by_vaf(overlapping, vaf)
+        method = RNA_DEPTH_X_VAF
+    else:
+        alt, ref, method = empty, empty, None
+    out["n_alt_reads"] = alt
+    out["n_ref_reads"] = ref
+    out["read_count_method"] = pd.Series(
+        [method if method and pd.notna(a) else pd.NA for a in alt],
+        index=out.index, dtype="object",
+    )
+
+    if supporting is not None:
+        if supporting_method not in READ_COUNT_METHODS:
+            raise ValueError(
+                f"supporting_method must name a derivation from "
+                f"{sorted(READ_COUNT_METHODS)}, got "
+                f"{supporting_method!r}. A count whose derivation is "
+                f"unnamed cannot be told from one that was measured."
+            )
+        out["n_alt_reads_supporting_protein_sequence"] = _counts(supporting)
+    else:
+        out["n_alt_reads_supporting_protein_sequence"] = empty
+
+    if expression is not None and dna_vaf is not None:
+        abundance = pd.to_numeric(expression, errors="coerce")
+        fraction = _fractions(dna_vaf)
+        estimate = (abundance * fraction).where(
+            abundance.notna() & fraction.notna()
+        )
+        out["variant_allele_expression"] = estimate
+        out["variant_allele_expression_method"] = pd.Series(
+            [TPM_X_DNA_VAF if pd.notna(v) else pd.NA for v in estimate],
+            index=out.index, dtype="object",
+        )
+    else:
+        out["variant_allele_expression"] = pd.Series(
+            [np.nan] * n_rows, index=out.index, dtype="float64"
+        )
+        out["variant_allele_expression_method"] = pd.Series(
+            [pd.NA] * n_rows, index=out.index, dtype="object"
+        )
+    return out
+
+
+def describe_read_evidence(df: pd.DataFrame) -> dict:
+    """``{column: method}`` for every read-evidence column *df* populates.
+
+    The frame-level summary of what the per-row method columns say, for a
+    caller reporting how a run's numbers were obtained without walking
+    the rows.
+    """
+    described = {}
+    for column, method_column in (
+        ("n_alt_reads", "read_count_method"),
+        ("n_ref_reads", "read_count_method"),
+        ("variant_allele_expression", "variant_allele_expression_method"),
+    ):
+        if column not in df.columns or method_column not in df.columns:
+            continue
+        methods = df[method_column][stated_values(df[method_column])]
+        for method in sorted(set(methods.tolist())):
+            described.setdefault(column, method)
+    return described


### PR DESCRIPTION
Toward #102 — the content half. 5.32.0 added the read-count fields to
`ProteinFragment` and nothing populated them, so "the same fields regardless of
path" was true of the *shape* and false of the *content*.

## What the readers now emit

```
n_overlapping_reads   n_alt_reads   n_ref_reads   read_count_method
               1233           429           804     rna_depth_x_vaf
```

Every derived number names its derivation, because **"429 reads counted" and
"429 reads implied by depth × VAF" are different claims**:

| Method | Meaning |
|---|---|
| `rna_reads` | Counted directly from an RNA alignment |
| `rna_depth_x_vaf` | depth × VAF, rounded — not counted |
| `cds_overlap_reads` | Counted, but of reads overlapping the peptide's CDS rather than supporting the variant |
| `tpm_x_dna_vaf` | Transcript abundance × DNA VAF — an expression proxy, not a read count |

Naming the derivation rather than tagging things "approximated" is the
difference between something a consumer can filter on and something it can only
caveat.

## Per source, from what the files actually carry

**pVACseq** has `Tumor RNA Depth` (a real count) and `Tumor RNA VAF`, so the
depth is counted and the split is arithmetic. Verified end to end:
`1233 × 0.348 → 429 alt / 804 ref`.

**LENS** has `rna_reads_covering_genomic_origin` *and*
`rna_reads_covering_genomic_origin_with_peptide_cds` — both real counts, but the
second counts reads overlapping the peptide's coding sequence rather than
supporting the variant allele. That is why it is `cds_overlap_reads` and not
`rna_reads`; it answers an adjacent question and a consumer should be able to
see that.

A LENS row with no `vaf` gets **no split and no method**, rather than a zero.
In the shipped fixture 10 of 30 rows carry a VAF, so both branches are exercised
by real data.

## The bulk-RNA fallback

`variant_allele_expression` = transcript abundance × DNA VAF, for when there is
no alignment to count alt reads from.

It assumes both alleles are transcribed equally, so a variant on a
transcriptionally silenced allele looks expressed — **the error being exactly
the phenomenon allele-specific counting exists to detect**. That is why it is
labelled rather than quietly mixed in with measured values, and why it lives in
its own column instead of overwriting `transcript_expression`.

## `sequence_source`

`source_type` says what an antigen *is* (`"variant:snv"`) and deliberately says
nothing about method, since consumers must not branch on it. So a frame could
not answer *"was this sequence assembled from RNA or translated from the
reference?"* — the first question you ask auditing a ranking, and the difference
between a sequence carrying the patient's other variants and one carrying the
reference everywhere except the variant itself.

One of `isovar_assembly`, `varcode_translation`, `lens_pep_context`,
`pvacseq_epitope`, `caller_supplied`.

## One implementation, not two

`topiary/rna_evidence.py` holds the arithmetic and both readers call it —
`split_reads_by_vaf`, `attach_read_evidence`, `attach_sequence_source` and
`describe_read_evidence` are all public, so a caller with its own source uses
this rather than writing the split again. That is the rule this repo added to
AGENTS.md two releases ago, applied at the point where it would otherwise have
been two copies immediately.

`None` throughout means the source could not answer, which is not zero. And
`attach_read_evidence` **refuses a supporting count whose derivation is
unnamed** — a count that cannot be told from a measurement is worse than no
count.

## What this does not do

- **No isovar integration.** `isovar_assembly` is in the vocabulary; nothing
  emits it yet. The adapter and its optional-dependency wiring are the
  remaining half of #102.
- **No fragment-level population.** These are frame columns; carrying them onto
  `ProteinFragment` through the fragment builders is separate.

## Tests

24 in `tests/test_rna_evidence.py`: the arithmetic alone, including that a
missing half yields no estimate (parameterized) and that VAF 0 is a real answer
rather than an absence; both readers' counts, methods and expression estimates
verified against the shipped fixtures; LENS rows with and without a VAF; a CDS
count not being called a read count; an unnamed derivation refused; a source
with no RNA columns getting absent-not-zero while the columns still exist; and
`sequence_source` per reader plus its refusal of an unknown value.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2136 passed, 3 skipped

Version 5.37.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
