### PR TITLE
Name a count column for what it counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 5.44.0
+
+**Fixed: read counts did not survive fragment → prediction frame.** The
+frame carried `read_count_method` and `read_count_subject` — which
+arrive as annotations — describing a count that was not there. So it
+said how a number was obtained and what it counted, while omitting the
+number. The four count fields now propagate the way `gene_expression`
+already did.
+
+**Fixed: a threshold written for reads was answered by a fragment
+count.** Once the counts reached the frame, `n_alt_reads > 5` on an
+isovar-derived frame was satisfied by 8 *fragments*. Both are integers
+and both are plausible, so nothing failed.
+
+Count columns are now named for what they count. A fragment-subject
+frame has `n_alt_fragments`; a read-subject frame keeps `n_alt_reads`:
+
+```
+n_alt_reads > 5        ValueError: Column 'n_alt_reads' not found.
+                       Did you mean: ['n_alt_fragments', ...]
+n_alt_fragments > 5    works
+```
+
+Naming rather than only tagging is what makes the wrong reference fail.
+5.43.0 put the subject on the fragment and on the frame; a threshold is
+written against a *column name*, and the DSL was never going to consult
+a sibling column before answering.
+
+Reader frames are unchanged — both state `reads`, so both keep the
+`n_*_reads` spelling. A source that states no subject keeps it too,
+since that is what a source which does not say counts.
+
+**Cost, stated plainly:** on any other path this would break every
+existing config. It is free here only because the isovar path shipped
+days ago and nothing depends on it yet — which is the argument for doing
+it now rather than later.
+
 ## 5.43.0
 
 **Added: a read count now names what it counts.** isovar counts

--- a/tests/test_count_column_naming.py
+++ b/tests/test_count_column_naming.py
@@ -1,0 +1,161 @@
+"""A count column is named for what it counts.
+
+Follow-on from the read-subject work, found by checking whether the subject
+reached the place thresholds are actually written — the DSL — rather than
+only the fragment and the reader frame.
+
+Two things were wrong:
+
+1. Read counts did not survive fragment -> prediction frame at all. The
+   frame carried `read_count_method` and `read_count_subject`, which arrive
+   as annotations, describing a count that was not there — so it said how a
+   number was obtained and what it counted while omitting the number.
+
+2. Once they did survive, `n_alt_reads > 5` on an isovar-derived frame was
+   answered by a *fragment* count. Both are integers and both are
+   plausible, so nothing failed.
+
+Naming the column for its subject is what makes the wrong reference fail:
+the DSL raises "Column not found" and suggests the right one.
+"""
+
+import warnings
+
+import pytest
+from mhctools import RandomBindingPredictor
+
+from topiary import (
+    FRAGMENTS,
+    READS,
+    TopiaryPredictor,
+    evaluate_scores,
+    fragment_from_isovar_result,
+    read_lens,
+    read_pvacseq,
+)
+from topiary.ranking import parse
+from topiary.rna_evidence import count_column_for_subject
+
+
+class _ProteinSequence:
+    amino_acids = "MKTVRQERLKSIVRILEDAAWQ"
+    mutation_start_idx = 10
+    mutation_end_idx = 12
+    gene_name = "BRAF"
+    transcript_ids = ["ENST1"]
+    transcript_names = ["BRAF-204"]
+    num_supporting_fragments = 27
+
+
+class _IsovarResult:
+    top_protein_sequence = _ProteinSequence()
+    variant = "chr7 g.140453136 A>T"
+    num_total_fragments = 61
+    num_alt_fragments = 8
+    num_ref_fragments = 31
+
+
+@pytest.fixture(scope="module")
+def isovar_frame():
+    predictor = TopiaryPredictor(
+        models=RandomBindingPredictor, alleles=["A0201"],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return predictor.predict_from_fragments(
+            [fragment_from_isovar_result(_IsovarResult())]
+        )
+
+
+# ---------------------------------------------------------------------------
+# The counts reach the frame at all
+# ---------------------------------------------------------------------------
+
+
+def test_read_counts_survive_onto_the_prediction_frame(isovar_frame):
+    """They were dropped, leaving method and subject columns describing a
+    count that was not there."""
+    counts = [c for c in isovar_frame.columns if c.startswith("n_alt")]
+
+    assert counts
+    assert isovar_frame[counts[0]].notna().any()
+
+
+def test_the_subject_and_the_count_arrive_together(isovar_frame):
+    assert "read_count_subject" in isovar_frame.columns
+    assert "n_alt_fragments" in isovar_frame.columns
+    assert set(isovar_frame["read_count_subject"].dropna()) == {FRAGMENTS}
+
+
+# ---------------------------------------------------------------------------
+# The name says the subject
+# ---------------------------------------------------------------------------
+
+
+def test_a_fragment_frame_uses_fragment_names(isovar_frame):
+    assert "n_alt_fragments" in isovar_frame.columns
+    assert "n_alt_reads" not in isovar_frame.columns
+
+
+@pytest.mark.parametrize("reader,path", [
+    (read_lens, "tests/data/lens/sample_v1_4.tsv"),
+    (read_pvacseq, "tests/data/pvacseq/mhc_i_all_epitopes.tsv"),
+], ids=["lens", "pvacseq"])
+def test_a_read_frame_keeps_the_read_names(reader, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        df = reader(path).df
+
+    assert "n_alt_reads" in df.columns
+    assert "n_alt_fragments" not in df.columns
+
+
+def test_a_threshold_for_reads_is_refused_on_a_fragment_frame(isovar_frame):
+    """The harm, as an assertion: 8 fragments would clear a bar written
+    for 5 reads, and both are plausible integers."""
+    with pytest.raises(ValueError, match="not found"):
+        evaluate_scores(isovar_frame, parse("n_alt_reads > 5"))
+
+
+def test_the_error_suggests_the_right_column(isovar_frame):
+    with pytest.raises(ValueError) as excinfo:
+        evaluate_scores(isovar_frame, parse("n_alt_reads > 5"))
+
+    assert "n_alt_fragments" in str(excinfo.value)
+
+
+def test_the_subject_qualified_threshold_works(isovar_frame):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        scores = evaluate_scores(isovar_frame, parse("n_alt_fragments > 5"))
+
+    assert scores.sum() == len(scores)
+
+
+# ---------------------------------------------------------------------------
+# The naming rule itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field,fragment_name", [
+    ("n_alt_reads", "n_alt_fragments"),
+    ("n_ref_reads", "n_ref_fragments"),
+    ("n_overlapping_reads", "n_overlapping_fragments"),
+    ("n_alt_reads_supporting_protein_sequence",
+     "n_alt_fragments_supporting_protein_sequence"),
+])
+def test_every_count_field_has_a_fragment_spelling(field, fragment_name):
+    assert count_column_for_subject(field, FRAGMENTS) == fragment_name
+    assert count_column_for_subject(field, READS) == field
+
+
+@pytest.mark.parametrize("subject", [None, "", "nan"])
+def test_an_unstated_subject_keeps_the_read_spelling(subject):
+    """That is what a source which does not say counts."""
+    assert count_column_for_subject("n_alt_reads", subject) == "n_alt_reads"
+
+
+def test_an_unknown_field_is_passed_through():
+    assert count_column_for_subject("something_else", FRAGMENTS) == (
+        "something_else"
+    )

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -124,6 +124,7 @@ from .rna_evidence import (
     attach_sequence_source,
     describe_read_evidence,
     provenance_for_method,
+    count_column_for_subject,
     subject_for_method,
     split_reads_by_vaf,
 )
@@ -134,7 +135,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.43.0"
+__version__ = "5.44.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -254,6 +255,7 @@ __all__ = [
     "READS",
     "READ_SUBJECTS",
     "subject_for_method",
+    "count_column_for_subject",
     "READ_COUNT_METHODS",
     "SEQUENCE_SOURCES",
     "attach_read_evidence",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -1481,8 +1481,31 @@ class TopiaryPredictor(object):
             "source_type", "variant", "effect", "effect_type",
             "gene", "gene_id", "transcript_id", "transcript_name",
             "gene_expression", "transcript_expression",
+            # RNA read evidence, for the same reason expression is here:
+            # a consumer filtering or weighting on it reads the
+            # prediction frame, not the fragment. Without these the
+            # frame carried read_count_method and read_count_subject —
+            # which arrive as annotations — describing a count that was
+            # not there, so the frame said how a number was obtained and
+            # what it counted while omitting the number.
         ):
             df[attr] = _map_attr(attr)
+
+        # Read counts are named for what they count, so a threshold
+        # written against n_alt_reads cannot be answered by a fragment
+        # count. The subject comes from the fragments themselves.
+        from .rna_evidence import count_column_for_subject
+        subjects = {
+            f.annotations.get("read_count_subject") for f in fragments
+        }
+        subject = subjects.pop() if len(subjects) == 1 else None
+        for attr in (
+            "n_overlapping_reads", "n_alt_reads", "n_ref_reads",
+            "n_alt_reads_supporting_protein_sequence",
+        ):
+            values = _map_attr(attr)
+            if values.notna().any():
+                df[count_column_for_subject(attr, subject)] = values
 
         def _overlaps(row):
             f = by_id.get(row["fragment_id"])

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -145,6 +145,38 @@ METHOD_SUBJECT = MappingProxyType({
 })
 
 
+#: Count fields, and what each is called when it counts fragments.
+#:
+#: The frame column is named for what it counts. A threshold is written
+#: against a column name, so a name that does not say its subject lets a
+#: bar written for reads be cleared by fragments — silently, because
+#: both are integers and both are plausible.
+COUNT_FIELDS_BY_SUBJECT = MappingProxyType({
+    "n_overlapping_reads": "n_overlapping_fragments",
+    "n_alt_reads": "n_alt_fragments",
+    "n_ref_reads": "n_ref_fragments",
+    "n_alt_reads_supporting_protein_sequence":
+        "n_alt_fragments_supporting_protein_sequence",
+})
+
+
+def count_column_for_subject(field: str, subject) -> str:
+    """The column name *field* takes when it counts *subject*.
+
+    ``reads`` keeps the ``n_*_reads`` names; ``fragments`` gets
+    ``n_*_fragments``. An unstated subject keeps the read spelling,
+    since that is what every source that does not say counts.
+
+    Naming the column rather than only tagging it is what makes a wrong
+    reference fail: the DSL raises "Column not found" and lists what is
+    there, so a threshold written for reads cannot quietly be answered
+    by a fragment count.
+    """
+    if not is_stated(subject) or str(subject).strip() != FRAGMENTS:
+        return field
+    return COUNT_FIELDS_BY_SUBJECT.get(field, field)
+
+
 def subject_for_method(method):
     """What a value obtained by *method* counts, or ``None`` if it depends.
 


### PR DESCRIPTION
Follow-on from 5.43.0, found by asking whether the subject reached the place
thresholds are actually written — the DSL — rather than only the fragment and
the reader frame. It had not.

## Two problems

**Read counts did not survive fragment → prediction frame at all.** The frame
carried `read_count_method` and `read_count_subject` — which arrive as
annotations, so they propagated — describing a count that was not there. It said
how a number was obtained and what it counted, while omitting the number. The
four count fields now propagate the way `gene_expression` already did.

**Then a threshold written for reads was answered by a fragment count.** With
the counts present, `n_alt_reads > 5` on an isovar-derived frame was satisfied
by **8 fragments**. Both are integers, both are plausible, nothing failed.

## The fix

Count columns are named for what they count:

```
n_alt_reads > 5        ValueError: Column 'n_alt_reads' not found.
                       Did you mean: ['n_alt_fragments', ...]
n_alt_fragments > 5    works
```

**Naming rather than only tagging is the point.** 5.43.0 put the subject on the
fragment (`count_in`) and on the frame (`read_count_subject`), and neither helps
here: a threshold is written against a *column name*, and the DSL was never
going to consult a sibling column before answering. This is the consumer's own
conclusion — they reached it implementing the same thing in their config
namespace, where `None` is correct and unusable because `sqrt(None)` raises and
coercing to `0` reintroduces exactly the substitution the subject prevents.

Reader frames are unchanged: both state `reads`, so both keep `n_*_reads`. A
source stating no subject keeps it too, since that is what a source which does
not say counts.

## The cost, stated plainly

On any other path this would break every existing config. It is free here
**only** because the isovar path shipped days ago and nothing depends on it yet
— which is the argument for doing it now rather than later. The consumer is
carrying the same change with real breakage, filed as vaxrank#385; topiary is
not, and that asymmetry is worth naming rather than presenting this as costless
in general.

## Tests

16 in `tests/test_count_column_naming.py`: the counts reaching the frame; the
subject and the count arriving together; a fragment frame using fragment names
and *not* read names; reader frames keeping read names (parameterized); **the
reads threshold refused on a fragment frame** and the error suggesting the right
column; the subject-qualified threshold working; every count field having a
fragment spelling (parameterized); and an unstated subject keeping the read
spelling.

## Verification

- `./lint.sh` — passes
- `./test.sh` — 2265 passed, 3 skipped

Version 5.44.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG
