### PR TITLE
Make a read count name what it counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 5.43.0
+
+**Added: a read count now names what it counts.** isovar counts
+*fragments* — `num_alt_fragments`, not `num_alt_reads`. A depth × VAF
+estimate is inherently about *reads*, because depth is a read depth.
+Both landed in `n_alt_reads`, so the field was honest about **how** a
+number was obtained and silent about **what it counts** — the same shape
+as the CDS-overlap column, a real count of an adjacent thing.
+
+```python
+fragment.read_count_subject()                    # "fragments" or "reads"
+fragment.count_in("n_alt_reads", FRAGMENTS)      # 30
+fragment.count_in("n_alt_reads", READS)          # None — says so
+```
+
+Frames carry `read_count_subject` beside `read_count_method`.
+
+**Why it matters, and where it does not.** Within one run the unit is
+internally consistent, so a ranking does not change. The harm is
+entirely in what travels: a documented `n_alt_reads > 5`, a config
+copied between projects, a number in a paper. Five fragments and five
+reads are different bars, and nothing said which was cleared.
+
+Fragments are the right subject for a `sqrt()` confidence weight: two
+mates of one fragment are not independent evidence, so read counts
+overstate paired-end support roughly twofold relative to single-end —
+precisely the distortion a diminishing-returns transform should not
+inherit.
+
+**What this deliberately does not attempt.** Perfect cross-path
+comparability is unattainable: converting a read estimate to fragments
+needs library information no source carries. So there is no conversion
+and no single comparable number. Every path names its subject, a score
+names the subject it wants, and a source asked for the other one
+**returns `None` rather than substituting** — the derivation rule one
+level up.
+
+`rna_reads` deliberately fixes no subject: it says a count came from an
+alignment, not whether the aligner counted reads or fragments, so the
+producer states it.
+
+Design settled with the downstream consumer, whose framing this is.
+
 ## 5.42.0
 
 **Fixed: `read_pvacseq` spoke two vocabularies depending on which

--- a/tests/test_read_subject.py
+++ b/tests/test_read_subject.py
@@ -1,0 +1,187 @@
+"""A read count names what it counts (topiary, read-subject axis).
+
+isovar counts **fragments** — `num_alt_fragments`, not `num_alt_reads`. A
+depth x VAF estimate is inherently about **reads**, because depth is a read
+depth. Both landed in `n_alt_reads`, so the field was honest about *how* a
+number was obtained and silent about *what it counts*: the same shape as the
+CDS-overlap column, a real count of an adjacent thing.
+
+Within one run the unit is internally consistent, so a ranking does not
+change. The harm is in what travels — a documented `n_alt_reads > 5`, a
+config copied between projects, a number in a paper. Five fragments and five
+reads are different bars and nothing said which was cleared.
+
+Perfect cross-path comparability is not attainable and is not the goal:
+converting a read estimate to fragments needs library information no source
+carries. The goal is that every path names its subject, and a source asked
+for the other one says so rather than substituting.
+"""
+
+import warnings
+
+import pytest
+
+from topiary import (
+    FRAGMENTS,
+    READ_SUBJECTS,
+    READS,
+    fragment_from_isovar_result,
+    fragments_from_dataframe,
+    read_lens,
+    read_pvacseq,
+    subject_for_method,
+)
+from topiary.rna_evidence import (
+    CDS_OVERLAP_READS,
+    RNA_DEPTH_X_VAF,
+    RNA_READS,
+)
+
+
+class _ProteinSequence:
+    amino_acids = "MKTVRQERLKSIVRILE"
+    mutation_start_idx = 4
+    mutation_end_idx = 6
+    gene_name = "BRAF"
+    transcript_ids = ["ENST1"]
+    transcript_names = ["BRAF-204"]
+    num_supporting_fragments = 27
+
+
+class _IsovarResult:
+    top_protein_sequence = _ProteinSequence()
+    variant = "chr7 g.140453136 A>T"
+    num_total_fragments = 61
+    num_alt_fragments = 30
+    num_ref_fragments = 31
+
+
+def _frame_fragment(reader, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return fragments_from_dataframe(reader(path).df)[0]
+
+
+@pytest.fixture(scope="module")
+def isovar_fragment():
+    return fragment_from_isovar_result(_IsovarResult())
+
+
+@pytest.fixture(scope="module")
+def pvacseq_fragment():
+    return _frame_fragment(
+        read_pvacseq, "tests/data/pvacseq/mhc_i_all_epitopes.tsv",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Every path names its subject
+# ---------------------------------------------------------------------------
+
+
+def test_isovar_counts_fragments(isovar_fragment):
+    assert isovar_fragment.read_count_subject() == FRAGMENTS
+
+
+def test_a_depth_estimate_counts_reads(pvacseq_fragment):
+    assert pvacseq_fragment.read_count_subject() == READS
+
+
+@pytest.mark.parametrize("reader,path", [
+    (read_lens, "tests/data/lens/sample_v1_4.tsv"),
+    (read_pvacseq, "tests/data/pvacseq/mhc_i_all_epitopes.tsv"),
+    (read_pvacseq, "tests/data/pvacseq/mhc_i_aggregated.tsv"),
+], ids=["lens", "pvacseq-all-epitopes", "pvacseq-aggregated"])
+def test_every_reader_states_a_subject(reader, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        df = reader(path).df
+
+    assert "read_count_subject" in df.columns
+
+
+def test_a_derivation_that_fixes_the_subject_says_so():
+    assert subject_for_method(RNA_DEPTH_X_VAF) == READS
+    assert subject_for_method(CDS_OVERLAP_READS) == READS
+
+
+def test_a_derivation_that_does_not_fix_the_subject_says_nothing():
+    """`rna_reads` says a count came from an alignment, not whether the
+    aligner counted reads or fragments — so the producer states it."""
+    assert subject_for_method(RNA_READS) is None
+
+
+def test_an_unstated_method_has_no_subject():
+    assert subject_for_method(None) is None
+    assert subject_for_method("nan") is None
+
+
+# ---------------------------------------------------------------------------
+# Asked for the other subject, a source says so
+# ---------------------------------------------------------------------------
+
+
+def test_a_fragment_count_is_not_offered_as_a_read_count(isovar_fragment):
+    """The substitution the vocabulary exists to prevent."""
+    assert isovar_fragment.count_in("n_alt_reads", FRAGMENTS) == 30
+    assert isovar_fragment.count_in("n_alt_reads", READS) is None
+
+
+def test_a_read_estimate_is_not_offered_as_a_fragment_count(pvacseq_fragment):
+    assert pvacseq_fragment.count_in("n_alt_reads", READS) > 0
+    assert pvacseq_fragment.count_in("n_alt_reads", FRAGMENTS) is None
+
+
+def test_an_absent_count_is_none_for_either_subject():
+    from topiary import ProteinFragment
+
+    fragment = ProteinFragment(fragment_id="f", sequence="SIINFEKLA")
+
+    assert fragment.count_in("n_alt_reads", READS) is None
+    assert fragment.count_in("n_alt_reads", FRAGMENTS) is None
+
+
+def test_an_unknown_subject_is_refused(isovar_fragment):
+    with pytest.raises(ValueError, match="must be one of"):
+        isovar_fragment.count_in("n_alt_reads", "molecules")
+
+
+def test_the_vocabulary_is_exactly_two_subjects():
+    assert READ_SUBJECTS == {FRAGMENTS, READS}
+
+
+# ---------------------------------------------------------------------------
+# What this is for
+# ---------------------------------------------------------------------------
+
+
+def test_a_threshold_knows_which_bar_it_cleared(isovar_fragment,
+                                                pvacseq_fragment):
+    """A documented `n_alt_reads > 5` travelling between projects.
+
+    Both fragments carry a count above 5. Only one of them cleared the
+    bar the threshold was written against, and now that is answerable.
+    """
+    def clears(fragment, minimum, subject):
+        count = fragment.count_in("n_alt_reads", subject)
+        return None if count is None else count > minimum
+
+    assert clears(isovar_fragment, 5, FRAGMENTS) is True
+    assert clears(pvacseq_fragment, 5, FRAGMENTS) is None   # cannot answer
+    assert clears(pvacseq_fragment, 5, READS) is True
+
+
+def test_a_confidence_weight_can_demand_fragments(isovar_fragment,
+                                                  pvacseq_fragment):
+    """Two mates of one fragment are not independent evidence, so a
+    sqrt() confidence weight over reads inherits a paired-end inflation a
+    confidence transform should not. A score that wants fragments can now
+    ask for them and get nothing rather than something wrong."""
+    import math
+
+    def weight(fragment):
+        count = fragment.count_in("n_alt_reads", FRAGMENTS)
+        return None if count is None else math.sqrt(count)
+
+    assert weight(isovar_fragment) == pytest.approx(math.sqrt(30))
+    assert weight(pvacseq_fragment) is None

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -115,12 +115,16 @@ from .rna_evidence import (
     RNA_DEPTH_X_VAF,
     RNA_READS,
     SEQUENCE_SOURCES,
+    FRAGMENTS,
+    READS,
+    READ_SUBJECTS,
     SOURCE_REPORTED,
     TPM_X_DNA_VAF,
     attach_read_evidence,
     attach_sequence_source,
     describe_read_evidence,
     provenance_for_method,
+    subject_for_method,
     split_reads_by_vaf,
 )
 from .result import (
@@ -130,7 +134,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.42.0"
+__version__ = "5.43.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -246,6 +250,10 @@ __all__ = [
     "CDS_OVERLAP_READS",
     "TPM_X_DNA_VAF",
     "SOURCE_REPORTED",
+    "FRAGMENTS",
+    "READS",
+    "READ_SUBJECTS",
+    "subject_for_method",
     "READ_COUNT_METHODS",
     "SEQUENCE_SOURCES",
     "attach_read_evidence",

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .protein_fragment import ProteinFragment
-from .rna_evidence import ISOVAR_ASSEMBLY, RNA_READS
+from .rna_evidence import FRAGMENTS, ISOVAR_ASSEMBLY, RNA_READS
 
 _MIN_ISOVAR = (1, 7, 2)
 _MIN_ISOVAR_TEXT = "1.7.2"
@@ -104,7 +104,12 @@ def fragment_from_isovar_result(
         getattr(protein_sequence, "transcript_names", ()) or ()
     )
 
-    # isovar counts these; nothing is derived, so they are measured.
+    # isovar counts *fragments*, not reads: num_alt_fragments, not
+    # num_alt_reads. Both exist on IsovarResult, and carrying the
+    # fragment count under a field named for reads is the same shape as
+    # the CDS-overlap column — a real count of an adjacent thing. The
+    # subject is recorded rather than the field renamed, because a
+    # consumer's threshold has to know which bar it cleared.
     counts = dict(
         n_overlapping_reads=_as_count(
             getattr(isovar_result, "num_total_fragments", None)
@@ -144,6 +149,7 @@ def fragment_from_isovar_result(
         annotations={
             "sequence_source": ISOVAR_ASSEMBLY,
             "read_count_method": RNA_READS,
+            "read_count_subject": FRAGMENTS,
             # Every transcript consistent with the assembled sequence,
             # not just the one named above. A release mismatch that
             # leaves these unresolvable downstream is visible rather

--- a/topiary/protein_fragment.py
+++ b/topiary/protein_fragment.py
@@ -233,6 +233,62 @@ n_alt_reads_supporting_protein_sequence : int, optional
         """Whether *name*'s value was derived rather than observed."""
         return self.provenance_of(name) == APPROXIMATED
 
+    def read_count_subject(self) -> Optional[str]:
+        """What this fragment's read counts count, or ``None`` if unstated.
+
+        ``"fragments"`` for an RNA-assembled fragment (isovar counts
+        fragments), ``"reads"`` for a depth-based estimate.
+        """
+        return self.annotations.get("read_count_subject")
+
+    def count_in(self, name: str, subject: str) -> Optional[int]:
+        """*name*'s value if it counts *subject*, else ``None``.
+
+        The point of the subject vocabulary. Five fragments and five
+        reads are different bars, so a threshold has to know which it
+        cleared — and a source that counted the other thing should
+        **say so rather than substitute**, because converting between
+        them needs library information no source carries.
+
+        Within one run the unit is consistent and a ranking does not
+        change either way. The harm is in what travels: a documented
+        ``n_alt_reads > 5``, a config copied between projects, a number
+        in a paper.
+
+        Parameters
+        ----------
+        name : str
+            A read-count field, e.g. ``"n_alt_reads"``.
+        subject : str
+            One of :data:`~topiary.READ_SUBJECTS`.
+
+        Returns
+        -------
+        int or None
+            ``None`` when the field is absent, or when this fragment's
+            counts are of the other subject.
+
+        Examples
+        --------
+        >>> fragment.count_in("n_alt_reads", "fragments")  # doctest: +SKIP
+        30
+        >>> fragment.count_in("n_alt_reads", "reads")      # doctest: +SKIP
+        None
+        """
+        from .rna_evidence import READ_SUBJECTS
+
+        if subject not in READ_SUBJECTS:
+            raise ValueError(
+                f"subject must be one of {sorted(READ_SUBJECTS)}, got "
+                f"{subject!r}. A count without a stated subject cannot "
+                f"be compared against a threshold."
+            )
+        if not self.is_known(name):
+            return None
+        if self.read_count_subject() != subject:
+            return None
+        return getattr(self, name)
+
     def is_usable_as_biology(self, name: str) -> bool:
         """Whether *name* may be interpreted as a fact about the sample.
 
@@ -675,7 +731,7 @@ def fragments_from_dataframe(df, *, sequence_column=None):
 
         annotations = {}
         for key in ("sequence_source", "read_count_method",
-                    "supporting_read_count_method",
+                    "read_count_subject", "supporting_read_count_method",
                     "variant_allele_expression",
                     "variant_allele_expression_method"):
             value = row.get(key)

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -110,6 +110,53 @@ def provenance_for_method(method):
     return resolved
 
 
+#: What a read count counts.
+#:
+#: A count needs a subject as well as a derivation. isovar counts
+#: **fragments**; a depth x VAF estimate is inherently about **reads**,
+#: because depth is a read depth. Five fragments and five reads are
+#: different bars, and ``n_alt_reads`` alone cannot say which was
+#: cleared.
+#:
+#: Within one run the unit is internally consistent, so a ranking does
+#: not change. The harm is in things that travel: a documented
+#: ``n_alt_reads > 5`` threshold, a config copied between projects, a
+#: number in a paper.
+#:
+#: Perfect cross-path comparability is not available and is not the
+#: goal — converting a read estimate to fragments needs library
+#: information the source does not carry. The goal is that every path
+#: names its subject, and a source that cannot supply the subject a
+#: caller wants says so rather than substituting.
+FRAGMENTS = "fragments"
+READS = "reads"
+
+READ_SUBJECTS = frozenset({FRAGMENTS, READS})
+
+#: What each derivation counts, where the derivation determines it.
+#:
+#: A depth x VAF estimate is about reads whatever produced it, because
+#: depth is a read depth. ``rna_reads`` is left out deliberately: it
+#: says the count came from an alignment, not whether the aligner was
+#: counting reads or fragments, so the producer has to say.
+METHOD_SUBJECT = MappingProxyType({
+    RNA_DEPTH_X_VAF: READS,
+    CDS_OVERLAP_READS: READS,
+})
+
+
+def subject_for_method(method):
+    """What a value obtained by *method* counts, or ``None`` if it depends.
+
+    Returns ``None`` for derivations that do not fix the subject —
+    ``rna_reads`` says a count came from an alignment, not whether the
+    aligner counted reads or fragments — so the producer states it.
+    """
+    if not is_stated(method):
+        return None
+    return METHOD_SUBJECT.get(str(method).strip())
+
+
 #: How the protein sequence a prediction was made on came to exist.
 #:
 #: ``source_type`` says what an antigen *is* (``"variant:snv"``), which
@@ -160,6 +207,7 @@ READ_EVIDENCE_COLUMNS = (
     "n_ref_reads",
     "n_alt_reads_supporting_protein_sequence",
     "read_count_method",
+    "read_count_subject",
     "supporting_read_count_method",
     "variant_allele_expression",
     "variant_allele_expression_method",
@@ -266,6 +314,11 @@ def attach_read_evidence(
     out["n_ref_reads"] = ref
     out["read_count_method"] = pd.Series(
         [method if method and pd.notna(a) else pd.NA for a in alt],
+        index=out.index, dtype="object",
+    )
+    subject = subject_for_method(method) if method else None
+    out["read_count_subject"] = pd.Series(
+        [subject if subject and pd.notna(a) else pd.NA for a in alt],
         index=out.index, dtype="object",
     )
 


### PR DESCRIPTION
Settles the fragments-versus-reads question, to the downstream consumer's
design.

## The problem

isovar counts **fragments** — `num_alt_fragments`, not `num_alt_reads`. A
depth × VAF estimate is inherently about **reads**, because depth is a read
depth. Both landed in `n_alt_reads`.

So the field was honest about *how* a number was obtained and silent about
*what it counts* — the same shape as LENS's CDS-overlap column, a real count of
an adjacent thing. topiary was part of the problem: `fragment_from_isovar_result`
mapped a fragment count onto a field named for reads and marked it `measured`.

## Where the harm actually is

**Not in ranking.** Within one run every candidate comes from one path, so the
unit is internally consistent and the order does not change either way.

The harm is entirely in **things that travel**: a documented `n_alt_reads > 5`
filter, a config copied between projects, a threshold in a paper. Five fragments
and five reads are different bars, and nothing said which was cleared.

## What this adds

```python
fragment.read_count_subject()                 # "fragments" | "reads"
fragment.count_in("n_alt_reads", FRAGMENTS)   # 30
fragment.count_in("n_alt_reads", READS)       # None — says so
```

Frames carry `read_count_subject` beside `read_count_method`. Every path states
its subject: isovar `fragments`, depth × VAF `reads`, CDS-overlap `reads`.

`rna_reads` deliberately fixes **no** subject — it says a count came from an
alignment, not whether the aligner counted reads or fragments, so the producer
states it.

## What this deliberately does not attempt

**Cross-path comparability.** Converting a read estimate to fragments needs
library information no source carries, so there is no conversion and no single
comparable number. The goal is narrower and achievable: every path names its
subject, a score names the subject it wants, and a source asked for the other
one **returns `None` rather than substituting**. That is the derivation rule one
level up.

It also means `rna_fragments` as a *method* would have been the wrong fix — the
subject is not a derivation, and adding a term alongside would have left
`n_alt_reads` still ambiguous on the isovar path.

## Why fragments for `sqrt()`

Two mates of one fragment are not independent evidence, so read counts overstate
paired-end support roughly twofold relative to single-end — precisely the
distortion a diminishing-returns confidence transform should not inherit. isovar
exposes both counts, so topiary can carry the honest one and say which it is.

## Tests

15 in `tests/test_read_subject.py`: each path stating its subject, parameterized
over LENS and both pVACseq flavours; a derivation that fixes the subject saying
so and `rna_reads` saying nothing; **a fragment count not offered as a read
count and vice versa**; an absent count answering `None` for either; an unknown
subject refused; and the two that say why this exists — a travelling threshold
knowing which bar it cleared, and a `sqrt()` weight that demands fragments
getting nothing rather than something wrong.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2249 passed, 3 skipped

Version 5.43.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
