### PR TITLE
Correct the guide's shared-column claim, and ship it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 5.46.0
+
+**Fixed: the consumer guide overpromised.** It said the nine evidence
+columns were "identical across readers". They are the same
+*vocabulary*, not the same *columns* — a reader emits one only where its
+source can answer, and a pVACseq **aggregated** report has no gene-level
+abundance, so no `gene_expression`.
+
+That mattered for the exact use the guide recommends: naming an absent
+column in an expression raises rather than evaluating to NaN, so a
+config written against a LENS frame would break on an aggregated
+pVACseq one. Corrected, with the failure shown.
+
+Raising stays the behaviour, and the columns stay absent rather than
+all-null. A present-but-empty column asserts the question was asked and
+answered as nothing; absent beats substituted here as everywhere else.
+
+**Added: `available_evidence_columns(df)` and `EVIDENCE_COLUMNS`**, so a
+consumer writing a portable config can check rather than discover the
+gap at runtime.
+
+**Fixed: the guide was not in the distribution.** No `docs/` in the
+sdist and no `.md` in the wheel, so anyone working from an installed
+package could not find the document framed as "the thing you read
+instead of asking". `MANIFEST.in` now ships `docs/`.
+
+Both found by the downstream consumer checking the guide's claims
+against the shipped package instead of reading it — which is what the
+guide asks its readers to do, so it is fitting that it is how the guide
+was found wrong. Every *code example* in it had been executed; the
+sentence summarising them had not.
+
 ## 5.45.1
 
 **Added: `docs/consumer-guide.md`** — what topiary offers a downstream

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+# Ship the docs with the source distribution.
+#
+# docs/consumer-guide.md is written as the reference a downstream
+# consumer reads instead of asking; a consumer working from an installed
+# package could not find it when it lived only in the repo.
+include README.md
+include CHANGELOG.md
+include LICENSE
+include requirements.txt
+recursive-include docs *.md
+recursive-include topiary/data *

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -29,7 +29,8 @@ unchanged against LENS, pVACseq, or a predictor's own output.
 
 ## RNA evidence
 
-Nine columns, identical across readers:
+Nine columns. **The same vocabulary across readers, not the same columns** — a
+reader emits one only where its source can answer:
 
 | Column | Meaning |
 |---|---|
@@ -43,8 +44,36 @@ Nine columns, identical across readers:
 | `gene_expression` | Gene-level abundance |
 | `sequence_source` | How the protein sequence came to exist |
 
-**Write thresholds against `n_rna_alt`.** It is populated wherever a source can
-answer, whatever unit that source counts in.
+**Check which are present before naming one in a config that has to run against
+more than one source:**
+
+```python
+from topiary import available_evidence_columns, EVIDENCE_COLUMNS
+
+missing = set(EVIDENCE_COLUMNS) - set(available_evidence_columns(df))
+```
+
+Naming an absent column in an expression **raises** rather than evaluating to
+NaN:
+
+```
+gene_expression > 1  on a pVACseq aggregated frame
+  ValueError: Column 'gene_expression' not found in DataFrame.
+              Did you mean: ['rna_alt_expression', 'transcript_expression', ...]
+```
+
+That is the intended behaviour — a silent NaN would drop every row in a filter
+and say nothing. The alternative, emitting all-null columns everywhere, is
+worse: a column that is present and empty asserts the question was asked and
+answered as nothing. Absent beats substituted here as everywhere else.
+
+Concretely, a pVACseq *aggregated* report has no gene-level abundance, so it has
+no `gene_expression`; a LENS file without a `tpm` column has none either.
+
+**`n_rna_alt`, `rna_evidence_subject` and `rna_evidence_method` are present
+wherever a source reports any RNA evidence at all**, which is what makes a
+threshold written against `n_rna_alt` portable — whatever unit that source
+counts in.
 
 **Read `rna_evidence_subject` before a number leaves the run.** Within one run
 the unit is consistent and rankings are unaffected. It matters for things that

--- a/tests/test_shared_expression_vocabulary.py
+++ b/tests/test_shared_expression_vocabulary.py
@@ -132,6 +132,7 @@ def test_a_consumer_can_ask_how_a_number_was_obtained_on_either_frame(frames):
 # opposite. A function with two branches needs both exercised.
 
 AGGREGATED = "tests/data/pvacseq/mhc_i_aggregated.tsv"
+LENS_FIXTURE_PATH = LENS
 ALL_EPITOPES = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
 
 
@@ -206,3 +207,64 @@ def test_one_filter_spans_both_pvacseq_flavours(path):
         scores = evaluate_scores(df, parse("rna_alt_expression > 0"))
 
     assert len(scores) == len(df)
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary is shared; the columns are not always present
+# ---------------------------------------------------------------------------
+#
+# The consumer guide claimed the nine evidence columns were "identical across
+# readers". They are the same *vocabulary* — a reader emits one only where its
+# source can answer. A pVACseq aggregated report has no gene-level abundance.
+#
+# This matters because naming an absent column raises rather than evaluating
+# to NaN, so a config written against one source can break on another.
+
+
+def test_the_evidence_vocabulary_is_shared():
+    from topiary import EVIDENCE_COLUMNS, available_evidence_columns
+
+    for path in (LENS_FIXTURE_PATH, ALL_EPITOPES, AGGREGATED):
+        reader = read_lens if str(path).endswith("sample_v1_4.tsv") else read_pvacseq
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            available = available_evidence_columns(reader(path).df)
+        assert set(available) <= set(EVIDENCE_COLUMNS)
+        assert "n_rna_alt" in available
+
+
+def test_an_aggregated_report_has_no_gene_level_abundance():
+    """The specific gap the guide got wrong."""
+    from topiary import available_evidence_columns
+
+    available = available_evidence_columns(_pvacseq(AGGREGATED))
+
+    assert "gene_expression" not in available
+    assert "gene_expression" in available_evidence_columns(
+        _pvacseq(ALL_EPITOPES)
+    )
+
+
+def test_naming_an_absent_column_raises_rather_than_dropping_everything():
+    """A silent NaN would drop every row in a filter and say nothing."""
+    with pytest.raises(ValueError, match="not found"):
+        evaluate_scores(_pvacseq(AGGREGATED), parse("gene_expression > 1"))
+
+
+def test_absent_columns_are_absent_not_all_null():
+    """A present-but-empty column asserts the question was asked and
+    answered as nothing."""
+    df = _pvacseq(AGGREGATED)
+
+    assert "gene_expression" not in df.columns
+
+
+def test_the_portable_columns_are_on_every_source():
+    """What makes a threshold against n_rna_alt actually portable."""
+    from topiary import available_evidence_columns
+
+    for df in (_pvacseq(AGGREGATED), _pvacseq(ALL_EPITOPES)):
+        available = available_evidence_columns(df)
+        for column in ("n_rna_alt", "rna_evidence_subject",
+                       "rna_evidence_method"):
+            assert column in available

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -126,7 +126,9 @@ from .rna_evidence import (
     attach_sequence_source,
     describe_read_evidence,
     provenance_for_method,
+    EVIDENCE_COLUMNS,
     attach_rna_evidence_columns,
+    available_evidence_columns,
     split_reads_by_vaf,
 )
 from .result import (
@@ -136,7 +138,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.45.1"
+__version__ = "5.46.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -258,6 +260,8 @@ __all__ = [
     "READS",
     "READ_SUBJECTS",
     "attach_rna_evidence_columns",
+    "available_evidence_columns",
+    "EVIDENCE_COLUMNS",
     "READ_COUNT_METHODS",
     "SEQUENCE_SOURCES",
     "attach_read_evidence",

--- a/topiary/rna_evidence.py
+++ b/topiary/rna_evidence.py
@@ -441,6 +441,55 @@ def attach_read_evidence(
     return out
 
 
+#: The evidence columns a reader emits when its source can answer.
+EVIDENCE_COLUMNS = (
+    "n_rna_alt",
+    "n_rna_ref",
+    "n_rna_overlapping",
+    "rna_evidence_subject",
+    "rna_evidence_method",
+    "rna_alt_expression",
+    "rna_alt_expression_method",
+    "gene_expression",
+    "sequence_source",
+)
+
+
+def available_evidence_columns(df: pd.DataFrame) -> tuple:
+    """Which of :data:`EVIDENCE_COLUMNS` *df* actually has.
+
+    Readers emit an evidence column only where the source can answer, so
+    the set is the same *vocabulary* across readers rather than the same
+    *columns*: a pVACseq aggregated report has no gene-level abundance,
+    and a LENS file without a ``tpm`` column has none either.
+
+    That matters because naming an absent column in an expression
+    **raises** rather than evaluating to NaN — which is the right
+    behaviour, and the reason to check before writing a config that has
+    to run against more than one source.
+
+    The alternative, emitting all-null columns everywhere, is worse: a
+    column that is present and empty asserts the question was asked and
+    answered as nothing. Absent beats substituted here as everywhere
+    else.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+
+    Returns
+    -------
+    tuple of str
+        In :data:`EVIDENCE_COLUMNS` order.
+
+    Examples
+    --------
+    >>> missing = set(EVIDENCE_COLUMNS) - set(available_evidence_columns(df))
+    ... # doctest: +SKIP
+    """
+    return tuple(c for c in EVIDENCE_COLUMNS if c in df.columns)
+
+
 def describe_read_evidence(df: pd.DataFrame) -> dict:
     """``{column: method}`` for every evidence column *df* populates.
 


### PR DESCRIPTION
Two findings from the downstream consumer, who checked the guide's claims against the shipped package rather than reading it — which is what the guide asks its readers to do, so it is fitting that it is how the guide was found wrong.

## The claim was false

The guide said the nine evidence columns were "identical across readers". They are the same **vocabulary**, not the same **columns** — a reader emits one only where its source can answer:

```
lens             missing: none
pvacseq          missing: none
pvacseq-agg      missing: ['gene_expression']
```

A pVACseq *aggregated* report has no gene-level abundance. A LENS file without a `tpm` column has none either.

**This mattered for the exact use the guide recommends.** Naming an absent column raises rather than evaluating to NaN, so a config written against a LENS frame breaks on an aggregated pVACseq one — the portability failure that section exists to prevent.

```
gene_expression > 1  on a pVACseq aggregated frame
  ValueError: Column 'gene_expression' not found in DataFrame.
              Did you mean: ['rna_alt_expression', 'transcript_expression', ...]
```

## What did not change

Raising stays — a silent NaN would drop every row in a filter and say nothing. And the columns stay **absent rather than all-null**: a present-but-empty column asserts the question was asked and answered as nothing. Absent beats substituted here as everywhere else, which was the consumer's own recommendation and is this repo's rule.

## What was added

`available_evidence_columns(df)` and `EVIDENCE_COLUMNS`, so a consumer writing a portable config checks rather than discovering the gap at runtime.

## The guide was not distributed

No `docs/` in the sdist, no `.md` in the wheel. For a document framed as "the thing you read instead of asking me", anyone working from an installed package could not find it — the consumer had to pull it from the GitHub API. `MANIFEST.in` ships `docs/` now; verified in a built sdist.

## The failure worth naming

Every *code example* in the guide had been executed against the package. The *sentence summarising them* had not. Verifying the parts and asserting the whole, one more time, in the document written partly to record that lesson.

## Tests

5 in `tests/test_shared_expression_vocabulary.py`: the vocabulary shared across all three fixtures; the aggregated report specifically lacking gene-level abundance while all-epitopes has it; naming an absent column raising; absent columns being absent rather than all-null; and the three genuinely portable columns present on every source.

- `./lint.sh` — passes
- `./test.sh` — 2255 passed, 3 skipped

Version 5.46.0.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG