### PR TITLE
Run isovar to build the protein context, interchangeably with varcode (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 5.40.0
+
+**Added: `fragments_from_variants` — isovar, actually run (#102).**
+5.38.0 could adapt an `IsovarResult` a caller already had. This runs
+isovar to produce them, so topiary can build the surrounding protein
+context for a mutation from RNA rather than only consume someone else's:
+
+```python
+fragments = fragments_from_variants(variants, alignment_file=bam)  # assembled
+fragments = fragments_from_variants(variants)                      # translated
+```
+
+**The two arms are interchangeable.** Both return `ProteinFragment`s
+with the same core, so a pipeline does not change shape when the RNA
+does or does not exist. What differs is what the fragments can tell
+you — an assembled sequence carries the patient's other variants and
+whatever phasing the reads support, plus counted read support; a
+translated one carries the reference everywhere except the variant, and
+no counts. `annotations["sequence_source"]` says which, so an RNA-backed
+candidate and an inferred one never blend.
+
+`protein_sequence_length` is a *sequence* length, not a peptide length:
+a fragment is scanned by a sliding window downstream, so the assembled
+context must contain every peptide that could cover the mutation.
+Default 25. `padding_around_mutation` defaults to half of it so the
+reference arm produces a comparable window.
+
+`allow_reference_fallback=True` translates variants isovar could not
+support instead of dropping them.
+
+isovar is needed **only** when `alignment_file` is given — the reference
+arm imports nothing from it, with a test asserting that arm works while
+isovar is unimportable.
+
 ## 5.39.0
 
 **Fixed: a peptide-level row that names an allele was projected onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,38 @@ reference arm produces a comparable window.
 `allow_reference_fallback=True` translates variants isovar could not
 support instead of dropping them.
 
-isovar is needed **only** when `alignment_file` is given — the reference
-arm imports nothing from it, with a test asserting that arm works while
-isovar is unimportable.
+`filter_thresholds` now actually filters. **isovar records filter
+outcomes and never drops anything**, so a caller's thresholds — and
+isovar's own defaults — annotated results that then flowed on as
+RNA-backed evidence. `require_passing_filters=True` drops them; pass
+`False` for the old behaviour.
+
+Assembly is turned **on**. isovar defaults `variant_sequence_assembly`
+to off, which requires a single read or fragment to span the whole
+window — so a longer context yields *fewer* variants rather than longer
+sequences, and "carrying the phasing the reads support" would not be
+true of the result. The default window is isovar's 21 rather than a
+raised 25, for the same reason.
+
+`fragments_from_effects` is public: the reference arm on its own, for a
+caller with variants and no alignment file. It filters silent and
+non-coding effects first (several varcode classes expose a
+`mutant_protein_sequence` while leaving the amino-acid offsets `None`,
+and `fragment_from_effect` raises on those — one such effect anywhere in
+a batch discarded every fragment already built), and it uses
+expression-aware transcript selection when transcript expression is
+given, so the same variants pick the same transcript whichever entry
+point built them.
+
+Conflicting or inapplicable arguments are refused rather than silently
+resolved: `protein_sequence_length` together with a
+`protein_sequence_creator` (the creator's length used to win silently),
+isovar-only arguments with no `alignment_file` (they were swallowed), a
+non-positive window, and a `padding_around_mutation` too small to
+contain an epitope — the last validated by the existing
+`check_padding_around_mutation` rather than a fresh derivation.
+
+isovar is needed **only** when `alignment_file` is given.
 
 ## 5.39.0
 

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -59,6 +59,41 @@ Two rules worth knowing before you rely on it:
 
 It returns `None` when the effect has no mutant protein sequence at all (silent, non-coding, untranslatable). That is an absence, not an error.
 
+## Building fragments from variants, with or without RNA
+
+```python
+from topiary import fragments_from_variants
+
+# RNA available: the context around each mutation is assembled from reads
+fragments = fragments_from_variants(variants, alignment_file=bam)
+
+# No RNA: the same variants translated from the reference
+fragments = fragments_from_variants(variants)
+```
+
+**The two arms are interchangeable.** Both return `ProteinFragment`s with the
+same core, so the rest of a pipeline does not change shape when the RNA does or
+does not exist. What changes is what the fragments can tell you: an assembled
+sequence carries the patient's other variants and whatever phasing the reads
+support, and comes with counted read support; a translated one carries the
+reference everywhere except the variant itself, and no read counts at all.
+`annotations["sequence_source"]` says which.
+
+`protein_sequence_length` is a *sequence* length, not a peptide length — a
+fragment is scanned by a sliding window downstream, so the assembled context has
+to be long enough to contain every peptide that could cover the mutation.
+Default 25 (a 9-mer plus 8 either side). `padding_around_mutation` defaults to
+half of it, so the reference arm produces a comparable window.
+
+`allow_reference_fallback=True` translates variants isovar could not support
+rather than dropping them. The fragments stay distinguishable by
+`sequence_source`, which is the reason to record it rather than blend an
+RNA-backed candidate with an inferred one.
+
+isovar is needed **only** when `alignment_file` is given. A caller without RNA
+never touches the optional dependency — there is a test asserting the reference
+arm works with isovar unimportable.
+
 ## Every source reaches a fragment
 
 Four paths, one shape. They differ only in which fields they can fill:

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -90,9 +90,11 @@ rather than dropping them. The fragments stay distinguishable by
 `sequence_source`, which is the reason to record it rather than blend an
 RNA-backed candidate with an inferred one.
 
-isovar is needed **only** when `alignment_file` is given. A caller without RNA
-never touches the optional dependency — there is a test asserting the reference
-arm works with isovar unimportable.
+isovar is needed **only** when `alignment_file` is given. `fragments_from_effects`
+is the reference arm on its own, public because a caller with variants and no
+alignment file wants exactly that. The test suite for this path imports isovar
+nowhere — the RNA arm is exercised through a fake — so it runs in an environment
+that has never installed it.
 
 ## Every source reaches a fragment
 
@@ -124,8 +126,9 @@ or not it can populate them.
 
 Not imported at module scope, not in `requirements.txt`, and topiary's shape is
 identical whether or not it is installed — `import topiary` does not import it.
-Only `fragment_from_isovar_result` needs it, and it says how to install it if
-missing. A consumer that only reads LENS reports should not pay for a package
+Only `fragments_from_variants` with an `alignment_file` imports it, and it says
+how to install it if missing. `fragment_from_isovar_result` needs nothing from
+isovar at all — it reads an already-built result by attribute. A consumer that only reads LENS reports should not pay for a package
 it never calls.
 
 isovar is also the only source that *counts* the reads supporting an assembled

--- a/tests/test_isovar_run.py
+++ b/tests/test_isovar_run.py
@@ -1,26 +1,24 @@
 """Running isovar for real, interchangeably with reference translation.
 
-The point of `fragments_from_variants`: give it an alignment file and the
-protein context around each mutation is **assembled from RNA reads**; leave
-it out and the same variants are **translated from the reference**. Either
-way the result is `ProteinFragment`s with the same core, so a pipeline does
-not change shape when the RNA does or does not exist.
+Give `fragments_from_variants` an alignment file and the protein context
+around each mutation is assembled from RNA reads; leave it out and the same
+variants are translated from the reference. Both arms return
+`ProteinFragment`s with the same core.
 
-The assembled sequence is deliberately longer than one peptide — a fragment
-is scanned by a sliding window downstream, so it has to contain every
-peptide that could cover the mutation.
+**Nothing here imports isovar.** The RNA arm is exercised through a fake, so
+these run in an environment that has never installed it — which is the claim
+the module makes and CI is such an environment.
 """
 
-import warnings
-
 import pytest
+from varcode import NonsilentCodingMutation
 
 from topiary import (
     DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     ProteinFragment,
+    fragments_from_effects,
     fragments_from_variants,
 )
-from topiary.io_isovar import _reference_fragments
 
 
 class _ProteinSequence:
@@ -34,12 +32,20 @@ class _ProteinSequence:
 
 
 class _Result:
-    def __init__(self, supported=True, variant="chr7 g.140453136 A>T"):
+    def __init__(self, supported=True, passes=True, variant="v"):
         self.top_protein_sequence = _ProteinSequence() if supported else None
         self.variant = variant
+        self.passes_all_filters = passes
         self.num_total_fragments = 61
         self.num_alt_fragments = 30
         self.num_ref_fragments = 31
+
+
+class _FakeCreator:
+    def __init__(self, protein_sequence_length=21,
+                 variant_sequence_assembly=False):
+        self.protein_sequence_length = protein_sequence_length
+        self.variant_sequence_assembly = variant_sequence_assembly
 
 
 class _FakeIsovar:
@@ -54,11 +60,25 @@ class _FakeIsovar:
         return self._results
 
 
-@pytest.fixture
-def fake_isovar(monkeypatch):
-    module = _FakeIsovar([_Result()])
+def _fake(monkeypatch, results):
+    module = _FakeIsovar(results)
     monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+    monkeypatch.setattr(
+        "topiary.io_isovar.ProteinSequenceCreator", _FakeCreator,
+        raising=False,
+    )
+    import sys
+    import types
+    stub = types.ModuleType("isovar.protein_sequence_creator")
+    stub.ProteinSequenceCreator = _FakeCreator
+    monkeypatch.setitem(sys.modules, "isovar", types.ModuleType("isovar"))
+    monkeypatch.setitem(sys.modules, "isovar.protein_sequence_creator", stub)
     return module
+
+
+@pytest.fixture
+def isovar(monkeypatch):
+    return _fake(monkeypatch, [_Result()])
 
 
 # ---------------------------------------------------------------------------
@@ -66,63 +86,68 @@ def fake_isovar(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_an_alignment_file_assembles_from_rna(fake_isovar):
+def test_an_alignment_file_assembles_from_rna(isovar):
     fragments = fragments_from_variants(["v"], alignment_file=object())
 
     assert len(fragments) == 1
     assert fragments[0].annotations["sequence_source"] == "isovar_assembly"
 
 
-def test_the_assembled_context_is_longer_than_a_peptide(fake_isovar):
-    """A sliding window has to fit; that is why this is a sequence length."""
-    fragments = fragments_from_variants(["v"], alignment_file=object())
+def test_assembly_is_turned_on():
+    """isovar defaults it off, and with it off a single read must span the
+    whole window — so a longer context yields fewer variants rather than
+    longer sequences, and "carrying the phasing the reads support" would
+    not be true of the result."""
+    import types
 
-    assert len(fragments[0].sequence) > 9
+    import topiary.io_isovar as module
+
+    captured = {}
+
+    class _Creator(_FakeCreator):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            super().__init__(**kwargs)
+
+    stub = types.ModuleType("isovar.protein_sequence_creator")
+    stub.ProteinSequenceCreator = _Creator
+    fake = _FakeIsovar([_Result()])
+
+    import sys
+    sys.modules["isovar"] = types.ModuleType("isovar")
+    sys.modules["isovar.protein_sequence_creator"] = stub
+    original = module._check_isovar
+    module._check_isovar = lambda: fake
+    try:
+        fragments_from_variants(["v"], alignment_file=object())
+    finally:
+        module._check_isovar = original
+        del sys.modules["isovar"], sys.modules["isovar.protein_sequence_creator"]
+
+    assert captured["variant_sequence_assembly"] is True
 
 
-def test_the_requested_context_length_reaches_isovar(fake_isovar):
-    fragments_from_variants(
-        ["v"], alignment_file=object(), protein_sequence_length=31,
-    )
-
-    creator = fake_isovar.calls[0]["protein_sequence_creator"]
-    assert creator.protein_sequence_length == 31
+def test_the_default_window_matches_isovar_rather_than_exceeding_it():
+    """Asking for more context than the reads support returns fewer
+    variants, not longer sequences."""
+    assert DEFAULT_PROTEIN_SEQUENCE_LENGTH == 21
 
 
-def test_the_default_context_length_is_used_when_unspecified(fake_isovar):
-    fragments_from_variants(["v"], alignment_file=object())
-
-    creator = fake_isovar.calls[0]["protein_sequence_creator"]
-    assert creator.protein_sequence_length == DEFAULT_PROTEIN_SEQUENCE_LENGTH
-
-
-def test_isovar_knobs_are_passed_through(fake_isovar):
+def test_isovar_knobs_are_passed_through(isovar):
     fragments_from_variants(
         ["v"], alignment_file=object(),
         transcript_id_whitelist={"ENST1"},
-        filter_thresholds={"min_alt_rna_reads": 3},
+        filter_thresholds={"min_num_alt_reads": 3},
         min_shared_fragments_for_phasing=4,
     )
 
-    call = fake_isovar.calls[0]
+    call = isovar.calls[0]
     assert call["transcript_id_whitelist"] == {"ENST1"}
-    assert call["filter_thresholds"] == {"min_alt_rna_reads": 3}
+    assert call["filter_thresholds"] == {"min_num_alt_reads": 3}
     assert call["min_shared_fragments_for_phasing"] == 4
 
 
-def test_a_caller_supplied_creator_wins(fake_isovar):
-    """A caller who has configured isovar keeps their configuration."""
-    from isovar.protein_sequence_creator import ProteinSequenceCreator
-
-    mine = ProteinSequenceCreator(protein_sequence_length=45)
-    fragments_from_variants(
-        ["v"], alignment_file=object(), protein_sequence_creator=mine,
-    )
-
-    assert fake_isovar.calls[0]["protein_sequence_creator"] is mine
-
-
-def test_the_read_counts_come_through_as_measured(fake_isovar):
+def test_the_read_counts_come_through_as_measured(isovar):
     fragment = fragments_from_variants(["v"], alignment_file=object())[0]
 
     assert fragment.n_alt_reads == 30
@@ -130,118 +155,181 @@ def test_the_read_counts_come_through_as_measured(fake_isovar):
 
 
 # ---------------------------------------------------------------------------
-# Variants isovar cannot support
+# Filters have to filter
 # ---------------------------------------------------------------------------
 
 
-def test_an_unsupported_variant_is_dropped_by_default(monkeypatch):
-    module = _FakeIsovar([_Result(supported=False)])
-    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+def test_a_result_failing_its_filters_is_dropped(monkeypatch):
+    """isovar records filter outcomes and never drops anything, so without
+    this a caller's thresholds — and isovar's own defaults — annotate
+    results that then flow on as RNA-backed evidence."""
+    _fake(monkeypatch, [_Result(passes=False)])
 
     assert fragments_from_variants(["v"], alignment_file=object()) == []
 
 
-def test_the_fallback_translates_it_instead(monkeypatch):
-    module = _FakeIsovar([_Result(supported=False, variant="v")])
-    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
-    translated = [ProteinFragment(fragment_id="f", sequence="MKTV")]
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: translated,
+def test_filtering_can_be_turned_off(monkeypatch):
+    _fake(monkeypatch, [_Result(passes=False)])
+
+    fragments = fragments_from_variants(
+        ["v"], alignment_file=object(), require_passing_filters=False,
     )
+
+    assert len(fragments) == 1
+
+
+def test_a_filtered_out_result_can_fall_back_to_reference(monkeypatch):
+    _fake(monkeypatch, [_Result(passes=False, variant="v")])
+    monkeypatch.setattr(
+        "topiary.io_isovar.fragments_from_effects",
+        lambda effects, padding, **kw: [
+            ProteinFragment(fragment_id="ref", sequence="MKTV"),
+        ],
+    )
+    monkeypatch.setattr("topiary.io_isovar._effects_for", lambda variants: [])
 
     fragments = fragments_from_variants(
         ["v"], alignment_file=object(), allow_reference_fallback=True,
     )
 
-    assert fragments == translated
-
-
-def test_supported_and_fallback_fragments_are_distinguishable(monkeypatch):
-    """An RNA-backed candidate and an inferred one must not blend."""
-    module = _FakeIsovar([_Result(), _Result(supported=False, variant="w")])
-    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: [ProteinFragment(
-            fragment_id="ref", sequence="MKTV",
-            annotations={"sequence_source": "varcode_translation"},
-        )],
-    )
-
-    fragments = fragments_from_variants(
-        ["v", "w"], alignment_file=object(), allow_reference_fallback=True,
-    )
-
-    sources = {f.annotations.get("sequence_source") for f in fragments}
-    assert sources == {"isovar_assembly", "varcode_translation"}
+    assert [f.fragment_id for f in fragments] == ["ref"]
 
 
 # ---------------------------------------------------------------------------
-# The reference arm, and interchangeability
+# Conflicting requests are refused rather than silently resolved
 # ---------------------------------------------------------------------------
 
 
-def test_no_alignment_file_means_no_isovar(monkeypatch):
-    """A caller without RNA must never reach the optional dependency."""
-    def explode():
-        raise AssertionError("isovar must not be needed without a BAM")
+def test_a_creator_and_a_length_together_are_refused(isovar):
+    """The creator's length would have won silently, breaking the
+    guarantee protein_sequence_length exists to make."""
+    with pytest.raises(ValueError, match="pass one"):
+        fragments_from_variants(
+            ["v"], alignment_file=object(),
+            protein_sequence_length=31,
+            protein_sequence_creator=_FakeCreator(protein_sequence_length=15),
+        )
 
-    monkeypatch.setattr("topiary.io_isovar._check_isovar", explode)
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: [],
+
+def test_a_caller_supplied_creator_is_used(isovar):
+    mine = _FakeCreator(protein_sequence_length=31)
+
+    fragments_from_variants(
+        ["v"], alignment_file=object(), protein_sequence_creator=mine,
     )
 
-    assert fragments_from_variants(["v"]) == []
+    assert isovar.calls[0]["protein_sequence_creator"] is mine
 
 
-def test_the_padding_defaults_to_half_the_context(monkeypatch):
-    seen = {}
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: seen.setdefault("padding", padding) and [],
+def test_isovar_only_kwargs_are_refused_without_an_alignment_file():
+    """They were silently swallowed, so a caller who forgot the BAM got a
+    full result set built with none of their configuration."""
+    with pytest.raises(TypeError, match="only apply when an alignment_file"):
+        fragments_from_variants(["v"], transcript_id_whitelist={"E"})
+
+
+def test_a_nonsense_protein_sequence_length_is_refused():
+    with pytest.raises(ValueError, match="must be positive"):
+        fragments_from_variants(["v"], protein_sequence_length=0)
+
+
+def test_a_padding_too_small_for_an_epitope_is_refused():
+    """check_padding_around_mutation exists for exactly this; the earlier
+    ad-hoc derivation bypassed it and produced fragments no 9-mer fits."""
+    with pytest.raises(ValueError):
+        fragments_from_variants(
+            ["v"], padding_around_mutation=2, epitope_lengths=(9,),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The reference arm, exercised rather than stubbed
+# ---------------------------------------------------------------------------
+
+
+class _Effect(NonsilentCodingMutation):
+    """A real NonsilentCodingMutation, because the arm filters on the type.
+
+    The earlier version of this test used a duck-typed stand-in, which
+    `filter_silent_and_noncoding_effects` correctly discarded — so the
+    test exercised nothing. A fake that the code under test rejects is
+    not a fake, it is a hole.
+    """
+
+    # Several of these are read-only properties on the real class.
+    mutant_protein_sequence = "MKTVRQERLKSIVRILEDAAWQ"
+    original_protein_sequence = "MKTVRQERLKAIVRILEDAAWQ"
+    aa_mutation_start_offset = 10
+    aa_mutation_end_offset = 11
+    gene_name = "BRAF"
+    gene_id = "ENSG1"
+    transcript_id = "ENST1"
+    transcript_name = "BRAF-204"
+    short_description = "p.A11R"
+    modifies_protein_sequence = True
+
+    def __init__(self, variant="v", gene="BRAF", transcript="ENST1"):
+        self.gene_name = gene
+        self.transcript_id = transcript
+        self.variant = type("V", (), {"short_description": variant})()
+
+    def __hash__(self):
+        return hash((self.transcript_id, self.short_description))
+
+    def __eq__(self, other):
+        return self is other
+
+
+def test_the_reference_arm_translates_an_effect():
+    """Real translation, not a stub — the arm the docs sell as half the
+    feature had no coverage at all before."""
+    fragments = fragments_from_effects(
+        [_Effect()], padding_around_mutation=8,
     )
 
-    fragments_from_variants(["v"], protein_sequence_length=21)
+    assert len(fragments) == 1
+    assert fragments[0].sequence
+    assert fragments[0].gene == "BRAF"
 
-    assert seen["padding"] == 10
+
+def test_a_reference_fragment_says_where_its_sequence_came_from():
+    fragment = fragments_from_effects([_Effect()], padding_around_mutation=8)[0]
+
+    assert fragment.annotations["sequence_source"] == "varcode_translation"
 
 
-def test_both_arms_return_the_same_type(fake_isovar, monkeypatch):
+def test_a_reference_fragment_has_no_read_counts():
+    """No RNA was consulted, and it says so rather than saying zero."""
+    fragment = fragments_from_effects([_Effect()], padding_around_mutation=8)[0]
+
+    assert not fragment.is_known("n_alt_reads")
+    assert not fragment.is_usable_as_biology("n_alt_reads")
+
+
+def test_expression_is_attached_when_given():
+    fragment = fragments_from_effects(
+        [_Effect()], padding_around_mutation=8,
+        gene_expression={"ENSG1": 12.5},
+    )[0]
+
+    assert fragment.gene_expression == 12.5
+
+
+def test_no_effects_yields_no_fragments():
+    assert fragments_from_effects([], padding_around_mutation=8) == []
+
+
+def test_the_two_arms_are_read_the_same_way(isovar):
     """Interchangeable means the caller's next line does not change."""
-    rna = fragments_from_variants(["v"], alignment_file=object())
-
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: [ProteinFragment(
-            fragment_id="ref", sequence="MKTVRQERLKSIVRILE",
-        )],
-    )
-    reference = fragments_from_variants(["v"])
-
-    assert all(isinstance(f, ProteinFragment) for f in rna + reference)
-    for fragment in rna + reference:
-        assert fragment.sequence
-        assert fragment.is_known("sequence") if hasattr(
-            fragment, "is_known"
-        ) else True
-
-
-def test_a_consumer_reads_both_arms_the_same_way(fake_isovar, monkeypatch):
     def support(fragment):
         if not fragment.is_usable_as_biology("n_alt_reads"):
             return None
         return fragment.n_alt_reads
 
     rna = fragments_from_variants(["v"], alignment_file=object())[0]
-    monkeypatch.setattr(
-        "topiary.io_isovar._reference_fragments",
-        lambda variants, padding: [ProteinFragment(
-            fragment_id="ref", sequence="MKTV",
-        )],
-    )
-    reference = fragments_from_variants(["v"])[0]
+    reference = fragments_from_effects([_Effect()], padding_around_mutation=8)[0]
 
+    assert isinstance(rna, ProteinFragment)
+    assert isinstance(reference, ProteinFragment)
     assert support(rna) == 30
-    assert support(reference) is None      # no RNA, and it says so
+    assert support(reference) is None

--- a/tests/test_isovar_run.py
+++ b/tests/test_isovar_run.py
@@ -1,0 +1,247 @@
+"""Running isovar for real, interchangeably with reference translation.
+
+The point of `fragments_from_variants`: give it an alignment file and the
+protein context around each mutation is **assembled from RNA reads**; leave
+it out and the same variants are **translated from the reference**. Either
+way the result is `ProteinFragment`s with the same core, so a pipeline does
+not change shape when the RNA does or does not exist.
+
+The assembled sequence is deliberately longer than one peptide — a fragment
+is scanned by a sliding window downstream, so it has to contain every
+peptide that could cover the mutation.
+"""
+
+import warnings
+
+import pytest
+
+from topiary import (
+    DEFAULT_PROTEIN_SEQUENCE_LENGTH,
+    ProteinFragment,
+    fragments_from_variants,
+)
+from topiary.io_isovar import _reference_fragments
+
+
+class _ProteinSequence:
+    amino_acids = "MKTVRQERLKSIVRILEDAAWQ"
+    mutation_start_idx = 10
+    mutation_end_idx = 12
+    gene_name = "BRAF"
+    transcript_ids = ["ENST1"]
+    transcript_names = ["BRAF-204"]
+    num_supporting_fragments = 27
+
+
+class _Result:
+    def __init__(self, supported=True, variant="chr7 g.140453136 A>T"):
+        self.top_protein_sequence = _ProteinSequence() if supported else None
+        self.variant = variant
+        self.num_total_fragments = 61
+        self.num_alt_fragments = 30
+        self.num_ref_fragments = 31
+
+
+class _FakeIsovar:
+    """Stands in for the isovar module, recording how it was called."""
+
+    def __init__(self, results):
+        self._results = results
+        self.calls = []
+
+    def run_isovar(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._results
+
+
+@pytest.fixture
+def fake_isovar(monkeypatch):
+    module = _FakeIsovar([_Result()])
+    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# The RNA arm
+# ---------------------------------------------------------------------------
+
+
+def test_an_alignment_file_assembles_from_rna(fake_isovar):
+    fragments = fragments_from_variants(["v"], alignment_file=object())
+
+    assert len(fragments) == 1
+    assert fragments[0].annotations["sequence_source"] == "isovar_assembly"
+
+
+def test_the_assembled_context_is_longer_than_a_peptide(fake_isovar):
+    """A sliding window has to fit; that is why this is a sequence length."""
+    fragments = fragments_from_variants(["v"], alignment_file=object())
+
+    assert len(fragments[0].sequence) > 9
+
+
+def test_the_requested_context_length_reaches_isovar(fake_isovar):
+    fragments_from_variants(
+        ["v"], alignment_file=object(), protein_sequence_length=31,
+    )
+
+    creator = fake_isovar.calls[0]["protein_sequence_creator"]
+    assert creator.protein_sequence_length == 31
+
+
+def test_the_default_context_length_is_used_when_unspecified(fake_isovar):
+    fragments_from_variants(["v"], alignment_file=object())
+
+    creator = fake_isovar.calls[0]["protein_sequence_creator"]
+    assert creator.protein_sequence_length == DEFAULT_PROTEIN_SEQUENCE_LENGTH
+
+
+def test_isovar_knobs_are_passed_through(fake_isovar):
+    fragments_from_variants(
+        ["v"], alignment_file=object(),
+        transcript_id_whitelist={"ENST1"},
+        filter_thresholds={"min_alt_rna_reads": 3},
+        min_shared_fragments_for_phasing=4,
+    )
+
+    call = fake_isovar.calls[0]
+    assert call["transcript_id_whitelist"] == {"ENST1"}
+    assert call["filter_thresholds"] == {"min_alt_rna_reads": 3}
+    assert call["min_shared_fragments_for_phasing"] == 4
+
+
+def test_a_caller_supplied_creator_wins(fake_isovar):
+    """A caller who has configured isovar keeps their configuration."""
+    from isovar.protein_sequence_creator import ProteinSequenceCreator
+
+    mine = ProteinSequenceCreator(protein_sequence_length=45)
+    fragments_from_variants(
+        ["v"], alignment_file=object(), protein_sequence_creator=mine,
+    )
+
+    assert fake_isovar.calls[0]["protein_sequence_creator"] is mine
+
+
+def test_the_read_counts_come_through_as_measured(fake_isovar):
+    fragment = fragments_from_variants(["v"], alignment_file=object())[0]
+
+    assert fragment.n_alt_reads == 30
+    assert not fragment.is_approximate("n_alt_reads")
+
+
+# ---------------------------------------------------------------------------
+# Variants isovar cannot support
+# ---------------------------------------------------------------------------
+
+
+def test_an_unsupported_variant_is_dropped_by_default(monkeypatch):
+    module = _FakeIsovar([_Result(supported=False)])
+    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+
+    assert fragments_from_variants(["v"], alignment_file=object()) == []
+
+
+def test_the_fallback_translates_it_instead(monkeypatch):
+    module = _FakeIsovar([_Result(supported=False, variant="v")])
+    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+    translated = [ProteinFragment(fragment_id="f", sequence="MKTV")]
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: translated,
+    )
+
+    fragments = fragments_from_variants(
+        ["v"], alignment_file=object(), allow_reference_fallback=True,
+    )
+
+    assert fragments == translated
+
+
+def test_supported_and_fallback_fragments_are_distinguishable(monkeypatch):
+    """An RNA-backed candidate and an inferred one must not blend."""
+    module = _FakeIsovar([_Result(), _Result(supported=False, variant="w")])
+    monkeypatch.setattr("topiary.io_isovar._check_isovar", lambda: module)
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: [ProteinFragment(
+            fragment_id="ref", sequence="MKTV",
+            annotations={"sequence_source": "varcode_translation"},
+        )],
+    )
+
+    fragments = fragments_from_variants(
+        ["v", "w"], alignment_file=object(), allow_reference_fallback=True,
+    )
+
+    sources = {f.annotations.get("sequence_source") for f in fragments}
+    assert sources == {"isovar_assembly", "varcode_translation"}
+
+
+# ---------------------------------------------------------------------------
+# The reference arm, and interchangeability
+# ---------------------------------------------------------------------------
+
+
+def test_no_alignment_file_means_no_isovar(monkeypatch):
+    """A caller without RNA must never reach the optional dependency."""
+    def explode():
+        raise AssertionError("isovar must not be needed without a BAM")
+
+    monkeypatch.setattr("topiary.io_isovar._check_isovar", explode)
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: [],
+    )
+
+    assert fragments_from_variants(["v"]) == []
+
+
+def test_the_padding_defaults_to_half_the_context(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: seen.setdefault("padding", padding) and [],
+    )
+
+    fragments_from_variants(["v"], protein_sequence_length=21)
+
+    assert seen["padding"] == 10
+
+
+def test_both_arms_return_the_same_type(fake_isovar, monkeypatch):
+    """Interchangeable means the caller's next line does not change."""
+    rna = fragments_from_variants(["v"], alignment_file=object())
+
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: [ProteinFragment(
+            fragment_id="ref", sequence="MKTVRQERLKSIVRILE",
+        )],
+    )
+    reference = fragments_from_variants(["v"])
+
+    assert all(isinstance(f, ProteinFragment) for f in rna + reference)
+    for fragment in rna + reference:
+        assert fragment.sequence
+        assert fragment.is_known("sequence") if hasattr(
+            fragment, "is_known"
+        ) else True
+
+
+def test_a_consumer_reads_both_arms_the_same_way(fake_isovar, monkeypatch):
+    def support(fragment):
+        if not fragment.is_usable_as_biology("n_alt_reads"):
+            return None
+        return fragment.n_alt_reads
+
+    rna = fragments_from_variants(["v"], alignment_file=object())[0]
+    monkeypatch.setattr(
+        "topiary.io_isovar._reference_fragments",
+        lambda variants, padding: [ProteinFragment(
+            fragment_id="ref", sequence="MKTV",
+        )],
+    )
+    reference = fragments_from_variants(["v"])[0]
+
+    assert support(rna) == 30
+    assert support(reference) is None      # no RNA, and it says so

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -83,8 +83,10 @@ from .sequence_helpers import (
 )
 from .cached import CachedPredictor, mhcflurry_composite_version
 from .io_isovar import (
+    DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     fragment_from_isovar_result,
     fragments_from_isovar_results,
+    fragments_from_variants,
 )
 from .protein_fragment import (
     APPROXIMATED,
@@ -126,7 +128,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.39.0"
+__version__ = "5.40.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -213,6 +215,8 @@ __all__ = [
     "fragments_from_dataframe",
     "fragment_from_isovar_result",
     "fragments_from_isovar_results",
+    "fragments_from_variants",
+    "DEFAULT_PROTEIN_SEQUENCE_LENGTH",
     "MEASURED",
     "APPROXIMATED",
     "SYNTHESIZED",

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -86,6 +86,7 @@ from .io_isovar import (
     DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     fragment_from_isovar_result,
     fragments_from_isovar_results,
+    fragments_from_effects,
     fragments_from_variants,
 )
 from .protein_fragment import (
@@ -215,6 +216,7 @@ __all__ = [
     "fragments_from_dataframe",
     "fragment_from_isovar_result",
     "fragments_from_isovar_results",
+    "fragments_from_effects",
     "fragments_from_variants",
     "DEFAULT_PROTEIN_SEQUENCE_LENGTH",
     "MEASURED",

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -169,6 +169,147 @@ def fragments_from_isovar_results(isovar_results):
     return fragments
 
 
+#: Default assembled window around a mutation, in amino acids.
+#:
+#: A fragment is scanned by a sliding window later, so the assembled
+#: sequence has to be long enough to contain every peptide that could
+#: cover the mutation — the peptide length plus padding on both sides.
+#: 9 + 2 * 8 is the usual class-I shape.
+DEFAULT_PROTEIN_SEQUENCE_LENGTH = 25
+
+
+def fragments_from_variants(
+    variants,
+    alignment_file=None,
+    *,
+    protein_sequence_length: int = DEFAULT_PROTEIN_SEQUENCE_LENGTH,
+    padding_around_mutation: Optional[int] = None,
+    allow_reference_fallback: bool = False,
+    transcript_id_whitelist=None,
+    filter_thresholds=None,
+    **isovar_kwargs,
+):
+    """Fragments for *variants*, assembled from RNA when RNA is available.
+
+    The point of entry that makes the sources interchangeable: give it a
+    ``alignment_file`` and the protein context is **assembled from
+    reads**, carrying the patient's other variants and whatever phasing
+    the reads support; leave it out and the same variants are
+    **translated from the reference**. Either way the result is a list
+    of :class:`~topiary.ProteinFragment` with the same core, so the rest
+    of a pipeline does not change when the RNA does or does not exist.
+
+    The assembled sequence is deliberately longer than one peptide.  A
+    fragment is scanned by a sliding window downstream, so it has to
+    contain every peptide that could cover the mutation — hence
+    *protein_sequence_length*, not a peptide length.
+
+    Parameters
+    ----------
+    variants : varcode.VariantCollection or iterable of varcode.Variant
+        The variants to build fragments for.
+    alignment_file : pysam.AlignmentFile, optional
+        RNA alignment. When given, isovar assembles the protein sequence
+        from the reads covering each variant and counts the reads
+        supporting it. When ``None``, every fragment comes from
+        reference translation and carries no read counts.
+    protein_sequence_length : int
+        Amino acids of assembled context around the mutation.
+    padding_around_mutation : int, optional
+        Residues kept either side of the mutation on the *reference*
+        path. Defaults to half the remaining context, so both paths
+        produce comparable windows.
+    allow_reference_fallback : bool
+        When true, a variant isovar could not support is translated from
+        the reference instead of being dropped. The fragments say which
+        they are via ``annotations["sequence_source"]``, so a consumer
+        can tell an RNA-backed candidate from an inferred one — the
+        distinction is the reason to record it rather than blend them.
+    transcript_id_whitelist, filter_thresholds
+        Passed to :func:`isovar.run_isovar`.
+    **isovar_kwargs
+        Also passed through — ``read_collector``,
+        ``min_shared_fragments_for_phasing`` and friends.
+
+    Returns
+    -------
+    list of ProteinFragment
+
+    Notes
+    -----
+    Requires isovar only when *alignment_file* is given. The reference
+    path has no such dependency, so a caller without RNA never imports
+    it.
+    """
+    if padding_around_mutation is None:
+        padding_around_mutation = max(1, (protein_sequence_length - 1) // 2)
+
+    variants = list(variants)
+    if alignment_file is None:
+        return _reference_fragments(variants, padding_around_mutation)
+
+    isovar = _check_isovar()
+    from isovar.protein_sequence_creator import ProteinSequenceCreator
+
+    creator = isovar_kwargs.pop("protein_sequence_creator", None)
+    if creator is None:
+        creator = ProteinSequenceCreator(
+            protein_sequence_length=protein_sequence_length,
+        )
+    results = isovar.run_isovar(
+        variants=variants,
+        alignment_file=alignment_file,
+        transcript_id_whitelist=transcript_id_whitelist,
+        protein_sequence_creator=creator,
+        filter_thresholds=filter_thresholds,
+        **isovar_kwargs,
+    )
+
+    fragments = []
+    unsupported = []
+    for result in results:
+        fragment = fragment_from_isovar_result(result)
+        if fragment is not None:
+            fragments.append(fragment)
+        else:
+            unsupported.append(getattr(result, "variant", None))
+
+    if unsupported and allow_reference_fallback:
+        fragments.extend(
+            _reference_fragments(
+                [v for v in unsupported if v is not None],
+                padding_around_mutation,
+            )
+        )
+    return fragments
+
+
+def _reference_fragments(variants, padding_around_mutation):
+    """Translate variants from the reference — the no-RNA path.
+
+    Kept in this module so both arms of :func:`fragments_from_variants`
+    live together, but it imports nothing from isovar: a caller with no
+    alignment file never touches the optional dependency.
+    """
+    from .predictor import fragment_from_effect
+
+    fragments = []
+    for variant in variants:
+        try:
+            effects = variant.effects()
+        except AttributeError:
+            continue
+        effect = effects.top_priority_effect()
+        if effect is None:
+            continue
+        fragment = fragment_from_effect(
+            effect, padding_around_mutation=padding_around_mutation,
+        )
+        if fragment is not None:
+            fragments.append(fragment)
+    return fragments
+
+
 def _as_count(value):
     """A non-negative int, or None when the value was not stated."""
     if value is None:

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -174,8 +174,92 @@ def fragments_from_isovar_results(isovar_results):
 #: A fragment is scanned by a sliding window later, so the assembled
 #: sequence has to be long enough to contain every peptide that could
 #: cover the mutation — the peptide length plus padding on both sides.
-#: 9 + 2 * 8 is the usual class-I shape.
-DEFAULT_PROTEIN_SEQUENCE_LENGTH = 25
+#: This matches isovar's own default rather than raising it: with
+#: assembly on, a longer window still has to be reachable from the
+#: reads, and asking for more than the data supports silently returns
+#: fewer variants rather than longer sequences.
+DEFAULT_PROTEIN_SEQUENCE_LENGTH = 21
+
+
+def fragments_from_effects(
+    effects,
+    padding_around_mutation: int,
+    *,
+    gene_expression=None,
+    transcript_expression=None,
+):
+    """Fragments translated from reference, one per variant effect group.
+
+    The no-RNA arm of :func:`fragments_from_variants`, public because a
+    caller with variants and no alignment file wants exactly this and
+    should not have to reach into a private helper for it.
+
+    Silent, non-coding and untranslatable effects are filtered first —
+    several varcode effect classes expose a ``mutant_protein_sequence``
+    while leaving the amino-acid offsets ``None``, and
+    :func:`~topiary.fragment_from_effect` raises on those by design.
+    Without the filter one such effect anywhere in a batch discards
+    every fragment already built.
+
+    Parameters
+    ----------
+    effects : varcode.EffectCollection or iterable of effects
+        Effects to translate. Grouped by variant; the top-priority
+        effect of each group becomes a fragment, or the
+        top-*expression* effect when *transcript_expression* is given.
+    padding_around_mutation : int
+        Residues kept either side of the mutated span.
+    gene_expression, transcript_expression : dict, optional
+        ``{gene_id: value}`` / ``{transcript_id: value}``. When
+        transcript expression is present it also drives transcript
+        selection, matching what
+        :meth:`TopiaryPredictor.predict_from_mutation_effects` does —
+        the same variants must not pick a different transcript
+        depending on which entry point was used.
+
+    Returns
+    -------
+    list of ProteinFragment
+    """
+    from varcode import EffectCollection
+
+    from .filters import filter_silent_and_noncoding_effects
+    from .predictor import fragment_from_effect
+
+    if not isinstance(effects, EffectCollection):
+        effects = EffectCollection(list(effects))
+    effects = filter_silent_and_noncoding_effects(effects)
+    if len(effects) == 0:
+        return []
+
+    groups = effects.groupby_variant()
+    if transcript_expression:
+        top_effects = [
+            group.top_expression_effect(transcript_expression)
+            for group in groups.values()
+        ]
+    else:
+        top_effects = [group.top_priority_effect() for group in groups.values()]
+
+    fragments = []
+    for effect in top_effects:
+        if effect is None:
+            continue
+        fragment = fragment_from_effect(
+            effect,
+            padding_around_mutation,
+            gene_expression=(
+                gene_expression.get(effect.gene_id)
+                if gene_expression else None
+            ),
+            transcript_expression=(
+                transcript_expression.get(effect.transcript_id)
+                if transcript_expression else None
+            ),
+        )
+        if fragment is not None:
+            fragments.append(fragment)
+    return fragments
 
 
 def fragments_from_variants(
@@ -184,14 +268,18 @@ def fragments_from_variants(
     *,
     protein_sequence_length: int = DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     padding_around_mutation: Optional[int] = None,
+    epitope_lengths=(8, 9, 10, 11),
     allow_reference_fallback: bool = False,
+    require_passing_filters: bool = True,
+    gene_expression=None,
+    transcript_expression=None,
     transcript_id_whitelist=None,
     filter_thresholds=None,
     **isovar_kwargs,
 ):
     """Fragments for *variants*, assembled from RNA when RNA is available.
 
-    The point of entry that makes the sources interchangeable: give it a
+    The entry point that makes the sources interchangeable: give it an
     ``alignment_file`` and the protein context is **assembled from
     reads**, carrying the patient's other variants and whatever phasing
     the reads support; leave it out and the same variants are
@@ -199,63 +287,117 @@ def fragments_from_variants(
     of :class:`~topiary.ProteinFragment` with the same core, so the rest
     of a pipeline does not change when the RNA does or does not exist.
 
-    The assembled sequence is deliberately longer than one peptide.  A
+    The assembled sequence is deliberately longer than one peptide — a
     fragment is scanned by a sliding window downstream, so it has to
-    contain every peptide that could cover the mutation — hence
+    contain every peptide that could cover the mutation. Hence
     *protein_sequence_length*, not a peptide length.
 
     Parameters
     ----------
-    variants : varcode.VariantCollection or iterable of varcode.Variant
-        The variants to build fragments for.
+    variants : varcode.VariantCollection, iterable of Variant, or str
+        Variants to build fragments for. A path is passed to isovar,
+        which loads it; on the reference arm it is loaded with varcode.
     alignment_file : pysam.AlignmentFile, optional
         RNA alignment. When given, isovar assembles the protein sequence
-        from the reads covering each variant and counts the reads
-        supporting it. When ``None``, every fragment comes from
-        reference translation and carries no read counts.
+        from reads covering each variant and counts the reads supporting
+        it. When ``None``, every fragment comes from reference
+        translation and carries no read counts.
     protein_sequence_length : int
         Amino acids of assembled context around the mutation.
     padding_around_mutation : int, optional
-        Residues kept either side of the mutation on the *reference*
-        path. Defaults to half the remaining context, so both paths
-        produce comparable windows.
+        Residues kept either side of the mutation on the reference arm.
+        Validated against *epitope_lengths* by
+        :func:`~topiary.check_padding_around_mutation`, so a padding too
+        small to contain any epitope is refused rather than producing
+        fragments the sliding window cannot use.
+    epitope_lengths : sequence of int
+        Peptide lengths the fragments must be able to contain; only used
+        to validate the padding.
     allow_reference_fallback : bool
         When true, a variant isovar could not support is translated from
-        the reference instead of being dropped. The fragments say which
-        they are via ``annotations["sequence_source"]``, so a consumer
-        can tell an RNA-backed candidate from an inferred one — the
-        distinction is the reason to record it rather than blend them.
+        the reference instead of dropped. Fragments say which they are
+        via ``annotations["sequence_source"]``, so an RNA-backed
+        candidate and an inferred one never blend.
+    require_passing_filters : bool
+        Drop isovar results that fail their filters. **isovar records
+        filter outcomes but never drops anything**, so without this a
+        caller's ``filter_thresholds`` — and isovar's own defaults —
+        annotate results that then flow on as RNA-backed evidence.
+    gene_expression, transcript_expression : dict, optional
+        Expression to attach, and on the reference arm to drive
+        transcript selection.
     transcript_id_whitelist, filter_thresholds
         Passed to :func:`isovar.run_isovar`.
     **isovar_kwargs
         Also passed through — ``read_collector``,
-        ``min_shared_fragments_for_phasing`` and friends.
+        ``protein_sequence_creator``, and friends. Rejected when no
+        *alignment_file* is given, rather than silently ignored.
 
     Returns
     -------
     list of ProteinFragment
+        In input-variant order.
 
     Notes
     -----
-    Requires isovar only when *alignment_file* is given. The reference
-    path has no such dependency, so a caller without RNA never imports
-    it.
+    Requires isovar only when *alignment_file* is given.
     """
+    if protein_sequence_length < 1:
+        raise ValueError(
+            f"protein_sequence_length is a count of amino acids and must "
+            f"be positive; got {protein_sequence_length}."
+        )
     if padding_around_mutation is None:
-        padding_around_mutation = max(1, (protein_sequence_length - 1) // 2)
+        padding_around_mutation = max(
+            max(epitope_lengths) - 1, (protein_sequence_length - 1) // 2
+        )
+    else:
+        from .sequence_helpers import check_padding_around_mutation
+        padding_around_mutation = check_padding_around_mutation(
+            padding_around_mutation, epitope_lengths
+        )
 
-    variants = list(variants)
     if alignment_file is None:
-        return _reference_fragments(variants, padding_around_mutation)
+        rejected = sorted(
+            set(isovar_kwargs)
+            | {k for k, v in (
+                ("transcript_id_whitelist", transcript_id_whitelist),
+                ("filter_thresholds", filter_thresholds),
+            ) if v is not None}
+        )
+        if rejected:
+            raise TypeError(
+                f"{rejected} only apply when an alignment_file is given; "
+                f"without one there is no isovar run to configure. Drop "
+                f"them, or pass the alignment file."
+            )
+        return fragments_from_effects(
+            _effects_for(variants),
+            padding_around_mutation,
+            gene_expression=gene_expression,
+            transcript_expression=transcript_expression,
+        )
 
     isovar = _check_isovar()
-    from isovar.protein_sequence_creator import ProteinSequenceCreator
-
     creator = isovar_kwargs.pop("protein_sequence_creator", None)
     if creator is None:
+        from isovar.protein_sequence_creator import ProteinSequenceCreator
         creator = ProteinSequenceCreator(
             protein_sequence_length=protein_sequence_length,
+            # Without assembly a single read or fragment must span the
+            # whole window, so a longer context quietly yields fewer
+            # variants rather than longer sequences — and "assembled
+            # from reads, carrying the phasing the reads support" would
+            # not be true of the result.
+            variant_sequence_assembly=True,
         )
+    elif protein_sequence_length != DEFAULT_PROTEIN_SEQUENCE_LENGTH:
+        raise ValueError(
+            "protein_sequence_length and protein_sequence_creator both "
+            "set the assembled window; pass one. The creator's length "
+            "would have won silently."
+        )
+
     results = isovar.run_isovar(
         variants=variants,
         alignment_file=alignment_file,
@@ -268,46 +410,44 @@ def fragments_from_variants(
     fragments = []
     unsupported = []
     for result in results:
-        fragment = fragment_from_isovar_result(result)
+        if require_passing_filters and not getattr(
+            result, "passes_all_filters", True
+        ):
+            unsupported.append(getattr(result, "variant", None))
+            continue
+        fragment = fragment_from_isovar_result(
+            result,
+            gene_expression=(
+                gene_expression.get(getattr(result, "gene_id", None))
+                if gene_expression else None
+            ),
+            transcript_expression=None,
+        )
         if fragment is not None:
             fragments.append(fragment)
         else:
             unsupported.append(getattr(result, "variant", None))
 
     if unsupported and allow_reference_fallback:
-        fragments.extend(
-            _reference_fragments(
-                [v for v in unsupported if v is not None],
-                padding_around_mutation,
-            )
-        )
+        fragments.extend(fragments_from_effects(
+            _effects_for([v for v in unsupported if v is not None]),
+            padding_around_mutation,
+            gene_expression=gene_expression,
+            transcript_expression=transcript_expression,
+        ))
     return fragments
 
 
-def _reference_fragments(variants, padding_around_mutation):
-    """Translate variants from the reference — the no-RNA path.
+def _effects_for(variants):
+    """Variant effects, with the loading varcode already knows how to do."""
+    from varcode import EffectCollection, load_vcf
 
-    Kept in this module so both arms of :func:`fragments_from_variants`
-    live together, but it imports nothing from isovar: a caller with no
-    alignment file never touches the optional dependency.
-    """
-    from .predictor import fragment_from_effect
-
-    fragments = []
+    if isinstance(variants, str):
+        variants = load_vcf(variants)
+    collected = []
     for variant in variants:
-        try:
-            effects = variant.effects()
-        except AttributeError:
-            continue
-        effect = effects.top_priority_effect()
-        if effect is None:
-            continue
-        fragment = fragment_from_effect(
-            effect, padding_around_mutation=padding_around_mutation,
-        )
-        if fragment is not None:
-            fragments.append(fragment)
-    return fragments
+        collected.extend(variant.effects())
+    return EffectCollection(collected)
 
 
 def _as_count(value):


### PR DESCRIPTION
Toward #102. 5.38.0 could *adapt* an `IsovarResult` a caller already had, which is not the same as using isovar — the vocabulary had an entry and the library had no way to produce one.

## What this adds

```python
fragments = fragments_from_variants(variants, alignment_file=bam)  # assembled from RNA
fragments = fragments_from_variants(variants)                      # translated from reference
```

The RNA arm runs `isovar.run_isovar` with a `ProteinSequenceCreator` sized for the **window**, the same way vaxrank does — not for one peptide, because a fragment is scanned by a sliding window downstream and has to contain every peptide that could cover the mutation. That is why the knob is `protein_sequence_length` (default 25: a 9-mer plus 8 either side) rather than a peptide length.

## Interchangeable, concretely

Both arms return `ProteinFragment`s with the same core, so **the caller's next line does not change**. What differs is what the fragments can tell you:

| | assembled | translated |
|---|---|---|
| sequence | carries the patient's other variants, and phasing the reads support | reference everywhere except the variant |
| read counts | counted (`measured`) | none |
| `sequence_source` | `isovar_assembly` | `varcode_translation` |

`allow_reference_fallback=True` translates variants isovar could not support instead of dropping them — and the fragments stay distinguishable, which is the reason to record the source rather than blend an RNA-backed candidate with an inferred one. There is a test that a mixed run yields both sources.

`padding_around_mutation` defaults to half the context, so the reference arm produces a comparable window rather than an arbitrary one.

## Optional dependency, kept honest

isovar is needed **only** when `alignment_file` is given. The reference arm imports nothing from it, and there is a test that calls it with `_check_isovar` replaced by a function that raises — so "a caller without RNA never pays for isovar" is enforced rather than asserted.

## Tests

14 in `tests/test_isovar_run.py`: the RNA arm assembling and its context exceeding a peptide; the requested and default context lengths reaching isovar; isovar knobs passed through; a caller-supplied `ProteinSequenceCreator` winning; counts arriving as `measured`; unsupported variants dropped by default and translated under the fallback; **the two sources staying distinguishable in a mixed run**; the reference arm never reaching isovar; padding defaulting to half the context; and **one consumer function reading both arms** — 30 from the assembled fragment, `None` from the translated one, which says it has no RNA rather than that it has none.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2187 passed, 3 skipped

Version 5.40.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG