### PR TITLE
Give both readers one name for gene-level expression (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.41.0
+
+**Fixed: gene-level expression had two names (#238).** `read_lens`
+called it `gene_tpm`; `read_pvacseq` called it `gene_expression`. A
+filter naming either matched nothing on the other frame rather than
+failing, so a consumer had to know which reader produced the frame —
+the thing a shared vocabulary exists to avoid.
+
+LENS frames now also carry `gene_expression`, the name topiary already
+uses for gene-level abundance in `ProteinFragment.gene_expression` and
+in `read_pvacseq`. `gene_tpm` stays as the LENS-native spelling, and
+`gene_tpm_raw` still holds the original string, since LENS writes fusion
+rows as composites and the numeric column is NaN for them.
+
+The other two problems in #238 were already fixed by 5.37.0, before the
+issue was read: both readers emit `variant_allele_expression` (there is
+no `allele_expression` on either frame, so no one quantity under two
+names), and both label every derivation — on the expression axis and the
+read axis. They are pinned by tests now rather than left to chance.
+
 ## 5.40.0
 
 **Added: `fragments_from_variants` — isovar, actually run (#102).**

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -135,6 +135,18 @@ isovar is also the only source that *counts* the reads supporting an assembled
 sequence. Everything else derives them or counts something adjacent, which is
 what the derivation names record.
 
+## One vocabulary across readers
+
+Both readers describe expression the same way, so a filter does not have to
+know which produced the frame:
+
+| Column | Meaning |
+|---|---|
+| `gene_expression` | Gene-level abundance. On LENS also available as `gene_tpm` (its native spelling), with the original string in `gene_tpm_raw` |
+| `transcript_expression` | Transcript-level abundance, where the source has it |
+| `variant_allele_expression` | Abundance attributed to the variant allele — an estimate; see below |
+| `*_method` | How each of those was obtained |
+
 ## RNA evidence, and knowing which fields are real
 
 Beyond `gene_expression` / `transcript_expression`, a fragment can carry

--- a/tests/test_shared_expression_vocabulary.py
+++ b/tests/test_shared_expression_vocabulary.py
@@ -1,0 +1,117 @@
+"""Both readers name expression the same way (topiary #238).
+
+A consumer writing one filter should not have to know which reader produced
+the frame. Filed with three problems; two of them were fixed by 5.37.0
+before the issue was read, and this closes the third.
+
+Fixed in 5.37.0, asserted here so they stay fixed:
+  - both frames carry `variant_allele_expression` (there was never an
+    `allele_expression`, so no two names for one quantity)
+  - both label the derivation, on the expression *and* the read axes
+
+Still open, and fixed here:
+  - gene-level abundance was `gene_tpm` on LENS and `gene_expression` on
+    pVACseq, so a filter naming either matched nothing on the other frame
+    rather than failing.
+"""
+
+import warnings
+
+import pytest
+
+from topiary import evaluate_scores, read_lens, read_pvacseq
+from topiary.ranking import parse
+
+LENS = "tests/data/lens/sample_v1_4.tsv"
+PVACSEQ = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
+
+
+def _frames():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return {
+            "lens": read_lens(LENS).to_long().df,
+            "pvacseq": read_pvacseq(PVACSEQ).df,
+        }
+
+
+@pytest.fixture(scope="module")
+def frames():
+    return _frames()
+
+
+# ---------------------------------------------------------------------------
+# One name for gene-level abundance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reader", ["lens", "pvacseq"])
+def test_gene_expression_exists_on_both(frames, reader):
+    assert "gene_expression" in frames[reader].columns
+
+
+@pytest.mark.parametrize("reader", ["lens", "pvacseq"])
+def test_one_filter_spans_both_readers(frames, reader):
+    """The property the issue is about: the consumer does not branch."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        scores = evaluate_scores(frames[reader], parse("gene_expression > 1"))
+
+    assert len(scores) == len(frames[reader])
+    assert scores.notna().any()
+
+
+def test_the_lens_native_spelling_still_works(frames):
+    """gene_tpm is what LENS calls it; existing expressions keep working."""
+    lens = frames["lens"]
+
+    assert "gene_tpm" in lens.columns
+    assert "gene_tpm_raw" in lens.columns
+    assert lens["gene_expression"].equals(lens["gene_tpm"])
+
+
+def test_the_raw_string_is_still_kept_separately(frames):
+    """LENS writes fusion rows as composite strings, so the numeric column
+    is NaN for them and the original is preserved — that is why `tpm` was
+    never a blind rename."""
+    lens = frames["lens"]
+
+    assert lens["gene_tpm_raw"].notna().any()
+
+
+# ---------------------------------------------------------------------------
+# Already fixed in 5.37.0 — pinned so they stay fixed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reader", ["lens", "pvacseq"])
+def test_both_readers_name_the_variant_allele_estimate_the_same(frames, reader):
+    assert "variant_allele_expression" in frames[reader].columns
+
+
+@pytest.mark.parametrize("reader", ["lens", "pvacseq"])
+def test_neither_reader_uses_the_other_spelling(frames, reader):
+    """`allele_expression` and `variant_allele_expression` would be the
+    same quantity under two names."""
+    assert "allele_expression" not in frames[reader].columns
+
+
+@pytest.mark.parametrize("reader", ["lens", "pvacseq"])
+@pytest.mark.parametrize("column", [
+    "variant_allele_expression_method",
+    "read_count_method",
+    "supporting_read_count_method",
+])
+def test_both_readers_label_every_derivation(frames, reader, column):
+    """The reason for labelling one applies identically to the other: the
+    estimate assumes both alleles are transcribed equally, so a variant on
+    a silenced allele looks expressed. A bare number cannot say that."""
+    assert column in frames[reader].columns
+
+
+def test_a_consumer_can_ask_how_a_number_was_obtained_on_either_frame(frames):
+    from topiary import describe_read_evidence
+
+    for reader in ("lens", "pvacseq"):
+        described = describe_read_evidence(frames[reader])
+        assert all(isinstance(v, str) for v in described.values())

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -129,7 +129,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.40.0"
+__version__ = "5.41.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -585,6 +585,14 @@ def _handle_tpm(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
     df["gene_tpm_raw"] = df["tpm"]
     df["gene_tpm"] = pd.to_numeric(df["tpm"], errors="coerce")
+    # Also under topiary's own name for gene-level abundance, which is
+    # what ProteinFragment.gene_expression and read_pvacseq already use.
+    # Without it a filter reading "gene_expression" matches nothing on a
+    # LENS frame and everything on a pVACseq one — a consumer would have
+    # to know which reader produced the frame, which is the thing the
+    # shared vocabulary exists to avoid. gene_tpm stays as the
+    # LENS-native spelling.
+    df["gene_expression"] = df["gene_tpm"]
     df = df.drop(columns=["tpm"])
     # If every raw value coerced cleanly, drop the raw column.
     if df["gene_tpm"].notna().sum() == df["gene_tpm_raw"].notna().sum():


### PR DESCRIPTION
Closes #238.

Three problems were reported. **Two were already fixed** by 5.37.0, which
shipped before the issue was read — checked rather than assumed, since the
alternative was fixing things twice or claiming a fix that was not mine.

## The one that was real

Gene-level abundance had two names:

```python
evaluate_scores(lens_frame,    parse("gene_expression > 1"))
# ValueError: Column 'gene_expression' not found in DataFrame

evaluate_scores(pvacseq_frame, parse("gene_expression > 1"))
# fine
```

`read_lens` called it `gene_tpm`; `read_pvacseq` called it `gene_expression`. A
filter naming either matched nothing on the other frame *rather than failing*,
so a consumer had to know which reader produced the frame — the thing a shared
vocabulary exists to avoid.

LENS frames now also carry `gene_expression`, the name topiary already uses for
gene-level abundance in `ProteinFragment.gene_expression` and in
`read_pvacseq` — converging on the existing name rather than inventing a third.
`gene_tpm` stays as the LENS-native spelling, and `gene_tpm_raw` still holds the
original string, since LENS writes fusion rows as composite strings and the
numeric column is NaN for them.

## The two that were already fixed

Verified on both frames rather than taken from the report:

- **`allele_expression` vs `variant_allele_expression`** — there is no
  `allele_expression` on either frame. Both emit
  `variant_allele_expression`, so there is no one quantity under two names.
- **Derivation labelled on one reader only** — both frames carry
  `variant_allele_expression_method`, `read_count_method` *and*
  `supporting_read_count_method`.

Both were closed by `attach_read_evidence` in 5.37.0, which the readers share.
They are pinned by tests here rather than left to drift back.

The reasoning in the issue for why the label matters is right and worth keeping
in the tests: the estimate assumes both alleles are transcribed equally, so a
variant on a transcriptionally silenced allele looks expressed — which is
exactly what allele-specific counting exists to detect. A bare number cannot say
that.

## Tests

17 in `tests/test_shared_expression_vocabulary.py`, parameterized over both
readers: `gene_expression` present on both; **one filter spanning both**; the
LENS-native spellings still working and still equal; the raw string still kept
separately; and the 5.37.0 fixes pinned — the shared estimate name, the absence
of the other spelling, and every derivation labelled on both frames.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2223 passed, 3 skipped

Version 5.41.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
