### PR TITLE
Add the isovar path, and make every source reach a fragment (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 5.38.0
+
+**Added: isovar → `ProteinFragment`, and every other path with it
+(#102).** 5.37.0 put `isovar_assembly` in the vocabulary with nothing
+emitting it — a name for a thing that did not exist, which is the same
+shape as a configured knob that does nothing.
+
+```python
+fragment_from_isovar_result(result)      # one result
+fragments_from_isovar_results(results)   # drops those with no RNA support
+fragments_from_dataframe(read_lens(path).df)      # the table readers
+fragment_from_effect(effect, padding)             # varcode, since 5.35.0
+```
+
+**isovar is the only source that counts.** It assembles a protein
+sequence from reads and counts the ones supporting it, so its numbers are
+`measured`. pVACseq derives the split from depth × VAF and LENS counts
+reads overlapping the peptide's CDS — both `approximated`. One mapping,
+`provenance_for_method`, decides which is which, so a frame and a
+fragment cannot disagree about whether depth × VAF counts as measured.
+It does not.
+
+**Optional in the strong sense**: isovar is not imported at module
+scope, not in `requirements.txt`, and `import topiary` does not import
+it. A consumer that only reads LENS reports should not pay for a package
+it never calls. There is a test asserting it stays unimported.
+
+**Every path now reaches a fragment with the same core.** `SEMANTIC_CORE`
+names the fields every source speaks to, whether or not it can fill
+them, so this reads all four without knowing which it has:
+
+```python
+def rna_support(fragment):
+    if not fragment.is_usable_as_biology("n_alt_reads"):
+        return None
+    return fragment.n_alt_reads, fragment.is_approximate("n_alt_reads")
+```
+
+isovar returns `(30, False)`, pVACseq a count with `True`, varcode
+`None` — no branching on `source_type`, which is why `source_type` stays
+biological.
+
+**Fixed: the supporting-count derivation was accepted and not
+recorded.** `attach_read_evidence` took `supporting_method` and dropped
+it, so a frame carried LENS's count of 45 CDS-overlapping reads with no
+way to say it was not 45 reads supporting the variant. It is now a
+column, and the fragment reads it.
+
 ## 5.37.0
 
 **Added: RNA read-level evidence from the readers, with each number

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -59,6 +59,44 @@ Two rules worth knowing before you rely on it:
 
 It returns `None` when the effect has no mutant protein sequence at all (silent, non-coding, untranslatable). That is an absence, not an error.
 
+## Every source reaches a fragment
+
+Four paths, one shape. They differ only in which fields they can fill:
+
+| Source | Builder | Sequence is | Read counts |
+|---|---|---|---|
+| isovar | `fragment_from_isovar_result(result)` | assembled from RNA reads | **counted** (`measured`) |
+| varcode | `fragment_from_effect(effect, padding)` | translated from the reference | none |
+| LENS | `fragments_from_dataframe(read_lens(p).df)` | the peptide's context | overlapping counted; support is CDS-overlap (`approximated`) |
+| pVACseq | `fragments_from_dataframe(read_pvacseq(p).df)` | the peptide itself | depth × VAF (`approximated`) |
+
+```python
+def rna_support(fragment):
+    if not fragment.is_usable_as_biology("n_alt_reads"):
+        return None
+    return fragment.n_alt_reads, fragment.is_approximate("n_alt_reads")
+```
+
+That function reads all four without knowing which it has: isovar returns
+`(30, False)`, pVACseq returns a count with `True`, varcode returns `None`
+because it has no RNA data at all. **No branching on `source_type`** — which is
+the whole point of the abstraction, and why `source_type` stays biological.
+
+`SEMANTIC_CORE` names the fields every source is expected to speak to, whether
+or not it can populate them.
+
+### isovar is optional in the strong sense
+
+Not imported at module scope, not in `requirements.txt`, and topiary's shape is
+identical whether or not it is installed — `import topiary` does not import it.
+Only `fragment_from_isovar_result` needs it, and it says how to install it if
+missing. A consumer that only reads LENS reports should not pay for a package
+it never calls.
+
+isovar is also the only source that *counts* the reads supporting an assembled
+sequence. Everything else derives them or counts something adjacent, which is
+what the derivation names record.
+
 ## RNA evidence, and knowing which fields are real
 
 Beyond `gene_expression` / `transcript_expression`, a fragment can carry

--- a/tests/test_fragment_paths.py
+++ b/tests/test_fragment_paths.py
@@ -1,0 +1,271 @@
+"""Every source reaches a ProteinFragment with the same core (topiary #102).
+
+The premise of the multi-source abstraction is that a consumer reads one
+shape and never branches on where the data came from. That only holds if
+*every* path produces a fragment — so isovar has an adapter, the table
+readers have one, and varcode already had one.
+
+They differ only in which fields they can fill, and each says how real its
+numbers are: isovar counts reads, so its counts are `measured`; pVACseq
+derives them from depth x VAF and LENS counts something adjacent, so theirs
+are `approximated`.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    SEMANTIC_CORE,
+    ProteinFragment,
+    fragment_from_effect,
+    fragment_from_isovar_result,
+    fragments_from_dataframe,
+    fragments_from_isovar_results,
+    provenance_for_method,
+    read_lens,
+    read_pvacseq,
+)
+from topiary.rna_evidence import (
+    CDS_OVERLAP_READS,
+    RNA_DEPTH_X_VAF,
+    RNA_READS,
+)
+
+LENS = "tests/data/lens/sample_v1_4.tsv"
+PVACSEQ = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
+
+
+class _ProteinSequence:
+    amino_acids = "MKTVRQERLKSIVRILE"
+    mutation_start_idx = 4
+    mutation_end_idx = 6
+    gene_name = "BRAF"
+    transcript_ids = ["ENST1", "ENST2"]
+    transcript_names = ["BRAF-204"]
+    num_supporting_fragments = 27
+
+
+class _IsovarResult:
+    """Shaped like isovar.IsovarResult — the attributes actually read."""
+
+    top_protein_sequence = _ProteinSequence()
+    variant = "chr7 g.140453136 A>T"
+    num_total_fragments = 61
+    num_alt_fragments = 30
+    num_ref_fragments = 31
+
+
+class _NoRNASupport:
+    top_protein_sequence = None
+    variant = "chr1 g.1 A>T"
+
+
+class _Effect:
+    def __init__(self):
+        self.mutant_protein_sequence = "MKTVRQERLK"
+        self.original_protein_sequence = "MKTVAQERLK"
+        self.aa_mutation_start_offset = 4
+        self.aa_mutation_end_offset = 5
+        self.gene_name = "BRAF"
+        self.gene_id = "ENSG1"
+        self.transcript_id = "ENST1"
+        self.transcript_name = "BRAF-204"
+        self.short_description = "p.A5R"
+        self.variant = type("V", (), {"short_description": "chr7:1A>T"})()
+
+
+def _frame(fn, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return fn(path).df
+
+
+# ---------------------------------------------------------------------------
+# isovar
+# ---------------------------------------------------------------------------
+
+
+def test_isovar_builds_a_fragment():
+    fragment = fragment_from_isovar_result(_IsovarResult())
+
+    assert isinstance(fragment, ProteinFragment)
+    assert fragment.sequence == "MKTVRQERLKSIVRILE"
+    assert fragment.gene == "BRAF"
+
+
+def test_isovar_counts_are_measured_not_derived():
+    """The distinction the whole vocabulary exists for: isovar counted
+    these, every other source estimates or counts something adjacent."""
+    fragment = fragment_from_isovar_result(_IsovarResult())
+
+    assert fragment.n_alt_reads == 30
+    assert fragment.n_ref_reads == 31
+    assert fragment.n_overlapping_reads == 61
+    assert fragment.n_alt_reads_supporting_protein_sequence == 27
+    assert not fragment.is_approximate("n_alt_reads")
+    assert fragment.is_usable_as_biology("n_alt_reads")
+
+
+def test_the_mutated_span_lands_inside_the_sequence():
+    fragment = fragment_from_isovar_result(_IsovarResult())
+
+    low, high = fragment.target_intervals[0]
+    assert 0 <= low <= high <= len(fragment.sequence)
+    assert fragment.sequence[low:high] == "RQ"
+
+
+def test_isovar_records_that_the_sequence_was_assembled():
+    fragment = fragment_from_isovar_result(_IsovarResult())
+
+    assert fragment.annotations["sequence_source"] == "isovar_assembly"
+    assert fragment.annotations["read_count_method"] == RNA_READS
+
+
+def test_supporting_transcripts_are_carried():
+    """A release mismatch downstream should be visible, not an empty list."""
+    fragment = fragment_from_isovar_result(_IsovarResult())
+
+    assert fragment.annotations["supporting_reference_transcripts"] == [
+        "ENST1", "ENST2",
+    ]
+
+
+def test_a_variant_with_no_rna_support_yields_no_fragment():
+    """An absence, not an error — a variant with no RNA support is normal."""
+    assert fragment_from_isovar_result(_NoRNASupport()) is None
+
+
+def test_the_list_helper_drops_unsupported_variants():
+    fragments = fragments_from_isovar_results([
+        _IsovarResult(), _NoRNASupport(), _IsovarResult(),
+    ])
+
+    assert len(fragments) == 2
+    assert all(f is not None for f in fragments)
+
+
+def test_isovar_is_not_imported_by_importing_topiary():
+    """Optional in the strong sense: not importable, not installed, shape
+    unchanged. A consumer reading LENS reports should not pay for it."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c",
+         "import sys, topiary; print('isovar' in sys.modules)"],
+        capture_output=True, text=True, check=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+# ---------------------------------------------------------------------------
+# The table readers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reader,path", [
+    (read_lens, LENS), (read_pvacseq, PVACSEQ),
+], ids=["lens", "pvacseq"])
+def test_a_reader_frame_becomes_fragments(reader, path):
+    fragments = fragments_from_dataframe(_frame(reader, path))
+
+    assert len(fragments) > 0
+    assert all(isinstance(f, ProteinFragment) for f in fragments)
+    assert all(f.sequence for f in fragments)
+
+
+def test_pvacseq_counts_are_marked_derived():
+    fragment = fragments_from_dataframe(_frame(read_pvacseq, PVACSEQ))[0]
+
+    assert fragment.n_alt_reads > 0
+    assert fragment.is_approximate("n_alt_reads")
+    assert fragment.annotations["read_count_method"] == RNA_DEPTH_X_VAF
+
+
+def test_a_lens_cds_overlap_count_is_marked_derived():
+    """It is a real count — of something adjacent to what was asked."""
+    fragment = fragments_from_dataframe(_frame(read_lens, LENS))[0]
+
+    assert fragment.n_alt_reads_supporting_protein_sequence > 0
+    assert fragment.is_approximate("n_alt_reads_supporting_protein_sequence")
+    assert fragment.annotations["supporting_read_count_method"] == (
+        CDS_OVERLAP_READS
+    )
+
+
+def test_a_reader_frame_records_its_sequence_source():
+    lens = fragments_from_dataframe(_frame(read_lens, LENS))[0]
+    pvac = fragments_from_dataframe(_frame(read_pvacseq, PVACSEQ))[0]
+
+    assert lens.annotations["sequence_source"] == "lens_pep_context"
+    assert pvac.annotations["sequence_source"] == "pvacseq_epitope"
+
+
+def test_a_frame_with_no_sequence_column_says_so():
+    with pytest.raises(ValueError, match="No sequence column"):
+        fragments_from_dataframe(pd.DataFrame({"gene": ["BRAF"]}))
+
+
+def test_an_empty_frame_yields_no_fragments():
+    assert fragments_from_dataframe(pd.DataFrame()) == []
+
+
+# ---------------------------------------------------------------------------
+# The property that makes the abstraction worth having
+# ---------------------------------------------------------------------------
+
+
+def test_every_path_produces_the_same_core():
+    """One shape from four sources; only which fields are filled differs."""
+    fragments = {
+        "isovar": fragment_from_isovar_result(_IsovarResult()),
+        "varcode": fragment_from_effect(_Effect(), padding_around_mutation=2),
+        "lens": fragments_from_dataframe(_frame(read_lens, LENS))[0],
+        "pvacseq": fragments_from_dataframe(_frame(read_pvacseq, PVACSEQ))[0],
+    }
+
+    for source, fragment in fragments.items():
+        for name in SEMANTIC_CORE:
+            assert hasattr(fragment, name), f"{source} missing {name}"
+
+
+def test_a_consumer_reads_every_source_through_one_path():
+    """No branching on where the data came from — the whole premise."""
+    def rna_support(fragment):
+        if not fragment.is_usable_as_biology("n_alt_reads"):
+            return None
+        return (fragment.n_alt_reads, fragment.is_approximate("n_alt_reads"))
+
+    isovar = rna_support(fragment_from_isovar_result(_IsovarResult()))
+    pvacseq = rna_support(
+        fragments_from_dataframe(_frame(read_pvacseq, PVACSEQ))[0]
+    )
+    varcode = rna_support(
+        fragment_from_effect(_Effect(), padding_around_mutation=2)
+    )
+
+    assert isovar == (30, False)          # counted
+    assert pvacseq[1] is True             # derived
+    assert varcode is None                # no RNA data at all
+
+
+def test_only_isovar_reports_counted_reads():
+    """The property the vocabulary encodes, asserted across sources."""
+    counted = {
+        "isovar": fragment_from_isovar_result(_IsovarResult()),
+        "pvacseq": fragments_from_dataframe(_frame(read_pvacseq, PVACSEQ))[0],
+    }
+
+    assert counted["isovar"].provenance_of("n_alt_reads") == "measured"
+    assert counted["pvacseq"].provenance_of("n_alt_reads") == "approximated"
+
+
+def test_the_method_to_provenance_map_is_single_valued():
+    """One mapping, so a frame and a fragment cannot disagree about
+    whether depth x VAF counts as measured. It does not."""
+    assert provenance_for_method(RNA_READS) == "measured"
+    assert provenance_for_method(RNA_DEPTH_X_VAF) == "approximated"
+    assert provenance_for_method(CDS_OVERLAP_READS) == "approximated"

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -82,12 +82,18 @@ from .sequence_helpers import (
     protein_subsequences_around_mutations,
 )
 from .cached import CachedPredictor, mhcflurry_composite_version
+from .io_isovar import (
+    fragment_from_isovar_result,
+    fragments_from_isovar_results,
+)
 from .protein_fragment import (
     APPROXIMATED,
     MEASURED,
     PROVENANCE_VALUES,
     SYNTHESIZED,
     ProteinFragment,
+    SEMANTIC_CORE,
+    fragments_from_dataframe,
     make_fragment_id,
 )
 from .self_proteome import SelfProteome
@@ -110,6 +116,7 @@ from .rna_evidence import (
     attach_read_evidence,
     attach_sequence_source,
     describe_read_evidence,
+    provenance_for_method,
     split_reads_by_vaf,
 )
 from .result import (
@@ -119,7 +126,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.37.0"
+__version__ = "5.38.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -202,6 +209,10 @@ __all__ = [
     "protein_subsequences_around_mutations",
     "ProteinFragment",
     "make_fragment_id",
+    "SEMANTIC_CORE",
+    "fragments_from_dataframe",
+    "fragment_from_isovar_result",
+    "fragments_from_isovar_results",
     "MEASURED",
     "APPROXIMATED",
     "SYNTHESIZED",
@@ -232,6 +243,7 @@ __all__ = [
     "attach_read_evidence",
     "attach_sequence_source",
     "describe_read_evidence",
+    "provenance_for_method",
     "split_reads_by_vaf",
     "TopiaryResult",
     "stack_results",

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -1,0 +1,186 @@
+"""isovar → :class:`ProteinFragment`.
+
+isovar assembles a mutant protein sequence from RNA reads rather than
+translating one from the reference, and counts the reads that support it.
+That makes it the only source topiary reads that can populate the read
+counts natively — everything else derives or approximates them.
+
+**isovar is optional in the strong sense**: not imported at module scope,
+not in ``requirements.txt``, and topiary's shape is identical whether or
+not it is installed. Only this module's functions need it, and they say
+so clearly when it is missing. A consumer that reads LENS reports should
+not pay for a package it never calls.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .protein_fragment import ProteinFragment
+from .rna_evidence import ISOVAR_ASSEMBLY, RNA_READS
+
+_MIN_ISOVAR = (1, 7, 2)
+_MIN_ISOVAR_TEXT = "1.7.2"
+
+
+def _check_isovar():
+    """Import isovar or explain how to get it, the way pirlygenes is."""
+    try:
+        import isovar
+    except ImportError:
+        raise ImportError(
+            f"isovar is required to build fragments from RNA-assembled "
+            f"protein sequences. Install with: "
+            f"pip install 'isovar>={_MIN_ISOVAR_TEXT}'"
+        ) from None
+    version = getattr(isovar, "__version__", "0.0.0")
+    parts = []
+    for piece in str(version).split(".")[:3]:
+        digits = "".join(c for c in piece if c.isdigit())
+        parts.append(int(digits) if digits else 0)
+    if tuple(parts + [0, 0, 0][: 3 - len(parts)]) < _MIN_ISOVAR:
+        raise ImportError(
+            f"isovar>={_MIN_ISOVAR_TEXT} required; found {version}. "
+            f"Upgrade with: pip install -U 'isovar>={_MIN_ISOVAR_TEXT}'"
+        )
+    return isovar
+
+
+def fragment_from_isovar_result(
+    isovar_result,
+    *,
+    gene_expression=None,
+    transcript_expression=None,
+) -> Optional[ProteinFragment]:
+    """Build a :class:`ProteinFragment` from one ``isovar.IsovarResult``.
+
+    The RNA arm of the multi-source fragment story. The sequence is
+    *assembled from reads* rather than translated from the reference, so
+    it carries the patient's other variants and whatever phasing the
+    reads support — which is what makes ``sequence_source`` worth
+    recording alongside it.
+
+    The read counts are **native**: isovar counted them, so they are
+    marked ``measured`` rather than carrying a derivation. That is the
+    distinction the whole evidence vocabulary exists for — every other
+    source either estimates them or counts something adjacent.
+
+    Parameters
+    ----------
+    isovar_result : isovar.IsovarResult
+        A result with a ``top_protein_sequence``.
+    gene_expression, transcript_expression : float, optional
+        Abundance to carry onto the fragment. Left ``None`` when the
+        caller has none, which is not the same as zero.
+
+    Returns
+    -------
+    ProteinFragment or None
+        ``None`` when isovar assembled no protein sequence for the
+        variant — an absence, not an error: a variant with no RNA
+        support is a normal result.
+
+    Examples
+    --------
+    >>> fragments = [                          # doctest: +SKIP
+    ...     fragment_from_isovar_result(r) for r in isovar_results
+    ... ]
+    >>> fragments = [f for f in fragments if f is not None]  # doctest: +SKIP
+    """
+    protein_sequence = getattr(isovar_result, "top_protein_sequence", None)
+    if protein_sequence is None:
+        return None
+
+    amino_acids = getattr(protein_sequence, "amino_acids", "") or ""
+    if not amino_acids:
+        return None
+
+    start = getattr(protein_sequence, "mutation_start_idx", None)
+    end = getattr(protein_sequence, "mutation_end_idx", None)
+    variant = getattr(isovar_result, "variant", None)
+
+    transcript_ids = list(getattr(protein_sequence, "transcript_ids", ()) or ())
+    transcript_names = list(
+        getattr(protein_sequence, "transcript_names", ()) or ()
+    )
+
+    # isovar counts these; nothing is derived, so they are measured.
+    counts = dict(
+        n_overlapping_reads=_as_count(
+            getattr(isovar_result, "num_total_fragments", None)
+        ),
+        n_alt_reads=_as_count(
+            getattr(isovar_result, "num_alt_fragments", None)
+        ),
+        n_ref_reads=_as_count(
+            getattr(isovar_result, "num_ref_fragments", None)
+        ),
+        n_alt_reads_supporting_protein_sequence=_as_count(
+            getattr(protein_sequence, "num_supporting_fragments", None)
+        ),
+    )
+    provenance = {
+        name: "measured" for name, value in counts.items() if value is not None
+    }
+
+    target_intervals = None
+    if start is not None and end is not None:
+        lo = max(0, min(int(start), len(amino_acids)))
+        hi = max(lo, min(int(end), len(amino_acids)))
+        target_intervals = [(lo, hi)]
+
+    return ProteinFragment(
+        fragment_id=_fragment_id(variant, amino_acids),
+        source_type="variant:rna_assembled",
+        sequence=amino_acids,
+        target_intervals=target_intervals,
+        variant=str(variant) if variant is not None else None,
+        gene=getattr(protein_sequence, "gene_name", None),
+        transcript_id=transcript_ids[0] if transcript_ids else None,
+        transcript_name=transcript_names[0] if transcript_names else None,
+        gene_expression=gene_expression,
+        transcript_expression=transcript_expression,
+        field_provenance=provenance,
+        annotations={
+            "sequence_source": ISOVAR_ASSEMBLY,
+            "read_count_method": RNA_READS,
+            # Every transcript consistent with the assembled sequence,
+            # not just the one named above. A release mismatch that
+            # leaves these unresolvable downstream is visible rather
+            # than an empty list.
+            "supporting_reference_transcripts": transcript_ids,
+        },
+        **counts,
+    )
+
+
+def fragments_from_isovar_results(isovar_results):
+    """Fragments for every result that assembled a protein sequence.
+
+    Results with no RNA support are dropped rather than yielding
+    ``None`` entries a caller has to filter — the absence is the answer,
+    and a list comprehension over it should not need a guard.
+    """
+    fragments = []
+    for result in isovar_results:
+        fragment = fragment_from_isovar_result(result)
+        if fragment is not None:
+            fragments.append(fragment)
+    return fragments
+
+
+def _as_count(value):
+    """A non-negative int, or None when the value was not stated."""
+    if value is None:
+        return None
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None
+    return count if count >= 0 else None
+
+
+def _fragment_id(variant, amino_acids):
+    from .protein_fragment import make_fragment_id
+    prefix = str(variant) if variant is not None else "isovar"
+    return make_fragment_id(prefix=prefix, sequence=amino_acids)

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -36,6 +36,7 @@ from .io import _model_version_str
 from mhctools.pred import COLUMNS as _PRED_COLUMNS
 
 from .protein_fragment import ProteinFragment
+from .rna_evidence import VARCODE_TRANSLATION
 from .sequence_helpers import (
     check_padding_around_mutation,
     peptide_mutation_interval,
@@ -446,6 +447,11 @@ def fragment_from_effect(
             _SUBSEQ_OFFSET_KEY: seq_start,
             _MUTATION_START_KEY: mut_start,
             _MUTATION_END_KEY: mut_end,
+            # Translated from the reference, not assembled from reads:
+            # this sequence carries the reference everywhere except the
+            # variant itself, which is the difference a consumer
+            # auditing a ranking needs to see.
+            "sequence_source": VARCODE_TRANSLATION,
         },
     )
 

--- a/topiary/protein_fragment.py
+++ b/topiary/protein_fragment.py
@@ -553,3 +553,172 @@ def collect_annotations(fragments: Iterable[ProteinFragment]) -> set:
     for f in fragments:
         keys.update(f.annotations.keys())
     return keys
+
+
+# ---------------------------------------------------------------------------
+# Every path to a fragment
+# ---------------------------------------------------------------------------
+
+#: The fields every source is expected to speak to, whether or not it can
+#: populate them. A source that cannot answer leaves them ``None``, which
+#: :meth:`ProteinFragment.is_known` distinguishes from zero — that is what
+#: makes one consumer code path work across every source.
+SEMANTIC_CORE = (
+    "fragment_id", "source_type", "sequence", "target_intervals",
+    "variant", "gene", "gene_id", "transcript_id",
+    "gene_expression", "transcript_expression",
+    "n_overlapping_reads", "n_alt_reads", "n_ref_reads",
+    "n_alt_reads_supporting_protein_sequence",
+)
+
+_FRAGMENT_IDENTITY = ("source_sequence_name", "variant", "peptide")
+
+_COUNT_FIELDS = (
+    "n_overlapping_reads", "n_alt_reads", "n_ref_reads",
+    "n_alt_reads_supporting_protein_sequence",
+)
+
+
+def fragments_from_dataframe(df, *, sequence_column=None):
+    """Fragments from a reader's frame — the LENS / pVACseq path.
+
+    :func:`~topiary.fragment_from_effect` covers varcode and
+    :func:`~topiary.fragment_from_isovar_result` covers isovar; this
+    covers the sources that arrive as a table. All three produce the
+    same :data:`SEMANTIC_CORE`, differing only in which fields they can
+    fill, so a consumer reads one shape rather than branching on where
+    the data came from.
+
+    Read counts carry the provenance their derivation implies —
+    ``rna_reads`` is ``measured``, ``rna_depth_x_vaf`` and
+    ``cds_overlap_reads`` are ``approximated`` — via one mapping in
+    :mod:`topiary.rna_evidence`, so a frame and a fragment cannot
+    disagree about whether a number was counted.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A frame from :func:`~topiary.read_lens` or
+        :func:`~topiary.read_pvacseq`, or anything with the same
+        columns.
+    sequence_column : str, optional
+        Which column holds the fragment's sequence. Defaults to the
+        first of ``sequence`` / ``pep_context`` / ``peptide`` present —
+        so a reader that carries surrounding context uses it, and one
+        that carries only the peptide produces the degenerate fragment
+        whose sequence *is* the peptide.
+
+    Returns
+    -------
+    list of ProteinFragment
+        One per distinct (source, variant, sequence). Rows with no
+        sequence are skipped: a fragment with nothing to present is not
+        a fragment.
+    """
+    import pandas as pd
+
+    from .rna_evidence import provenance_for_method
+    from .ranking import is_stated
+
+    if df is None or len(df) == 0:
+        return []
+
+    if sequence_column is None:
+        for candidate in ("sequence", "pep_context", "peptide"):
+            if candidate in df.columns:
+                sequence_column = candidate
+                break
+    if sequence_column is None or sequence_column not in df.columns:
+        raise ValueError(
+            f"No sequence column found. Looked for 'sequence', "
+            f"'pep_context', 'peptide'; frame has "
+            f"{sorted(df.columns)[:8]}... Pass sequence_column= to say "
+            f"which column holds the fragment's sequence."
+        )
+
+    identity = [c for c in _FRAGMENT_IDENTITY if c in df.columns]
+    if sequence_column not in identity:
+        identity = identity + [sequence_column]
+
+    fragments = []
+    for _, group in df.groupby(identity, sort=False, dropna=False):
+        row = group.iloc[0]
+        sequence = row.get(sequence_column)
+        if not is_stated(sequence):
+            continue
+
+        counts = {}
+        provenance = {}
+        method = row.get("read_count_method")
+        supporting_method = row.get("supporting_read_count_method")
+        for count_field in _COUNT_FIELDS:
+            value = row.get(count_field)
+            if value is None or pd.isna(value):
+                continue
+            counts[count_field] = int(value)
+            # n_overlapping_reads is a direct count wherever a reader
+            # reports it; only the split carries the derivation.
+            applicable = (
+                None if count_field == "n_overlapping_reads"
+                else (supporting_method if count_field.endswith("_sequence")
+                      else method)
+            )
+            resolved = provenance_for_method(applicable)
+            if resolved is not None:
+                provenance[count_field] = resolved
+
+        expression_method = row.get("variant_allele_expression_method")
+        if is_stated(expression_method):
+            provenance["transcript_expression"] = provenance_for_method(
+                expression_method
+            )
+
+        annotations = {}
+        for key in ("sequence_source", "read_count_method",
+                    "supporting_read_count_method",
+                    "variant_allele_expression",
+                    "variant_allele_expression_method"):
+            value = row.get(key)
+            if is_stated(value) and not (
+                isinstance(value, float) and pd.isna(value)
+            ):
+                annotations[key] = value
+
+        fragments.append(ProteinFragment(
+            fragment_id=make_fragment_id(
+                prefix=str(row.get("variant") or row.get(
+                    "source_sequence_name") or "fragment"),
+                sequence=str(sequence),
+            ),
+            source_type=_optional(row.get("source_type")),
+            sequence=str(sequence),
+            target_intervals=None,
+            variant=_optional(row.get("variant")),
+            gene=_optional(row.get("gene")),
+            gene_id=_optional(row.get("gene_id")),
+            transcript_id=_optional(row.get("transcript_id")),
+            gene_expression=_optional_float(row.get("gene_expression")),
+            transcript_expression=_optional_float(
+                row.get("transcript_expression")
+            ),
+            field_provenance=provenance,
+            annotations=annotations,
+            **counts,
+        ))
+    return fragments
+
+
+def _optional(value):
+    """The value as a string, or ``None`` when the source said nothing."""
+    from .ranking import is_stated
+    return str(value) if is_stated(value) else None
+
+
+def _optional_float(value):
+    from .ranking import is_stated
+    if not is_stated(value):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -34,7 +34,9 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from .ranking import stated_values
+from types import MappingProxyType
+
+from .ranking import is_stated, stated_values
 
 #: Counted directly from an RNA alignment.
 RNA_READS = "rna_reads"
@@ -53,6 +55,47 @@ TPM_X_DNA_VAF = "tpm_x_dna_vaf"
 READ_COUNT_METHODS = frozenset({
     RNA_READS, RNA_DEPTH_X_VAF, CDS_OVERLAP_READS, TPM_X_DNA_VAF,
 })
+
+#: How each derivation maps onto :data:`~topiary.PROVENANCE_VALUES`.
+#:
+#: Two vocabularies answer different questions — this one says *how* a
+#: number was obtained, ``field_provenance`` says *how real* it is — and
+#: the mapping between them belongs in one place so a reader and a
+#: fragment builder cannot disagree about whether depth x VAF counts as
+#: measured. It does not: only a direct count does.
+METHOD_PROVENANCE = MappingProxyType({
+    RNA_READS: "measured",
+    RNA_DEPTH_X_VAF: "approximated",
+    CDS_OVERLAP_READS: "approximated",
+    TPM_X_DNA_VAF: "approximated",
+})
+
+
+def provenance_for_method(method):
+    """How real a value obtained by *method* is, or ``None`` if unstated.
+
+    Parameters
+    ----------
+    method : str or None
+        One of :data:`READ_COUNT_METHODS`.
+
+    Returns
+    -------
+    str or None
+        A ``field_provenance`` value, or ``None`` when no method was
+        recorded — which means the number was not derived here and
+        carries no claim either way.
+    """
+    if not is_stated(method):
+        return None
+    resolved = METHOD_PROVENANCE.get(str(method).strip())
+    if resolved is None:
+        raise ValueError(
+            f"{method!r} is not a known derivation; use one of "
+            f"{sorted(READ_COUNT_METHODS)}."
+        )
+    return resolved
+
 
 #: How the protein sequence a prediction was made on came to exist.
 #:
@@ -104,6 +147,7 @@ READ_EVIDENCE_COLUMNS = (
     "n_ref_reads",
     "n_alt_reads_supporting_protein_sequence",
     "read_count_method",
+    "supporting_read_count_method",
     "variant_allele_expression",
     "variant_allele_expression_method",
     "sequence_source",
@@ -219,9 +263,22 @@ def attach_read_evidence(
                 f"{supporting_method!r}. A count whose derivation is "
                 f"unnamed cannot be told from one that was measured."
             )
-        out["n_alt_reads_supporting_protein_sequence"] = _counts(supporting)
+        supporting_counts = _counts(supporting)
+        out["n_alt_reads_supporting_protein_sequence"] = supporting_counts
+        # Record the derivation, not just accept it. Without this the
+        # frame carries the count and loses how it was obtained, so a
+        # fragment built from the frame cannot say whether 45 reads were
+        # counted supporting the variant or counted overlapping a CDS.
+        out["supporting_read_count_method"] = pd.Series(
+            [supporting_method if pd.notna(v) else pd.NA
+             for v in supporting_counts],
+            index=out.index, dtype="object",
+        )
     else:
         out["n_alt_reads_supporting_protein_sequence"] = empty
+        out["supporting_read_count_method"] = pd.Series(
+            [pd.NA] * n_rows, index=out.index, dtype="object"
+        )
 
     if expression is not None and dna_vaf is not None:
         abundance = pd.to_numeric(expression, errors="coerce")
@@ -255,6 +312,8 @@ def describe_read_evidence(df: pd.DataFrame) -> dict:
     for column, method_column in (
         ("n_alt_reads", "read_count_method"),
         ("n_ref_reads", "read_count_method"),
+        ("n_alt_reads_supporting_protein_sequence",
+         "supporting_read_count_method"),
         ("variant_allele_expression", "variant_allele_expression_method"),
     ):
         if column not in df.columns or method_column not in df.columns:


### PR DESCRIPTION
Toward #102 — the isovar path, and every other path with it.

5.37.0 put `isovar_assembly` in the vocabulary with **nothing emitting it**. A
name for a thing that does not exist is the same shape as a configured knob that
does nothing, which this repo has spent the week removing. This adds the
emitter, and the three other paths alongside it.

## isovar

`fragment_from_isovar_result` mirrors what a consumer already does with an
`IsovarResult`: `top_protein_sequence` for the assembled sequence and the
mutated span, `num_total/alt/ref_fragments` plus
`num_supporting_fragments` for the counts, `transcript_ids` for the supporting
transcripts. A result with no `top_protein_sequence` returns `None` — an
absence, not an error, since a variant with no RNA support is a normal result.
`fragments_from_isovar_results` drops those, so a caller does not need a guard.

**isovar is the only source that counts.** It assembles a sequence from reads
and counts the ones supporting it, so its numbers are `measured`. pVACseq
derives the split from depth × VAF; LENS counts reads overlapping the peptide's
CDS. Both `approximated`. One mapping — `provenance_for_method` — decides which
is which, so a frame and a fragment cannot disagree about whether depth × VAF
counts as measured. It does not.

**Optional in the strong sense**, as the consumer asked: not imported at module
scope, not in `requirements.txt`, and `import topiary` does not import it.
There is a test asserting that in a subprocess, because the claim is easy to
make and easy to break with one convenience import.

## Every path reaches a fragment

`fragments_from_dataframe` gives the table readers the same destination that
varcode and isovar have:

| Source | Sequence is | Read counts |
|---|---|---|
| isovar | assembled from RNA reads | **counted** (`measured`) |
| varcode | translated from the reference | none |
| LENS | the peptide's context | overlapping counted; support is CDS-overlap (`approximated`) |
| pVACseq | the peptide itself | depth × VAF (`approximated`) |

`SEMANTIC_CORE` names the fields every source speaks to, so this reads all four
without knowing which it has:

```python
def rna_support(fragment):
    if not fragment.is_usable_as_biology("n_alt_reads"):
        return None
    return fragment.n_alt_reads, fragment.is_approximate("n_alt_reads")
```

isovar `(30, False)`, pVACseq a count with `True`, varcode `None`. **No
branching on `source_type`** — which is why `source_type` stays biological.

## A gap in 5.37.0 this surfaced

`attach_read_evidence` took `supporting_method` and dropped it. So a frame
carried LENS's count of 45 CDS-overlapping reads with **no way to say it was
not 45 reads supporting the variant** — the exact distinction that release
existed to record, lost one field over from where it was stated. It is a column
now, and the fragment reads it.

The consumer independently hit the downstream half of this: they had assigned
that column straight to `n_alt_reads`, and it reached ranking. On their real
fixtures the CDS count and depth × VAF disagree in both directions
(2 vs 51, 12 vs 6, 166 vs 75) and the top pick flipped on two of four.

## Tests

19 in `tests/test_fragment_paths.py`: isovar builds a fragment with counts
marked `measured`, the mutated span inside the sequence, supporting transcripts
carried, no-RNA-support returning `None`, the list helper dropping those, and
isovar staying unimported; both table readers producing fragments with their
derivations marked; a frame with no sequence column saying so; and the two that
matter — **every path producing `SEMANTIC_CORE`**, and **one consumer function
reading all four sources correctly**.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2155 passed, 3 skipped

Version 5.38.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
