### PR TITLE
Do not project a peptide-level row that names an allele (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ conflict.** They are two answers to two questions. Two *blank-allele*
 rows that disagree still raise, since that is a peptide contradicting
 itself.
 
+**The warning now describes what happened.** It said "which carries no
+allele" in every case — which becomes false the moment a row names one,
+and that is exactly the user whose scores just narrowed. Three messages
+now, naming the action taken rather than the counterfactual avoided:
+rows all naming alleles, rows mixed, and rows carrying none.
+
 This unblocks allele attribution downstream (openvax/vaxrank#349):
 writing a row onto chosen alleles is the natural way to say "credit this
 evidence here", and it was being discarded — so every attribution policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 5.39.0
+
+**Fixed: a peptide-level row that names an allele was projected onto
+every other allele (#232).** The explicit allele was silently discarded:
+
+```
+row: antigen_processing, allele=HLA-A*02:01, score=0.8
+
+  HLA-A*02:01    0.8
+  HLA-B*07:02    0.8      <- the row said A*02:01
+```
+
+Peptide-level evidence usually carries no allele, and then there is
+exactly one thing a reference to it can mean — this peptide's value, for
+every allele — so topiary projects it. But a producer that writes such a
+row *onto one allele* is saying something narrower, and projecting it
+anyway credits a score to alleles the row explicitly did not name. That
+is a value attributed to something that did not state it, the same
+family as the stringified-null group keys one level up.
+
+Now: a blank-allele row broadcasts as before; a row that names an allele
+lands in that allele's group and nowhere else; and the two compose — the
+named row claims its allele, a blank row fills the rest. "Names an
+allele" uses the same `is_stated` rule as everything else, so a frame
+that went through `astype(str)` does not stop broadcasting.
+
+**`haplotype` is deliberately exempt.** mhctools stamps a genotype-level
+score with the allele it deconvolved as the best presenter, so that
+allele is an artifact of reporting rather than a restriction — treating
+it as one would strand a joint score on a single allele, which is the
+failure projection exists to prevent.
+
+**Two peptide-level rows at different alleles are no longer a
+conflict.** They are two answers to two questions. Two *blank-allele*
+rows that disagree still raise, since that is a peptide contradicting
+itself.
+
+This unblocks allele attribution downstream (openvax/vaxrank#349):
+writing a row onto chosen alleles is the natural way to say "credit this
+evidence here", and it was being discarded — so every attribution policy
+produced identical per-allele scores, and a narrowing knob could compute
+an answer and then silently fail to apply it.
+
 ## 5.38.0
 
 **Added: isovar → `ProteinFragment`, and every other path with it

--- a/tests/test_named_allele_projection.py
+++ b/tests/test_named_allele_projection.py
@@ -1,0 +1,222 @@
+"""A peptide-level row that names an allele is not broadcast (topiary #232).
+
+Peptide-level evidence — cleavage, TAP, ERAP, integrated processing — usually
+carries no allele, and then there is exactly one thing a reference to it can
+mean: this peptide's value, for every allele. So topiary projects it.
+
+But a producer that writes such a row *onto one allele* is saying something
+narrower, and projecting it anyway credits a score to alleles the row
+explicitly did not name. That is a value attributed to something that did not
+state it — the same family as the stringified-null group keys, one level up.
+
+It also blocks the mechanism a consumer needs for allele attribution
+(openvax/vaxrank#349): writing the row onto an allele is the natural way to say
+"credit this here only", and it was being discarded, so every attribution
+policy produced identical per-allele scores.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from topiary import EvalContext, evaluate_scores, is_stated, peptide_view
+from topiary.ranking import parse
+
+ALLELES = ("HLA-A*02:01", "HLA-B*07:02")
+
+
+def _row(kind, allele, score, method="mhcflurry", allele_set=""):
+    return dict(
+        source_sequence_name="s", peptide="SIINFEKLA", peptide_offset=0,
+        allele=allele, allele_set=allele_set, kind=kind, value=score,
+        score=score, percentile_rank=1.0, prediction_method_name=method,
+        predictor_version="1",
+    )
+
+
+def _affinity_rows():
+    return [
+        _row("pMHC_affinity", allele, value, method="netmhcpan")
+        for allele, value in zip(ALLELES, (50.0, 900.0))
+    ]
+
+
+def _by_allele(series):
+    """Scores keyed by allele, for groups that name one.
+
+    A blank-allele row forms its own group (deliberate, since 5.35.0 — a
+    blank cell is stated-but-empty, not a stringified null), so
+    "by allele" has to mean groups that actually name an allele. Using
+    `pd.notna` here would let that group in and compare it against real
+    alleles.
+    """
+    return {
+        key[3]: (None if pd.isna(value) else round(float(value), 3))
+        for key, value in series.items()
+        if is_stated(key[3])
+    }
+
+
+def _eval(rows, expression="antigen_processing['mhcflurry'].score", **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return parse(expression).eval(
+            EvalContext(pd.DataFrame(_affinity_rows() + rows), **kwargs)
+        )
+
+
+# ---------------------------------------------------------------------------
+# The bug
+# ---------------------------------------------------------------------------
+
+
+def test_a_named_allele_is_not_projected_onto_the_others():
+    scores = _by_allele(_eval([
+        _row("antigen_processing", "HLA-A*02:01", 0.8),
+    ]))
+
+    assert scores["HLA-A*02:01"] == 0.8
+    assert scores["HLA-B*07:02"] is None
+
+
+def test_an_allele_free_row_still_broadcasts():
+    """The case projection exists for, unchanged."""
+    scores = _by_allele(_eval([_row("antigen_processing", None, 0.8)]))
+
+    assert scores == {"HLA-A*02:01": 0.8, "HLA-B*07:02": 0.8}
+
+
+def test_a_named_row_and_a_free_row_compose():
+    """The named row claims its allele; the free row fills the rest."""
+    scores = _by_allele(_eval([
+        _row("antigen_processing", "HLA-A*02:01", 0.8),
+        _row("antigen_processing", None, 0.3),
+    ]))
+
+    assert scores == {"HLA-A*02:01": 0.8, "HLA-B*07:02": 0.3}
+
+
+def test_two_named_rows_each_keep_their_own_allele():
+    """Two answers to two questions, not one peptide contradicting itself."""
+    scores = _by_allele(_eval([
+        _row("antigen_processing", "HLA-A*02:01", 0.9),
+        _row("antigen_processing", "HLA-B*07:02", 0.1),
+    ]))
+
+    assert scores == {"HLA-A*02:01": 0.9, "HLA-B*07:02": 0.1}
+
+
+@pytest.mark.parametrize("blank", [None, "", "  ", "nan"],
+                         ids=["none", "empty", "blank", "literal-nan"])
+def test_every_spelling_of_no_allele_broadcasts(blank):
+    """"Names an allele" uses the same is_stated rule as everything else,
+    so a frame through astype(str) does not stop broadcasting."""
+    scores = _by_allele(_eval([_row("antigen_processing", blank, 0.8)]))
+
+    assert scores == {"HLA-A*02:01": 0.8, "HLA-B*07:02": 0.8}
+
+
+# ---------------------------------------------------------------------------
+# peptide_view says the same thing
+# ---------------------------------------------------------------------------
+
+
+def test_peptide_view_respects_a_named_allele():
+    df = pd.DataFrame(_affinity_rows() + [
+        _row("antigen_processing", "HLA-A*02:01", 0.8),
+    ])
+
+    scores = evaluate_scores(df, peptide_view(parse("antigen_processing.score")))
+
+    assert scores.notna().sum() < len(scores)
+
+
+def test_peptide_view_still_broadcasts_an_allele_free_row():
+    df = pd.DataFrame(_affinity_rows() + [
+        _row("antigen_processing", None, 0.8),
+    ])
+
+    scores = evaluate_scores(df, peptide_view(parse("antigen_processing.score")))
+
+    assert (scores.dropna() == 0.8).all()
+
+
+# ---------------------------------------------------------------------------
+# haplotype is exempt, deliberately
+# ---------------------------------------------------------------------------
+
+
+def test_a_haplotype_row_still_projects_across_the_genotype():
+    """mhctools stamps a genotype-level score with the allele it
+    deconvolved as the best presenter. That allele is an artifact of
+    reporting, not a restriction — treating it as one would strand a
+    joint score on a single allele, which is the failure projection
+    exists to prevent."""
+    kind_support = {
+        "mhcflurry": {
+            "pMHC_presentation": {
+                "mhc_dependence": "haplotype", "mhc_class": "I",
+            },
+            "pMHC_affinity": {
+                "mhc_dependence": "single_allele", "mhc_class": "I",
+            },
+        },
+    }
+    scores = _by_allele(_eval(
+        [_row("pMHC_presentation", "HLA-A*02:01", 0.9,
+              allele_set="HLA-A*02:01,HLA-B*07:02")],
+        expression="presentation.score",
+        kind_support=kind_support,
+    ))
+
+    assert scores["HLA-A*02:01"] == 0.9
+    assert scores["HLA-B*07:02"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# The conflict guard still guards
+# ---------------------------------------------------------------------------
+
+
+def test_two_allele_free_rows_that_disagree_still_raise():
+    """That is a peptide contradicting itself, and still an error."""
+    df = pd.DataFrame(_affinity_rows() + [
+        _row("antigen_processing", None, 0.9),
+        _row("antigen_processing", None, 0.1),
+    ])
+
+    with pytest.raises(ValueError, match="several different"):
+        evaluate_scores(df, peptide_view(parse("antigen_processing.score")))
+
+
+def test_two_named_rows_that_disagree_do_not_raise():
+    """They disagree about different alleles, which is not a disagreement."""
+    df = pd.DataFrame(_affinity_rows() + [
+        _row("antigen_processing", "HLA-A*02:01", 0.9),
+        _row("antigen_processing", "HLA-B*07:02", 0.1),
+    ])
+
+    scores = evaluate_scores(df, peptide_view(parse("antigen_processing.score")))
+
+    assert scores.notna().any()
+
+
+# ---------------------------------------------------------------------------
+# What this unblocks
+# ---------------------------------------------------------------------------
+
+
+def test_an_attribution_policy_can_now_change_the_scores():
+    """The mechanism vaxrank#349 needs: writing the row onto chosen
+    alleles must change per-allele scores. Every policy previously
+    produced identical output, which is why a narrowing knob could
+    compute an answer and then fail to apply it."""
+    whole_genotype = _by_allele(_eval([
+        _row("antigen_processing", None, 0.8),
+    ]))
+    best_allele_only = _by_allele(_eval([
+        _row("antigen_processing", "HLA-A*02:01", 0.8),
+    ]))
+
+    assert whole_genotype != best_allele_only

--- a/tests/test_named_allele_projection.py
+++ b/tests/test_named_allele_projection.py
@@ -220,3 +220,63 @@ def test_an_attribution_policy_can_now_change_the_scores():
     ]))
 
     assert whole_genotype != best_allele_only
+
+
+# ---------------------------------------------------------------------------
+# The warning has to describe what happened
+# ---------------------------------------------------------------------------
+#
+# The message a user reads when their scores change is the only signal they
+# get. Saying "carries no allele" to someone whose allele-naming rows just
+# stopped broadcasting describes the opposite of what topiary did.
+
+
+def test_the_warning_says_rows_name_alleles_when_they_do():
+    with pytest.warns(UserWarning, match="whose rows name alleles"):
+        parse("antigen_processing['mhcflurry'].score").eval(
+            EvalContext(pd.DataFrame(_affinity_rows() + [
+                _row("antigen_processing", "HLA-A*02:01", 0.8),
+            ]))
+        )
+
+
+def test_the_warning_says_no_allele_when_that_is_true():
+    with pytest.warns(UserWarning, match="which carries no allele"):
+        parse("antigen_processing['mhcflurry'].score").eval(
+            EvalContext(pd.DataFrame(_affinity_rows() + [
+                _row("antigen_processing", None, 0.8),
+            ]))
+        )
+
+
+def test_the_warning_distinguishes_all_named_from_mixed():
+    """A mixed frame projects the blank rows; an all-named one does not."""
+    with pytest.warns(UserWarning, match="and no other"):
+        parse("antigen_processing['mhcflurry'].score").eval(
+            EvalContext(pd.DataFrame(_affinity_rows() + [
+                _row("antigen_processing", "HLA-A*02:01", 0.8),
+            ]))
+        )
+    with pytest.warns(UserWarning, match="projects the allele-free rows"):
+        parse("antigen_processing['mhcflurry'].score").eval(
+            EvalContext(pd.DataFrame(_affinity_rows() + [
+                _row("antigen_processing", "HLA-A*02:01", 0.8),
+                _row("antigen_processing", None, 0.3),
+            ]))
+        )
+
+
+def test_every_branch_states_the_outcome_not_the_counterfactual():
+    """"would leave every group NaN" is what topiary avoided, not what it
+    did. Each message has to name the action taken."""
+    for extra in (
+        [_row("antigen_processing", "HLA-A*02:01", 0.8)],
+        [_row("antigen_processing", None, 0.8)],
+    ):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            parse("antigen_processing['mhcflurry'].score").eval(
+                EvalContext(pd.DataFrame(_affinity_rows() + extra))
+            )
+        message = str(caught[0].message)
+        assert "so topiary credits" in message or "so topiary projects" in message

--- a/tests/test_peptide_view.py
+++ b/tests/test_peptide_view.py
@@ -772,11 +772,16 @@ def test_best_field_without_a_direction_is_rejected_not_downgraded():
 
 
 def test_no_direction_error_explains_the_real_cause():
-    """Not 'mhc_dependence=single_allele means one row per peptide'."""
+    """Not 'mhc_dependence=single_allele means one row per peptide'.
+
+    The disagreeing rows must be **allele-free** to be a disagreement.
+    Two allele-restricted rows are two answers to two questions (#232),
+    not one peptide contradicting itself.
+    """
     df = pd.DataFrame([
-        _row(allele=allele, kind="antigen_processing", value=value,
+        _row(allele=None, kind="antigen_processing", value=value,
              prediction_method_name="mhcflurry")
-        for allele, value in zip(ALLELES, (0.9, 0.1))
+        for value in (0.9, 0.1)
     ])
 
     with pytest.raises(ValueError, match="no defined best direction"):

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -126,7 +126,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.38.0"
+__version__ = "5.39.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -2004,24 +2004,48 @@ class Field(DSLNode):
 
         kind_name = _kind_short_name(self.kind)
         if dependence == "none":
-            subject = f"{kind_name}, which carries no allele,"
-            reading = "would leave every allele group NaN"
+            # Say which shape the rows are actually in. A frame whose
+            # peptide-level rows name alleles is no longer broadcast
+            # wholesale (#232), and telling that user their rows "carry
+            # no allele" describes the opposite of what happened —
+            # exactly when their scores just narrowed.
+            named = (
+                "allele" in sub.columns and stated_values(sub["allele"]).any()
+            )
+            if named:
+                all_named = stated_values(sub["allele"]).all()
+                subject = (
+                    f"{kind_name}, which is peptide-level but whose rows "
+                    f"name alleles,"
+                )
+                reading = (
+                    "credits each row to the allele it names and no other"
+                    if all_named else
+                    "credits each allele-naming row to that allele, and "
+                    "projects the allele-free rows across the rest"
+                )
+            else:
+                subject = f"{kind_name}, which carries no allele,"
+                reading = (
+                    "projects its peptide-level value across them — "
+                    "reading it directly would leave every allele group NaN"
+                )
         else:
             subject = (
                 f"{kind_name}, which is predicted for a whole genotype "
                 f"rather than one allele,"
             )
             reading = (
+                "projects it across the genotype — reading it directly "
                 "would hand that joint score to the single allele "
                 "mhctools deconvolved as the best one, leaving the rest "
                 "of the genotype NaN"
             )
         import warnings
         warnings.warn(
-            f"{self!r} reads {subject} in a grouping keyed by allele. "
-            f"Reading it directly {reading}, so its peptide-level value "
-            f"is projected across them — write peptide_view({self!r}) to "
-            f"say so explicitly and silence this warning.",
+            f"{self!r} reads {subject} in a grouping keyed by allele, so "
+            f"topiary {reading}. Write peptide_view({self!r}) to say so "
+            f"explicitly and silence this warning.",
             UserWarning, stacklevel=4,
         )
         return PeptideView(self).eval(ctx)

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -2624,7 +2624,24 @@ class PeptideView(DSLNode):
 
     def _eval_peptide_level(self, ctx, sub, peptide_keys, dependence,
                             aggregable):
-        """Read the one row per peptide and broadcast it to its groups."""
+        """Read the one row per peptide and broadcast it to its groups.
+
+        A row that *names* an allele is not broadcast. Peptide-level
+        evidence usually carries no allele, and then there is exactly
+        one thing the reference can mean — this peptide's value, for
+        every allele. But a producer that writes such a row onto one
+        allele is saying something narrower, and projecting it anyway
+        credits a score to alleles the row explicitly did not name.
+        Blank-allele rows broadcast; named rows land in their own group
+        and nowhere else.
+
+        ``haplotype`` is deliberately exempt. mhctools stamps a
+        genotype-level score with the allele it deconvolved as the best
+        presenter, so the allele there is an artifact of reporting
+        rather than a restriction — treating it as one would strand a
+        joint score on a single allele, which is the failure projection
+        exists to prevent.
+        """
         inner = self.inner
         if sub is None:
             return ctx.empty_series()
@@ -2634,17 +2651,57 @@ class PeptideView(DSLNode):
 
         values = pd.to_numeric(sub[col_name], errors="coerce")
         keep = values.notna()
+        if not keep.any():
+            return ctx.empty_series()
+
+        restricts = (
+            dependence == "none"
+            and "allele" in ctx.group_keys
+            and "allele" in sub.columns
+        )
+        named = (
+            keep & stated_values(sub["allele"]) if restricts
+            else pd.Series(False, index=sub.index)
+        )
+
+        broadcast = self._broadcast_unnamed(
+            ctx, sub, peptide_keys, values, keep & ~named,
+            dependence, aggregable,
+        )
+        if not named.any():
+            return broadcast
+        return self._overlay_named(ctx, sub, values, named, broadcast)
+
+    def _broadcast_unnamed(self, ctx, sub, peptide_keys, values, keep,
+                           dependence, aggregable):
+        """The classic path: one value per peptide, across its groups."""
+        if not keep.any():
+            return ctx.empty_series()
         valid = sub.loc[keep, peptide_keys].assign(
             __peptide_value=values[keep],
         )
-        if valid.empty:
-            return ctx.empty_series()
-
         stats = valid.groupby(peptide_keys, sort=False, dropna=False)[
             "__peptide_value"
         ].agg(["first", "min", "max"])
         self._check_one_value_per_peptide(stats, dependence, aggregable)
         return _broadcast_per_peptide(ctx, stats["first"], peptide_keys)
+
+    def _overlay_named(self, ctx, sub, values, named, broadcast):
+        """Write allele-restricted rows onto their own groups only."""
+        result = broadcast.copy()
+        positions = {key: i for i, key in enumerate(ctx.group_index)}
+        single_key = len(ctx.group_keys) == 1
+        array = result.to_numpy(dtype=float, copy=True)
+        rows = sub.loc[named, list(ctx.group_keys)]
+        for value, (_, row) in zip(values[named], rows.iterrows()):
+            key = (
+                row[ctx.group_keys[0]] if single_key
+                else tuple(row[k] for k in ctx.group_keys)
+            )
+            position = positions.get(key)
+            if position is not None:
+                array[position] = value
+        return pd.Series(array, index=ctx.group_index)
 
     def _check_one_value_per_peptide(self, stats, dependence, aggregable):
         """A peptide-level read must not find the peptide disagreeing.


### PR DESCRIPTION
Closes #232.

## The bug

A peptide-level kind was projected across a peptide's allele groups **even when
the row itself named an allele**:

```
row: antigen_processing, allele=HLA-A*02:01, score=0.8

  HLA-A*02:01    0.8
  HLA-B*07:02    0.8      <- the row said A*02:01
```

Peptide-level evidence usually carries no allele, and then projection is the
only sensible reading — a plain read would leave every allele group NaN, which
is no answer rather than a different one. But a producer that writes such a row
*onto one allele* is saying something narrower, and projecting it anyway credits
a score to alleles the row explicitly did not name.

**That is a value attributed to something that did not state it** — the same
family as the stringified-null group keys, one level up, as the issue notes.

## The fix

- A **blank-allele row broadcasts**, exactly as before.
- A row that **names an allele lands in that group and nowhere else**.
- The two **compose**: the named row claims its allele, a blank row fills the
  rest. `{A*02:01: 0.8, B*07:02: 0.3}` from one named row at 0.8 and one blank
  row at 0.3.

"Names an allele" goes through the same `is_stated` rule as everything else, so
a frame that went through `astype(str)` somewhere does not stop broadcasting.
Parameterized over `None` / `""` / `"  "` / `"nan"`.

## `haplotype` is exempt, deliberately

mhctools stamps a genotype-level score with the allele it deconvolved as the
best presenter. That allele is **an artifact of reporting, not a restriction** —
treating it as one would strand a joint score on a single allele and leave the
rest of the genotype NaN, which is precisely the failure projection exists to
prevent. Only `mhc_dependence='none'` restricts. There is a test.

## A behavior change worth naming

Two peptide-level rows at **different alleles** are no longer a conflict — they
answer different questions. Two **blank-allele** rows that disagree still raise,
since that is a peptide contradicting itself.

One existing test pinned the old semantics: it triggered the "several different
values" error using two rows at different alleles. That shape is now legal, so
the test uses two blank-allele rows — the shape that is genuinely
contradictory. The guard is unchanged and still fires.

## What this unblocks

openvax/vaxrank#349. Writing a row onto chosen alleles is the natural way for an
attribution policy to say "credit this evidence here", and it was being
discarded — so **every policy produced identical per-allele scores**, and a
narrowing knob could compute an answer and then silently fail to apply it. There
is a test asserting that whole-genotype and best-allele-only attribution now
produce different scores, which is the property the mechanism needs.

This also corrects something I got wrong earlier: I checked that the four
capabilities vaxrank#349 needs were exported and concluded it was unblocked. I
verified the pieces existed without testing whether they compose into the thing
being asked for. They did not.

## Tests

14 in `tests/test_named_allele_projection.py`: the named row not projecting; the
blank row still broadcasting; the two composing; two named rows each keeping
their allele; every spelling of blank still broadcasting (parameterized);
`peptide_view` agreeing with the bare read on both; haplotype still projecting
across the genotype; the conflict guard still firing for blank-allele
disagreement and not for named ones; and an attribution policy now changing the
scores.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2169 passed, 3 skipped

Version 5.39.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
