### PR TITLE
Make both pVACseq branches speak one vocabulary (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 5.42.0
+
+**Fixed: `read_pvacseq` spoke two vocabularies depending on which
+flavour of its own format it was given (#238).** The aggregated report
+supplies pVACseq's own `Allele Expr` and `RNA Expr`, which were passed
+through as `allele_expression` and `rna_transcript_expression` — names
+the all_epitopes path never emits. **And that branch never called
+`attach_read_evidence` at all**, so it had no method columns whatsoever:
+
+```
+all_epitopes   variant_allele_expression + 3 method columns
+aggregated     allele_expression, rna_transcript_expression, no methods
+```
+
+So no single filter worked across two pVACseq files. Both branches now
+emit the same columns.
+
+**Added: `SOURCE_REPORTED`.** When pVACseq supplies the estimate itself,
+neither answer was honest — passing it through unlabelled claims a
+derivation nobody can check, and recomputing it discards the number the
+source stands behind. `variant_allele_expression_method` is
+`source_reported` on the aggregated path and `tpm_x_dna_vaf` where
+topiary derived it. It maps to `approximated`, not `measured`: the
+source stands behind the number but did not say how it got there.
+
+This was the sharper half of #238 and I closed the issue without it,
+having verified on the all_epitopes fixture and concluded about the
+reader. The consumer who reported it made the mirror-image error,
+grepping for `express` against headers abbreviated `Expr`. **A function
+with two branches needs both exercised**; the tests are parameterized
+over both flavours now.
+
 ## 5.41.0
 
 **Fixed: gene-level expression had two names (#238).** `read_lens`

--- a/tests/test_shared_expression_vocabulary.py
+++ b/tests/test_shared_expression_vocabulary.py
@@ -115,3 +115,95 @@ def test_a_consumer_can_ask_how_a_number_was_obtained_on_either_frame(frames):
     for reader in ("lens", "pvacseq"):
         described = describe_read_evidence(frames[reader])
         assert all(isinstance(v, str) for v in described.values())
+
+
+# ---------------------------------------------------------------------------
+# One reader, one vocabulary — whichever flavour of its format it was given
+# ---------------------------------------------------------------------------
+#
+# The sharper bug behind #238, and the one I missed: read_pvacseq took two
+# branches. Its aggregated report supplies pVACseq's own `Allele Expr` and
+# `RNA Expr`, which were passed through under names the all_epitopes path
+# never emits — and that path never ran attach_read_evidence at all, so it
+# had no method columns.
+#
+# Both of us mis-verified this by checking one branch: I read the
+# all_epitopes fixture and concluded about the reader; the consumer grepped
+# for "express" against headers abbreviated "Expr" and concluded the
+# opposite. A function with two branches needs both exercised.
+
+AGGREGATED = "tests/data/pvacseq/mhc_i_aggregated.tsv"
+ALL_EPITOPES = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
+
+
+def _pvacseq(path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return read_pvacseq(path).df
+
+
+@pytest.mark.parametrize("path", [AGGREGATED, ALL_EPITOPES],
+                         ids=["aggregated", "all-epitopes"])
+def test_both_pvacseq_flavours_name_expression_the_same(path):
+    df = _pvacseq(path)
+
+    assert "variant_allele_expression" in df.columns
+    assert "transcript_expression" in df.columns
+
+
+@pytest.mark.parametrize("path", [AGGREGATED, ALL_EPITOPES],
+                         ids=["aggregated", "all-epitopes"])
+def test_neither_flavour_uses_the_old_spellings(path):
+    """`allele_expression` and `rna_transcript_expression` existed on one
+    branch only, so a filter naming them worked on one pVACseq file and
+    silently matched nothing on the other."""
+    df = _pvacseq(path)
+
+    assert "allele_expression" not in df.columns
+    assert "rna_transcript_expression" not in df.columns
+
+
+@pytest.mark.parametrize("path", [AGGREGATED, ALL_EPITOPES],
+                         ids=["aggregated", "all-epitopes"])
+def test_both_flavours_label_their_derivations(path):
+    df = _pvacseq(path)
+
+    for column in ("read_count_method", "supporting_read_count_method",
+                   "variant_allele_expression_method"):
+        assert column in df.columns
+
+
+def test_a_source_supplied_estimate_says_so():
+    """pVACseq computed `Allele Expr` itself. Keeping it and calling it
+    ours would claim a derivation nobody can check; recomputing it would
+    discard the number the source stands behind."""
+    df = _pvacseq(AGGREGATED)
+
+    methods = set(df["variant_allele_expression_method"].dropna())
+    assert methods == {"source_reported"}
+
+
+def test_a_derived_estimate_says_that_instead():
+    df = _pvacseq(ALL_EPITOPES)
+
+    methods = set(df["variant_allele_expression_method"].dropna())
+    assert methods == {"tpm_x_dna_vaf"}
+
+
+def test_source_reported_is_not_measured():
+    """The source stands behind it but did not say how it got there."""
+    from topiary import provenance_for_method
+
+    assert provenance_for_method("source_reported") == "approximated"
+
+
+@pytest.mark.parametrize("path", [AGGREGATED, ALL_EPITOPES],
+                         ids=["aggregated", "all-epitopes"])
+def test_one_filter_spans_both_pvacseq_flavours(path):
+    df = _pvacseq(path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        scores = evaluate_scores(df, parse("variant_allele_expression > 0"))
+
+    assert len(scores) == len(df)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -115,6 +115,7 @@ from .rna_evidence import (
     RNA_DEPTH_X_VAF,
     RNA_READS,
     SEQUENCE_SOURCES,
+    SOURCE_REPORTED,
     TPM_X_DNA_VAF,
     attach_read_evidence,
     attach_sequence_source,
@@ -129,7 +130,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.41.0"
+__version__ = "5.42.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -244,6 +245,7 @@ __all__ = [
     "RNA_DEPTH_X_VAF",
     "CDS_OVERLAP_READS",
     "TPM_X_DNA_VAF",
+    "SOURCE_REPORTED",
     "READ_COUNT_METHODS",
     "SEQUENCE_SOURCES",
     "attach_read_evidence",

--- a/topiary/io_pvacseq.py
+++ b/topiary/io_pvacseq.py
@@ -207,11 +207,13 @@ _AGG_ANNOTATIONS = {
     "Gene":                    "gene",
     "Best Transcript":         "transcript",
     "ID":                      "variant",
-    "RNA Expr":                "rna_transcript_expression",
-    "RNA VAF":                 "rna_vaf",
-    "Allele Expr":             "allele_expression",
-    "RNA Depth":               "rna_depth",
-    "DNA VAF":                 "dna_vaf",
+    # Same names the all_epitopes path uses. A reader that speaks two
+    # vocabularies depending on which flavour of its own format it was
+    # given means no single filter works across two pVACseq files.
+    "RNA Expr":                "transcript_expression",
+    "RNA VAF":                 "tumor_rna_vaf",
+    "RNA Depth":               "tumor_rna_depth",
+    "DNA VAF":                 "tumor_dna_vaf",
     "Tier":                    "pvacseq_tier",
     "Num Passing Transcripts": "pvacseq_num_passing_transcripts",
     "Num Included Peptides":   "pvacseq_num_included_peptides",
@@ -465,7 +467,22 @@ def _parse_aggregated(df):
     for src, dst in _AGG_ANNOTATIONS.items():
         if src in df.columns:
             out[dst] = df[src].values
-    return out
+
+    # The same evidence columns the all_epitopes path emits. pVACseq's
+    # aggregated report supplies "Allele Expr" itself, so that value is
+    # kept and labelled source_reported rather than being recomputed or
+    # passed through unlabelled.
+    out = attach_read_evidence(
+        out,
+        overlapping=df["RNA Depth"] if "RNA Depth" in df else None,
+        vaf=df["RNA VAF"] if "RNA VAF" in df else None,
+        expression=df["RNA Expr"] if "RNA Expr" in df else None,
+        dna_vaf=df["DNA VAF"] if "DNA VAF" in df else None,
+        reported_variant_allele_expression=(
+            df["Allele Expr"] if "Allele Expr" in df else None
+        ),
+    )
+    return attach_sequence_source(out, PVACSEQ_EPITOPE)
 
 
 def _parse_all_epitopes(df):

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -52,8 +52,18 @@ CDS_OVERLAP_READS = "cds_overlap_reads"
 #: proxy, not a read count.
 TPM_X_DNA_VAF = "tpm_x_dna_vaf"
 
+#: Reported by the source, which did not say how it got there.
+#:
+#: pVACseq's aggregated report supplies its own ``Allele Expr``. Passing
+#: that through as if topiary had derived it would claim a derivation
+#: nobody can check, and dropping it in favour of our own estimate would
+#: discard the number the source actually stands behind. Neither
+#: ``measured`` nor any of the arithmetic terms is true of it.
+SOURCE_REPORTED = "source_reported"
+
 READ_COUNT_METHODS = frozenset({
     RNA_READS, RNA_DEPTH_X_VAF, CDS_OVERLAP_READS, TPM_X_DNA_VAF,
+    SOURCE_REPORTED,
 })
 
 #: How each derivation maps onto :data:`~topiary.PROVENANCE_VALUES`.
@@ -68,6 +78,9 @@ METHOD_PROVENANCE = MappingProxyType({
     RNA_DEPTH_X_VAF: "approximated",
     CDS_OVERLAP_READS: "approximated",
     TPM_X_DNA_VAF: "approximated",
+    # The source stands behind it, but did not say how it got there, so
+    # it cannot be called measured.
+    SOURCE_REPORTED: "approximated",
 })
 
 
@@ -204,6 +217,7 @@ def attach_read_evidence(
     supporting_method=None,
     expression=None,
     dna_vaf=None,
+    reported_variant_allele_expression=None,
 ) -> pd.DataFrame:
     """Write the read-evidence columns onto *df*, naming each derivation.
 
@@ -280,7 +294,19 @@ def attach_read_evidence(
             [pd.NA] * n_rows, index=out.index, dtype="object"
         )
 
-    if expression is not None and dna_vaf is not None:
+    if reported_variant_allele_expression is not None:
+        # The source supplied the number. Keep it and say where it came
+        # from, rather than overwriting it with our own estimate or
+        # passing it through unlabelled as if we had derived it.
+        reported = pd.to_numeric(
+            reported_variant_allele_expression, errors="coerce"
+        )
+        out["variant_allele_expression"] = reported
+        out["variant_allele_expression_method"] = pd.Series(
+            [SOURCE_REPORTED if pd.notna(v) else pd.NA for v in reported],
+            index=out.index, dtype="object",
+        )
+    elif expression is not None and dna_vaf is not None:
         abundance = pd.to_numeric(expression, errors="coerce")
         fraction = _fractions(dna_vaf)
         estimate = (abundance * fraction).where(


### PR DESCRIPTION
Reopens and closes the half of #238 I missed.

## What I got wrong

I verified #238 on the `all_epitopes` fixture, saw the shared vocabulary, and
closed it. `read_pvacseq` has **two branches**, and the other one behaves
completely differently:

```
all_epitopes   gene_expression, transcript_expression,
               variant_allele_expression + variant_allele_expression_method,
               read_count_method, supporting_read_count_method

aggregated     allele_expression, rna_transcript_expression
               (no method columns at all)
```

The aggregated report supplies pVACseq's own `Allele Expr` and `RNA Expr`, which
were passed through under names the all_epitopes path never emits — **and that
branch never called `attach_read_evidence`**, so it had no derivation labels
whatsoever. No single filter worked across two pVACseq files.

Both of us mis-verified this from opposite directions: I read one fixture and
concluded about the reader; the consumer grepped for `express` against headers
abbreviated `Expr` and concluded the fixture had no expression data. **A
function with two branches needs both exercised** — the tests are parameterized
over both flavours now.

## `SOURCE_REPORTED`

When pVACseq supplies the estimate itself, neither available answer was honest:

- passing it through unlabelled **claims a derivation nobody can check**;
- recomputing it as `tpm_x_dna_vaf` **discards the number the source stands
  behind**.

So there is a term for it. `variant_allele_expression_method` is now
`source_reported` on the aggregated path and `tpm_x_dna_vaf` where topiary
derived it. It maps to `approximated`, not `measured` — the source stands behind
the number but did not say how it got there, and that is exactly the distinction
the vocabulary exists to keep.

## Also renamed on the aggregated path

`RNA Expr` → `transcript_expression`, `RNA VAF` → `tumor_rna_vaf`,
`RNA Depth` → `tumor_rna_depth`, `DNA VAF` → `tumor_dna_vaf` — matching what the
all_epitopes path already called them, so the read counts derive identically on
both.

## Tests

11 added to `tests/test_shared_expression_vocabulary.py`, parameterized over
both flavours: the shared expression names present on both; the old
branch-specific spellings gone from both; all three method columns on both; a
source-supplied estimate labelled `source_reported` and a derived one labelled
`tpm_x_dna_vaf`; `source_reported` mapping to `approximated` rather than
`measured`; and one filter spanning both flavours.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2234 passed, 3 skipped

Version 5.42.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
