### PR TITLE
Symmetric DNA/RNA evidence, source-prefixed originals, public cache key

### DIFF
--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -27,22 +27,49 @@ unchanged against LENS, pVACseq, or a predictor's own output.
 
 ---
 
-## RNA evidence
+## RNA and DNA evidence
 
-Nine columns. **The same vocabulary across readers, not the same columns** — a
-reader emits one only where its source can answer:
+Columns come in three layers. **Filter against layer 1.**
+
+1. **Canonical cross-source** — same meaning from every reader.
+2. **Canonical unit-specific** — `n_alt_reads` / `n_alt_fragments`, present
+   only where a source reports both units and they differ.
+3. **Source-prefixed originals** — `lens_vaf`, `pvacseq_tumor_dna_vaf`:
+   exactly the number the tool printed, never reinterpreted. Find them with
+   `source_columns(df)`, or `source_columns(df, "lens")` for one tool.
+
+**The same vocabulary across readers, not the same columns** — a reader emits
+one only where its source can answer:
 
 | Column | Meaning |
 |---|---|
 | `n_rna_alt` | Evidence supporting the variant allele |
 | `n_rna_ref` | Evidence supporting the reference allele |
-| `n_rna_overlapping` | Evidence covering the position |
+| `n_rna_other` | Evidence supporting neither — a third allele, error, or nearby indel |
+| `n_rna_overlapping` | Evidence covering the position (total coverage) |
+| `rna_vaf` | Variant allele fraction |
 | `rna_evidence_subject` | `"reads"` or `"fragments"` — what those counts count |
 | `rna_evidence_method` | How they were obtained |
 | `rna_alt_expression` | Abundance attributed to the variant allele |
 | `rna_alt_expression_method` | How that was obtained |
 | `gene_expression` | Gene-level abundance |
 | `sequence_source` | How the protein sequence came to exist |
+
+**DNA support is the same shape**, so a filter written against RNA depth
+becomes the DNA one by changing three letters: `n_dna_alt`, `n_dna_ref`,
+`n_dna_other`, `n_dna_overlapping`, `dna_vaf`, `dna_evidence_subject`,
+`dna_evidence_method`. There is no DNA expression pair — abundance is a
+transcript property.
+
+`n_rna_other` / `n_dna_other` are **absent unless the source counted the
+reference independently.** Where topiary derived `ref` as `depth - alt`, that
+figure already absorbs the other alleles, so reporting a difference of zero
+would assert a clean locus nobody checked.
+
+**A column is omitted, not nulled, where the source cannot answer it.** A
+pVACseq aggregated report states a DNA VAF but no DNA depth, so it gets
+`dna_vaf` and no `n_dna_*` at all — a column full of nulls would make
+`available_evidence_columns()` report a capability the source lacks.
 
 **Check which are present before naming one in a config that has to run against
 more than one source:**
@@ -101,17 +128,33 @@ count does.
 
 ### Per source
 
-| | `n_rna_alt` | subject | method |
-|---|---|---|---|
-| isovar | 30 | `fragments` | `rna_alignment` |
-| pVACseq | 429 | `reads` | `rna_depth_x_vaf` |
-| LENS | from `vaf` | `reads` | `rna_depth_x_source_vaf` |
+| | `n_rna_alt` | subject | method | DNA columns |
+|---|---|---|---|---|
+| isovar | 30 | `fragments` | `rna_alignment` | none — isovar reads RNA |
+| pVACseq (all_epitopes) | 429 | `reads` | `rna_depth_x_vaf` | yes, from DNA depth × DNA VAF |
+| pVACseq (aggregated) | from `RNA VAF` | `reads` | `rna_depth_x_vaf` | `dna_vaf` only — no DNA depth stated |
+| LENS | from `lens_vaf` | `reads` | `rna_depth_x_source_vaf` | none — see below |
 
-**LENS's `vaf` carries no assay qualifier.** LENS names its read columns `rna_*`
-explicitly and leaves `vaf` bare, so topiary cannot tell whether the fraction is
-from RNA or DNA. It is used to split the RNA depth — under a method that says
-so — and *not* to scale expression, which would assert the opposite assay. If
-you derive anything from that column yourself, the same ambiguity applies.
+**LENS's `vaf` carries no assay qualifier**, and lands as `lens_vaf`. LENS names
+its read columns `rna_*` explicitly and leaves `vaf` bare, so topiary cannot tell
+whether the fraction is from RNA or DNA. It is used to split the RNA depth —
+under a method that says so — and *not* to scale expression or to populate any
+`n_dna_*` column, either of which would assert an assay nobody stated.
+
+### Multiple samples
+
+Evidence is per row, and `sample_name` is a first-class column and a DSL group
+key, so a stacked multi-sample frame already carries each sample's own counts
+and each stays attributable:
+
+```python
+merged = stack_results([per_sample_result(name) for name in samples])
+merged.df[["sample_name", "n_rna_alt", "n_rna_overlapping", "rna_vaf"]]
+```
+
+**There is no built-in cross-sample aggregate yet** — summing counts across
+samples is currently a `groupby` you write yourself. Tracked in
+[#247](https://github.com/openvax/topiary/issues/247).
 
 ---
 
@@ -284,6 +327,12 @@ Floors worth knowing:
 | Named-allele rows not broadcast | 5.39.0 |
 | `fragments_from_variants` (isovar) | 5.40.0 |
 | RNA columns scoped and cut to nine | 5.45.0 |
+| DNA evidence columns, mirroring the RNA ones | 5.47.0 |
+| `n_rna_other` / `n_dna_other` for third-allele support | 5.47.0 |
+| `rna_vaf` / `dna_vaf` canonical fractions | 5.47.0 |
+| Source prefixes: `vaf` → `lens_vaf`, `tumor_dna_vaf` → `pvacseq_tumor_dna_vaf` | 5.47.0 |
+| `PREDICTION_KEY_COLUMNS` public | 5.47.0 |
+| `topiary.rna_evidence` module renamed to `topiary.evidence` | 5.47.0 |
 
 ### Removed in 5.45.0, with no compatibility shim
 

--- a/docs/expression-semantics.md
+++ b/docs/expression-semantics.md
@@ -671,8 +671,12 @@ Expression fields are just `column()` references with short aliases. The parser 
 ```
 gene_tpm           →  Column("gene_tpm")
 transcript_tpm     →  Column("transcript_tpm")
-vaf                →  Column("vaf")
+rna_vaf            →  Column("rna_vaf")
 ```
+
+Reach for the canonical `rna_vaf` / `dna_vaf` rather than a tool's own
+fraction: a source-prefixed column such as `lens_vaf` exists only on frames
+from that tool, and naming an absent column raises.
 
 This means any user-provided column works — the aliases are just convenience for common ones. Users can always fall back to `column(my_custom_field)` for arbitrary data.
 

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -69,7 +69,8 @@ def test_a_lens_report_can_be_filtered_and_sorted_by_a_dsl_expression():
 
 @pytest.mark.parametrize("expression", [
     "gene_tpm > 1",
-    "vaf > 0.1",
+    "lens_vaf > 0.1",
+    "rna_vaf > 0.1",
     "n_rna_alt > 5",
     "affinity['netmhcpan'].value.logistic_normalized(350,150) * (gene_tpm > 1)",
 ])
@@ -95,6 +96,9 @@ def test_the_lens_renames_are_what_the_dsl_sees():
     for original, renamed in (
         ("tpm", "gene_tpm"), ("gene_name", "gene"),
         ("variant_coords", "variant"),
+        # LENS's own fraction keeps LENS's name: unqualified `vaf` would
+        # be unattributable next to another tool's VAF in a stacked frame.
+        ("vaf", "lens_vaf"),
     ):
         assert renamed in df.columns, f"{original} should surface as {renamed}"
         assert original not in df.columns

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -20,7 +20,7 @@ from topiary import (
     RNA_DEPTH_X_SOURCE_VAF,
     RNA_DEPTH_X_VAF,
     TPM_X_DNA_VAF,
-    attach_read_evidence,
+    attach_rna_evidence,
     attach_sequence_source,
     describe_read_evidence,
     read_lens,
@@ -109,7 +109,7 @@ def test_the_expression_estimate_is_abundance_times_fraction():
     df = _read(read_pvacseq, PVACSEQ).df
     row = df.dropna(subset=["rna_alt_expression"]).iloc[0]
 
-    expected = row["transcript_expression"] * row["tumor_dna_vaf"]
+    expected = row["transcript_expression"] * row["pvacseq_tumor_dna_vaf"]
     assert row["rna_alt_expression"] == pytest.approx(expected)
 
 
@@ -128,7 +128,7 @@ def test_lens_populates_the_counted_columns():
 def test_lens_rows_without_a_vaf_get_no_split_and_no_method():
     """Absent stays absent, and says so — it does not become zero."""
     df = _read(read_lens, LENS).df
-    unstated = df[df["vaf"].isna()]
+    unstated = df[df["lens_vaf"].isna()]
 
     assert unstated["n_rna_alt"].isna().all()
     assert unstated["rna_evidence_method"].isna().all()
@@ -136,7 +136,7 @@ def test_lens_rows_without_a_vaf_get_no_split_and_no_method():
 
 def test_lens_rows_with_a_vaf_do_get_a_split():
     df = _read(read_lens, LENS).df
-    stated = df[df["vaf"].notna()]
+    stated = df[df["lens_vaf"].notna()]
 
     assert len(stated) > 0
     assert stated["n_rna_alt"].notna().all()
@@ -157,7 +157,7 @@ def test_a_cds_overlap_count_keeps_its_own_name():
         warnings.simplefilter("ignore", UserWarning)
         df = read_lens(LENS).df
 
-    assert "rna_reads_covering_genomic_origin_with_peptide_cds" in df.columns
+    assert "lens_rna_reads_covering_genomic_origin_with_peptide_cds" in df.columns
     assert "n_alt_reads_supporting_protein_sequence" not in df.columns
 
 
@@ -167,7 +167,7 @@ def test_a_cds_overlap_count_keeps_its_own_name():
 
 
 def test_a_frame_with_no_rna_columns_gets_absent_not_zero():
-    frame = attach_read_evidence(pd.DataFrame({"x": [1, 2, 3]}))
+    frame = attach_rna_evidence(pd.DataFrame({"x": [1, 2, 3]}))
 
     for column in ("n_rna_overlapping", "n_rna_alt", "n_rna_ref"):
         assert frame[column].isna().all()
@@ -176,7 +176,7 @@ def test_a_frame_with_no_rna_columns_gets_absent_not_zero():
 
 def test_the_columns_exist_even_when_unpopulated():
     """Same shape from every source; only which fields are filled differs."""
-    frame = attach_read_evidence(pd.DataFrame({"x": [1]}))
+    frame = attach_rna_evidence(pd.DataFrame({"x": [1]}))
 
     assert "n_rna_alt" in frame.columns
     assert "rna_evidence_method" in frame.columns
@@ -200,7 +200,7 @@ def test_describe_reports_how_each_number_was_obtained():
 
 def test_describe_says_nothing_about_columns_nothing_populated():
     assert describe_read_evidence(
-        attach_read_evidence(pd.DataFrame({"x": [1]}))
+        attach_rna_evidence(pd.DataFrame({"x": [1]}))
     ) == {}
 
 

--- a/tests/test_fragment_paths.py
+++ b/tests/test_fragment_paths.py
@@ -27,7 +27,7 @@ from topiary import (
     read_lens,
     read_pvacseq,
 )
-from topiary.rna_evidence import RNA_ALIGNMENT, RNA_DEPTH_X_VAF
+from topiary.evidence import RNA_ALIGNMENT, RNA_DEPTH_X_VAF
 
 LENS = "tests/data/lens/sample_v1_4.tsv"
 PVACSEQ = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
@@ -192,7 +192,7 @@ def test_a_lens_cds_overlap_count_keeps_its_own_name():
     that overstates it."""
     frame = _frame(read_lens, LENS)
 
-    assert "rna_reads_covering_genomic_origin_with_peptide_cds" in frame.columns
+    assert "lens_rna_reads_covering_genomic_origin_with_peptide_cds" in frame.columns
     assert "n_alt_reads_supporting_protein_sequence" not in frame.columns
 
 

--- a/tests/test_io_lens.py
+++ b/tests/test_io_lens.py
@@ -275,7 +275,7 @@ class TestAnnotations:
         r = read_lens(V1_4)
         # Spot-check a selection of annotation columns.
         for col in [
-            "vaf", "ccf", "priority_score", "erv_orf_id",
+            "lens_vaf", "ccf", "priority_score", "erv_orf_id",
             "mean_mtec_tpm", "gene_detectable_normal_tissues",
             "pep_context", "coding_sequence",
         ]:
@@ -360,8 +360,8 @@ class TestDSLIntegration:
         from topiary.ranking import Column
         r = read_lens(V1_4).to_long()
         # Filter on vaf (pass-through annotation)
-        if "vaf" in r.df.columns:
+        if "lens_vaf" in r.df.columns:
             try:
-                apply_filter(r.df, Column("vaf") >= 0.0)
+                apply_filter(r.df, Column("lens_vaf") >= 0.0)
             except Exception as e:  # noqa: BLE001
-                pytest.fail(f"Column('vaf') filter failed: {e}")
+                pytest.fail(f"Column('lens_vaf') filter failed: {e}")

--- a/tests/test_io_pvacseq.py
+++ b/tests/test_io_pvacseq.py
@@ -264,7 +264,7 @@ class TestLoadAllEpitopes:
 
     def test_annotation_columns_renamed(self):
         r = read_pvacseq(MHC_I_ALL)
-        assert {"gene_expression", "tumor_dna_vaf", "variant_type"} <= set(r.df.columns)
+        assert {"gene_expression", "pvacseq_tumor_dna_vaf", "variant_type"} <= set(r.df.columns)
 
     def test_effect_type_substitution_for_missense(self):
         r = read_pvacseq(MHC_I_ALL)

--- a/tests/test_shared_expression_vocabulary.py
+++ b/tests/test_shared_expression_vocabulary.py
@@ -123,7 +123,7 @@ def test_a_consumer_can_ask_how_a_number_was_obtained_on_either_frame(frames):
 # The sharper bug behind #238, and the one I missed: read_pvacseq took two
 # branches. Its aggregated report supplies pVACseq's own `Allele Expr` and
 # `RNA Expr`, which were passed through under names the all_epitopes path
-# never emits — and that path never ran attach_read_evidence at all, so it
+# never emits — and that path never ran attach_rna_evidence at all, so it
 # had no method columns.
 #
 # Both of us mis-verified this by checking one branch: I read the

--- a/tests/test_symmetric_evidence.py
+++ b/tests/test_symmetric_evidence.py
@@ -1,0 +1,250 @@
+"""DNA and RNA evidence are the same shape, and sources stay attributable.
+
+The defect class these guard: a caller who has written a filter against
+RNA depth should be able to write the DNA one by changing three letters,
+and a frame holding two tools' numbers should never answer "what was the
+VAF" with whichever tool filled the column first.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    DNA_EVIDENCE_COLUMNS,
+    PREDICTION_KEY_COLUMNS,
+    RNA_EVIDENCE_COLUMNS,
+    SOURCE_PREFIXES,
+    ProteinFragment,
+    TopiaryResult,
+    attach_dna_evidence,
+    other_allele_count,
+    read_lens,
+    read_pvacseq,
+    source_column,
+    source_columns,
+    stack_results,
+)
+from topiary.evidence import DNA_DEPTH_X_VAF, attach_rna_evidence
+
+LENS = "tests/data/lens/sample_v1_4.tsv"
+PVAC_ALL = "tests/data/pvacseq/mhc_i_all_epitopes.tsv"
+
+
+def _read(fn, path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return fn(path).df
+
+
+# ---------------------------------------------------------------------------
+# Symmetry: the same question, asked of either assay
+# ---------------------------------------------------------------------------
+
+
+def test_the_dna_columns_mirror_the_rna_columns_name_for_name():
+    """The point of the symmetry: s/rna/dna/ names a real column."""
+    rna_shape = {c.replace("rna", "", 1) for c in RNA_EVIDENCE_COLUMNS}
+    dna_shape = {c.replace("dna", "", 1) for c in DNA_EVIDENCE_COLUMNS}
+    # Expression is transcript-only and has no DNA meaning; everything
+    # else must exist on both sides.
+    expression_only = {"_alt_expression", "_alt_expression_method",
+                       "gene_expression"}
+    assert rna_shape - expression_only == dna_shape
+
+
+def test_pvacseq_derives_dna_counts_from_depth_and_vaf():
+    """The asymmetry this closes: DNA depth+VAF were raw passthroughs."""
+    df = _read(read_pvacseq, PVAC_ALL)
+    row = df[df["n_dna_alt"].notna()].iloc[0]
+
+    depth = row["pvacseq_tumor_dna_depth"]
+    vaf = row["pvacseq_tumor_dna_vaf"]
+    assert row["n_dna_alt"] == round(depth * vaf)
+    assert row["n_dna_ref"] == depth - row["n_dna_alt"]
+    assert row["n_dna_overlapping"] == depth
+    assert row["dna_evidence_method"] == DNA_DEPTH_X_VAF
+    assert row["dna_evidence_subject"] == "reads"
+
+
+def test_a_depth_without_a_fraction_yields_no_split_rather_than_zero():
+    out = attach_dna_evidence(
+        pd.DataFrame({"x": [1]}), depth=pd.Series([50]), vaf=pd.Series([None]),
+    )
+    assert pd.isna(out["n_dna_alt"].iloc[0])
+    assert pd.isna(out["dna_evidence_method"].iloc[0])
+    # Depth is still known: the source did cover the locus.
+    assert out["n_dna_overlapping"].iloc[0] == 50
+
+
+def test_a_source_that_states_only_a_fraction_gets_only_the_fraction_column():
+    """The defect: 6 all-null DNA columns claiming the source answered.
+
+    pVACseq's aggregated report has a DNA VAF but no DNA depth, so no
+    alt/ref split exists. Emitting `n_dna_alt` full of nulls would make
+    available_evidence_columns() report a capability the source lacks.
+    """
+    agg = _read(read_pvacseq, "tests/data/pvacseq/mhc_i_aggregated.tsv")
+    dna = [c for c in agg.columns if c.startswith(("n_dna_", "dna_"))]
+    assert dna == ["dna_vaf"]
+
+
+def test_no_dna_inputs_at_all_writes_no_dna_columns():
+    out = attach_dna_evidence(pd.DataFrame({"x": [1]}))
+    assert list(out.columns) == ["x"]
+
+
+def test_other_allele_column_is_omitted_not_nulled_when_ref_was_derived():
+    """A column of nulls would claim the locus was checked for third alleles."""
+    out = attach_rna_evidence(
+        pd.DataFrame({"x": [1]}),
+        overlapping=pd.Series([100]), vaf=pd.Series([0.4]),
+    )
+    assert "n_rna_other" not in out.columns
+
+
+def test_lens_gets_no_dna_columns_because_it_never_names_the_assay():
+    """LENS's single `vaf` could be either assay; guessing would be wrong."""
+    df = _read(read_lens, LENS)
+    assert not [c for c in df.columns if c.startswith(("n_dna_", "dna_"))]
+
+
+# ---------------------------------------------------------------------------
+# Other-allele support, and why it is usually absent
+# ---------------------------------------------------------------------------
+
+
+def test_other_allele_support_is_real_when_ref_was_counted():
+    out = attach_dna_evidence(
+        pd.DataFrame({"x": [1]}),
+        depth=pd.Series([100]), alt=pd.Series([40]), ref=pd.Series([50]),
+    )
+    assert out["n_dna_other"].iloc[0] == 10
+
+
+def test_other_allele_support_is_absent_when_ref_was_derived_from_depth():
+    """A derived ref already absorbs third alleles; 0 would be a lie."""
+    out = attach_dna_evidence(
+        pd.DataFrame({"x": [1]}), depth=pd.Series([100]), vaf=pd.Series([0.4]),
+    )
+    assert out["n_dna_ref"].iloc[0] == 60
+    assert "n_dna_other" not in out.columns
+
+
+def test_counts_that_do_not_add_up_clip_at_zero_rather_than_go_negative():
+    got = other_allele_count(
+        pd.Series([100]), pd.Series([80]), pd.Series([70]),
+    )
+    assert got.iloc[0] == 0
+
+
+def test_a_fragment_reports_other_allele_support_in_its_preferred_unit():
+    both = ProteinFragment(
+        fragment_id="f", sequence="MKTVRQ",
+        n_other_fragments=10, n_other_reads=19,
+    )
+    assert both.n_rna_other == 10
+
+    reads_only = ProteinFragment(
+        fragment_id="f", sequence="MKTVRQ", n_other_reads=4,
+    )
+    assert reads_only.n_rna_other == 4
+
+    assert ProteinFragment(
+        fragment_id="f", sequence="MKTVRQ",
+    ).n_rna_other is None
+
+
+# ---------------------------------------------------------------------------
+# Source attribution
+# ---------------------------------------------------------------------------
+
+
+def test_each_tools_own_numbers_carry_that_tools_name():
+    lens = _read(read_lens, LENS)
+    pvac = _read(read_pvacseq, PVAC_ALL)
+
+    assert "lens_vaf" in lens.columns and "vaf" not in lens.columns
+    assert "pvacseq_tumor_dna_vaf" in pvac.columns
+    assert "tumor_dna_vaf" not in pvac.columns
+
+
+def test_two_tools_vafs_coexist_and_stay_attributable_in_one_frame():
+    """The defect this prevents: an unattributable bare `vaf` column."""
+    lens = _read(read_lens, LENS).head(2)
+    pvac = _read(read_pvacseq, PVAC_ALL).head(2)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        merged = stack_results(
+            [TopiaryResult(lens), TopiaryResult(pvac)],
+        ).df
+
+    present = source_columns(merged)
+    assert "lens_vaf" in present
+    assert "pvacseq_tumor_rna_vaf" in present
+    # And each is answerable per tool.
+    assert source_columns(merged, "lens") == tuple(
+        c for c in present if c.startswith("lens_")
+    )
+
+
+def test_an_unknown_source_is_refused_rather_than_given_a_guessed_prefix():
+    with pytest.raises(ValueError, match="unknown source"):
+        source_column("nonesuch", "vaf")
+    with pytest.raises(ValueError, match="unknown source"):
+        source_columns(pd.DataFrame(), "nonesuch")
+
+
+def test_every_known_prefix_ends_in_an_underscore():
+    """Otherwise `lensvaf` and a real column could collide."""
+    for name, prefix in SOURCE_PREFIXES.items():
+        assert prefix == f"{name}_"
+
+
+# ---------------------------------------------------------------------------
+# Canonical VAF
+# ---------------------------------------------------------------------------
+
+
+def test_the_canonical_vaf_prefers_the_number_the_source_stated():
+    out = attach_rna_evidence(
+        pd.DataFrame({"x": [1]}),
+        overlapping=pd.Series([100]), vaf=pd.Series([0.37]),
+    )
+    assert out["rna_vaf"].iloc[0] == pytest.approx(0.37)
+    # Not the rounded round-trip through the integer counts.
+    assert out["n_rna_alt"].iloc[0] == 37
+
+
+def test_the_canonical_vaf_is_absent_when_nothing_supports_it():
+    out = attach_rna_evidence(pd.DataFrame({"x": [1]}))
+    assert pd.isna(out["rna_vaf"].iloc[0])
+
+
+# ---------------------------------------------------------------------------
+# The cache key, now public
+# ---------------------------------------------------------------------------
+
+
+def test_the_cache_key_is_public_and_names_the_genotype_column():
+    assert "allele_set" in PREDICTION_KEY_COLUMNS
+    assert "sample_name" not in PREDICTION_KEY_COLUMNS
+
+
+def test_the_concat_overlap_error_names_the_key_it_actually_used():
+    """It used to name a stale 4-tuple, so the message misled."""
+    from topiary import CachedPredictor
+
+    row = pd.DataFrame([dict(
+        peptide="SIINFEKLA", peptide_length=9, allele="HLA-A*02:01",
+        kind="pMHC_affinity", value=0.5, score=0.5, percentile_rank=1.0,
+        prediction_method_name="netmhcpan", predictor_version="4.1",
+    )])
+    with pytest.raises(ValueError) as excinfo:
+        CachedPredictor.concat(
+            [CachedPredictor(row), CachedPredictor(row)],
+        )
+    for column in PREDICTION_KEY_COLUMNS:
+        assert column in str(excinfo.value)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -81,7 +81,11 @@ from .sequence_helpers import (
     contains_mutant_residues,
     protein_subsequences_around_mutations,
 )
-from .cached import CachedPredictor, mhcflurry_composite_version
+from .cached import (
+    CachedPredictor,
+    PREDICTION_KEY_COLUMNS,
+    mhcflurry_composite_version,
+)
 from .io_isovar import (
     DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     fragment_from_isovar_result,
@@ -109,7 +113,7 @@ from .io_pvacseq import (
     melt_pvacseq_algorithms,
     read_pvacseq,
 )
-from .rna_evidence import (
+from .evidence import (
     CDS_OVERLAP_READS,
     READ_COUNT_METHODS,
     RNA_DEPTH_X_SOURCE_VAF,
@@ -122,13 +126,22 @@ from .rna_evidence import (
     READ_SUBJECTS,
     SOURCE_REPORTED,
     TPM_X_DNA_VAF,
-    attach_read_evidence,
+    attach_dna_evidence,
+    attach_rna_evidence,
     attach_sequence_source,
     describe_read_evidence,
     provenance_for_method,
+    DNA_ALIGNMENT,
+    DNA_DEPTH_X_VAF,
+    DNA_EVIDENCE_COLUMNS,
     EVIDENCE_COLUMNS,
+    RNA_EVIDENCE_COLUMNS,
+    SOURCE_PREFIXES,
     attach_rna_evidence_columns,
     available_evidence_columns,
+    other_allele_count,
+    source_column,
+    source_columns,
     split_reads_by_vaf,
 )
 from .result import (
@@ -138,7 +151,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.46.0"
+__version__ = "5.47.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -264,10 +277,20 @@ __all__ = [
     "EVIDENCE_COLUMNS",
     "READ_COUNT_METHODS",
     "SEQUENCE_SOURCES",
-    "attach_read_evidence",
+    "attach_rna_evidence",
     "attach_sequence_source",
     "describe_read_evidence",
     "provenance_for_method",
+    "attach_dna_evidence",
+    "other_allele_count",
+    "source_column",
+    "source_columns",
+    "SOURCE_PREFIXES",
+    "PREDICTION_KEY_COLUMNS",
+    "RNA_EVIDENCE_COLUMNS",
+    "DNA_EVIDENCE_COLUMNS",
+    "DNA_ALIGNMENT",
+    "DNA_DEPTH_X_VAF",
     "split_reads_by_vaf",
     "TopiaryResult",
     "stack_results",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -91,10 +91,20 @@ _CACHE_COLUMNS = (
 # kind, flanks, genotype) is the same prediction whichever protein or
 # sample it came from.  Keying on them would defeat the cache — the
 # same peptide would be re-predicted once per source protein.
-_KEY_COLS = (
+#: The columns that decide whether two rows are the same prediction.
+#:
+#: Public because it is a decision a consumer has to agree with rather
+#: than guess at: anyone building a cache table, de-duplicating one, or
+#: checking whether two shards overlap needs the same answer topiary
+#: uses, and a private copy of this tuple is a copy that drifts.
+#:
+#: The reasoning for each column, and for the three deliberately left
+#: out, is in the comment block above.
+PREDICTION_KEY_COLUMNS = (
     "peptide", "allele", "peptide_length", "kind",
     "n_flank", "c_flank", "allele_set",
 )
+
 
 
 class CachedPredictor:
@@ -1033,7 +1043,7 @@ class CachedPredictor:
         combined = pd.concat(
             [c._df for c in caches], ignore_index=True,
         )
-        key_cols = list(_KEY_COLS)
+        key_cols = list(PREDICTION_KEY_COLUMNS)
 
         dup_mask = combined.duplicated(subset=key_cols, keep=False)
         if dup_mask.any():
@@ -1056,7 +1066,7 @@ class CachedPredictor:
                 f" (and {len(dupes) - 5} more)"
             raise ValueError(
                 f"CachedPredictor.concat: {len(dupes)} overlapping "
-                f"(peptide, allele, peptide_length, kind) key(s) across "
+                f"{tuple(key_cols)} key(s) across "
                 f"shards.  Sample: {sample}{extra}.  Pass "
                 f"on_overlap='last' / 'first' / callable to resolve."
             )

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -1,4 +1,4 @@
-"""RNA read-level evidence, and saying where each number came from.
+"""Read-level DNA and RNA evidence, and saying where each number came from.
 
 Readers report RNA support differently, and the difference matters. isovar
 counts reads supporting an assembled protein sequence. pVACseq reports a
@@ -25,6 +25,22 @@ transcribed equally, so a variant on a transcriptionally silenced allele
 looks expressed. That error is exactly the phenomenon allele-specific
 counting exists to detect, which is why the estimate is labelled rather
 than silently mixed in with measured values.
+
+DNA support is carried in the same shape under a ``dna_`` prefix
+(:func:`attach_dna_evidence`), so a caller writing a depth threshold writes
+it the same way for either assay and can always tell which one it got.
+
+Three layers of column, and which to reach for:
+
+1. **Canonical cross-source** — ``n_rna_alt``, ``rna_vaf``, ``n_dna_alt``,
+   ``dna_vaf`` and friends. Same meaning from every reader. Write
+   filters against these.
+2. **Canonical unit-specific** — ``n_alt_reads`` / ``n_alt_fragments``.
+   Same meaning everywhere, present only where a source reports both
+   units and they genuinely differ.
+3. **Source-prefixed originals** — ``lens_vaf``, ``pvacseq_tumor_dna_depth``.
+   Exactly the number the tool printed, never reinterpreted. See
+   :data:`SOURCE_PREFIXES`.
 
 ``None`` throughout means the source could not answer, which is not the
 same as answering zero.
@@ -70,6 +86,18 @@ TPM_X_DNA_VAF = "tpm_x_dna_vaf"
 #: nobody stated.
 RNA_DEPTH_X_SOURCE_VAF = "rna_depth_x_source_vaf"
 
+#: DNA depth x DNA VAF, rounded — arithmetic, not counted.
+#:
+#: The DNA twin of :data:`RNA_DEPTH_X_VAF`. Kept as a separate term
+#: rather than reusing the RNA one so that a row naming its derivation
+#: also names its assay: a caller reading ``rna_depth_x_vaf`` in a
+#: ``dna_evidence_method`` column would have no way to tell a mislabelled
+#: frame from a correct one.
+DNA_DEPTH_X_VAF = "dna_depth_x_vaf"
+
+#: Counted directly from a DNA alignment, in whichever unit it reported.
+DNA_ALIGNMENT = "dna_alignment"
+
 #: Reported by the source, which did not say how it got there.
 #:
 #: pVACseq's aggregated report supplies its own ``Allele Expr``. Passing
@@ -79,9 +107,15 @@ RNA_DEPTH_X_SOURCE_VAF = "rna_depth_x_source_vaf"
 #: ``measured`` nor any of the arithmetic terms is true of it.
 SOURCE_REPORTED = "source_reported"
 
+#: Every named derivation, RNA and DNA alike.
+#:
+#: One set rather than one per assay: the question a caller asks is
+#: "is this a derivation topiary knows about", and a term is already
+#: self-identifying as to assay.
 READ_COUNT_METHODS = frozenset({
     RNA_ALIGNMENT, RNA_DEPTH_X_VAF, RNA_DEPTH_X_SOURCE_VAF,
     CDS_OVERLAP_READS, TPM_X_DNA_VAF, SOURCE_REPORTED,
+    DNA_ALIGNMENT, DNA_DEPTH_X_VAF,
 })
 
 #: How each derivation maps onto :data:`~topiary.PROVENANCE_VALUES`.
@@ -100,6 +134,8 @@ METHOD_PROVENANCE = MappingProxyType({
     # The source stands behind it, but did not say how it got there, so
     # it cannot be called measured.
     SOURCE_REPORTED: "approximated",
+    DNA_ALIGNMENT: "measured",
+    DNA_DEPTH_X_VAF: "approximated",
 })
 
 
@@ -160,7 +196,9 @@ READ_SUBJECTS = frozenset({FRAGMENTS, READS})
 #: counting reads or fragments, so the producer has to say.
 METHOD_SUBJECT = MappingProxyType({
     RNA_DEPTH_X_VAF: READS,
+    RNA_DEPTH_X_SOURCE_VAF: READS,
     CDS_OVERLAP_READS: READS,
+    DNA_DEPTH_X_VAF: READS,
 })
 
 
@@ -175,6 +213,7 @@ METHOD_SUBJECT = MappingProxyType({
 RNA_EVIDENCE_PREFERENCE = MappingProxyType({
     "n_rna_alt": ("n_alt_fragments", "n_alt_reads"),
     "n_rna_ref": ("n_ref_fragments", "n_ref_reads"),
+    "n_rna_other": ("n_other_fragments", "n_other_reads"),
     "n_rna_overlapping": ("n_overlapping_fragments", "n_overlapping_reads"),
     "n_rna_supporting_protein_sequence": (
         "n_alt_fragments_supporting_protein_sequence",
@@ -297,6 +336,64 @@ def _fractions(values) -> pd.Series:
     return numeric.where((numeric >= 0) & (numeric <= 1))
 
 
+def _vaf_from(stated, alt, depth, index):
+    """The canonical variant allele fraction for one assay.
+
+    Prefers the fraction the source stated over one recomputed from the
+    counts. They agree to rounding where topiary derived the counts *from*
+    the fraction, and where it did not, the source's own number is the
+    one it stands behind.
+
+    Absent wherever neither a stated fraction nor a usable alt/depth pair
+    exists, so "no variant reads" and "nobody measured" stay apart.
+    """
+    if stated is not None:
+        fraction = _fractions(stated)
+        fraction.index = index
+        if fraction.notna().any():
+            return fraction
+    if alt is None or depth is None:
+        return pd.Series([np.nan] * len(index), index=index, dtype="float64")
+    counts, total = _counts(alt), _counts(depth)
+    counts.index, total.index = index, index
+    usable = counts.notna() & total.notna() & (total > 0)
+    return (
+        counts.astype("Float64") / total.astype("Float64")
+    ).where(usable).astype("float64")
+
+
+def other_allele_count(overlapping, alt, ref):
+    """Reads at the locus supporting neither the reference nor the alt allele.
+
+    A third allele, a sequencing error, or a nearby indel all land here.
+    Worth seeing separately: a variant with 40 alt, 10 ref and 50 "other"
+    reads is a messy locus, and a caller weighting by depth of support
+    should be able to tell it from a clean 40/60.
+
+    Returns ``NA`` unless all three inputs are stated **and** *ref* was
+    counted independently. Where *ref* was derived as ``depth - alt`` it
+    already absorbs the other alleles, so the difference is
+    definitionally zero and reporting it would assert a clean locus
+    nobody checked.
+
+    Parameters
+    ----------
+    overlapping : pandas.Series
+        Total reads covering the position.
+    alt, ref : pandas.Series
+        Independently counted alt and reference support.
+
+    Returns
+    -------
+    pandas.Series
+        Nullable integer, clipped at zero — counts that do not add up
+        are a source's inconsistency, not a negative quantity.
+    """
+    total, a, r = _counts(overlapping), _counts(alt), _counts(ref)
+    usable = total.notna() & a.notna() & r.notna()
+    return (total - a - r).where(usable).clip(lower=0)
+
+
 def split_reads_by_vaf(depth, vaf):
     """``(n_alt_reads, n_ref_reads)`` from a depth and a variant fraction.
 
@@ -325,7 +422,7 @@ def split_reads_by_vaf(depth, vaf):
     return alt, ref.clip(lower=0)
 
 
-def attach_read_evidence(
+def attach_rna_evidence(
     df: pd.DataFrame,
     *,
     overlapping=None,
@@ -382,6 +479,11 @@ def attach_read_evidence(
         alt, ref, method = empty, empty, None
     out["n_rna_alt"] = alt
     out["n_rna_ref"] = ref
+    # No n_rna_other here by construction: ref came from depth - alt,
+    # which already absorbs any third allele. The column is omitted
+    # rather than written full of nulls — a source that counts ref
+    # independently gets a real one via other_allele_count.
+    out["rna_vaf"] = _vaf_from(vaf, alt, overlapping, out.index)
     out["rna_evidence_method"] = pd.Series(
         [method if method and pd.notna(a) else pd.NA for a in alt],
         index=out.index, dtype="object",
@@ -441,17 +543,231 @@ def attach_read_evidence(
     return out
 
 
-#: The evidence columns a reader emits when its source can answer.
-EVIDENCE_COLUMNS = (
+def attach_dna_evidence(
+    df: pd.DataFrame,
+    *,
+    depth=None,
+    vaf=None,
+    alt=None,
+    ref=None,
+    method=None,
+) -> pd.DataFrame:
+    """Write the DNA-evidence columns onto *df*, naming the derivation.
+
+    The DNA twin of :func:`attach_rna_evidence`, deliberately the same
+    shape: ``n_dna_alt`` / ``n_dna_ref`` / ``n_dna_overlapping`` /
+    ``dna_vaf`` / ``dna_evidence_subject`` / ``dna_evidence_method``.
+    A caller who has written a filter against RNA depth can write the
+    DNA one by changing three letters.
+
+    A source supplies either counts or a depth-and-fraction pair. Counts
+    are taken as measured; a depth x VAF split is arithmetic and is
+    labelled :data:`DNA_DEPTH_X_VAF` so it is never mistaken for one.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Frame to write onto. Not mutated; a copy is returned.
+    depth : pandas.Series, optional
+        Reads covering the variant position in the DNA alignment.
+    vaf : pandas.Series, optional
+        DNA variant allele fraction, used with *depth* to split alt from
+        reference when *alt* is not given directly.
+    alt, ref : pandas.Series, optional
+        Direct counts, when the source reports them rather than a
+        fraction. Take precedence over the *depth* x *vaf* split.
+    method : str, optional
+        Overrides the derivation name. Defaults to
+        :data:`DNA_ALIGNMENT` for direct counts and
+        :data:`DNA_DEPTH_X_VAF` for a split.
+
+    Returns
+    -------
+    pandas.DataFrame
+
+    Notes
+    -----
+    Nothing is invented. A source that reports no DNA at all — isovar,
+    and LENS, whose single ``vaf`` never names its assay — gets no DNA
+    columns rather than a column of nulls, so
+    :func:`available_evidence_columns` keeps meaning "what this source
+    could answer".
+    """
+    out = df.copy()
+    empty = pd.Series([pd.NA] * len(out), index=out.index, dtype="Int64")
+
+    if alt is not None:
+        counted_alt = _counts(alt)
+        counted_alt.index = out.index
+        if ref is not None:
+            counted_ref = _counts(ref)
+            counted_ref.index = out.index
+        elif depth is not None:
+            total = _counts(depth)
+            total.index = out.index
+            counted_ref = (total - counted_alt).clip(lower=0)
+        else:
+            counted_ref = empty
+        derivation = method or DNA_ALIGNMENT
+    elif depth is not None and vaf is not None:
+        counted_alt, counted_ref = split_reads_by_vaf(depth, vaf)
+        counted_alt.index, counted_ref.index = out.index, out.index
+        derivation = method or DNA_DEPTH_X_VAF
+    else:
+        counted_alt, counted_ref, derivation = empty, empty, None
+
+    if depth is not None:
+        overlapping = _counts(depth)
+        overlapping.index = out.index
+    else:
+        overlapping = empty
+
+    # Emit a column only where the source could answer it. A frame that
+    # carries `n_dna_alt` full of nulls says "measured nothing"; one that
+    # omits the column says "cannot measure this", and
+    # available_evidence_columns is only a useful signal if that
+    # distinction is kept at the column level as well as the value level.
+    if derivation is not None:
+        out["n_dna_alt"] = counted_alt
+        out["n_dna_ref"] = counted_ref
+        out["dna_evidence_method"] = pd.Series(
+            [derivation if pd.notna(a) else pd.NA for a in counted_alt],
+            index=out.index, dtype="object",
+        )
+        out["dna_evidence_subject"] = pd.Series(
+            [READS if pd.notna(a) else pd.NA for a in counted_alt],
+            index=out.index, dtype="object",
+        )
+    if depth is not None:
+        out["n_dna_overlapping"] = overlapping
+    if ref is not None:
+        out["n_dna_other"] = other_allele_count(
+            overlapping, counted_alt, counted_ref,
+        )
+    if vaf is not None or derivation is not None:
+        out["dna_vaf"] = _vaf_from(vaf, counted_alt, overlapping, out.index)
+    return out
+
+
+#: Tool name -> the prefix its own columns carry on a topiary frame.
+#:
+#: A canonical column such as ``rna_vaf`` means the same thing whichever
+#: reader produced it, because topiary derived it under a stated method.
+#: A tool's own columns do not have that guarantee: pVACseq's
+#: ``Tumor RNA VAF`` and LENS's ``vaf`` are both "a variant allele
+#: fraction" and are not the same quantity — LENS never says which assay
+#: its fraction is from. Landing both as a bare ``vaf`` would let a
+#: stacked frame silently answer with whichever tool happened to fill
+#: the column first.
+#:
+#: So a tool's own numbers keep the tool's name. ``lens_vaf`` and
+#: ``pvacseq_tumor_rna_vaf`` can coexist in one frame, disagree, and
+#: still be attributable; the unprefixed canonical columns are the ones
+#: to filter on.
+SOURCE_PREFIXES = MappingProxyType({
+    "isovar": "isovar_",
+    "lens": "lens_",
+    "pvacseq": "pvacseq_",
+})
+
+
+def source_column(source: str, name: str) -> str:
+    """The prefixed column name *source* uses for its own field *name*.
+
+    Parameters
+    ----------
+    source : str
+        A key of :data:`SOURCE_PREFIXES`.
+    name : str
+        The tool's own column name, already normalized to snake_case.
+
+    Returns
+    -------
+    str
+        e.g. ``source_column("lens", "vaf") == "lens_vaf"``.
+
+    Raises
+    ------
+    ValueError
+        If *source* is not a known tool. Guessing a prefix would let a
+        typo create a column nobody can find again.
+    """
+    if source not in SOURCE_PREFIXES:
+        raise ValueError(
+            f"source_column: unknown source {source!r}; expected one of "
+            f"{sorted(SOURCE_PREFIXES)}. Add it to SOURCE_PREFIXES "
+            f"rather than passing a prefix directly, so every reader "
+            f"spells the same tool the same way."
+        )
+    return f"{SOURCE_PREFIXES[source]}{name}"
+
+
+def source_columns(df: pd.DataFrame, source: str = None) -> tuple:
+    """The tool-specific columns present in *df*, in column order.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+    source : str, optional
+        Restrict to one tool. ``None`` (default) returns the columns of
+        every known tool, which is what you want to see which tools a
+        stacked frame is carrying evidence from.
+
+    Returns
+    -------
+    tuple of str
+
+    Notes
+    -----
+    Answers the question "what did each tool actually say", which is the
+    one you ask when two sources disagree on a canonical column.
+    """
+    if source is not None and source not in SOURCE_PREFIXES:
+        raise ValueError(
+            f"source_columns: unknown source {source!r}; expected one "
+            f"of {sorted(SOURCE_PREFIXES)}."
+        )
+    prefixes = (
+        (SOURCE_PREFIXES[source],) if source is not None
+        else tuple(SOURCE_PREFIXES.values())
+    )
+    return tuple(c for c in df.columns if c.startswith(prefixes))
+
+
+#: Canonical RNA columns, in the order a reader writes them.
+RNA_EVIDENCE_COLUMNS = (
     "n_rna_alt",
     "n_rna_ref",
     "n_rna_overlapping",
+    "n_rna_other",
+    "rna_vaf",
     "rna_evidence_subject",
     "rna_evidence_method",
     "rna_alt_expression",
     "rna_alt_expression_method",
     "gene_expression",
-    "sequence_source",
+)
+
+#: Canonical DNA columns — the same shape as
+#: :data:`RNA_EVIDENCE_COLUMNS`, minus the expression pair, which has no
+#: DNA meaning: abundance is a transcript property.
+DNA_EVIDENCE_COLUMNS = (
+    "n_dna_alt",
+    "n_dna_ref",
+    "n_dna_overlapping",
+    "n_dna_other",
+    "dna_vaf",
+    "dna_evidence_subject",
+    "dna_evidence_method",
+)
+
+#: The evidence columns a reader emits when its source can answer.
+#:
+#: The canonical layer only. A tool's own numbers are prefixed and found
+#: with :func:`source_columns`; the unit-specific ``n_alt_reads`` /
+#: ``n_alt_fragments`` pair appears only where a source reports both.
+EVIDENCE_COLUMNS = (
+    RNA_EVIDENCE_COLUMNS + DNA_EVIDENCE_COLUMNS + ("sequence_source",)
 )
 
 

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .protein_fragment import ProteinFragment
-from .rna_evidence import ISOVAR_ASSEMBLY, RNA_ALIGNMENT
+from .evidence import ISOVAR_ASSEMBLY, RNA_ALIGNMENT
 
 _MIN_ISOVAR = (1, 7, 2)
 _MIN_ISOVAR_TEXT = "1.7.2"

--- a/topiary/io_lens.py
+++ b/topiary/io_lens.py
@@ -39,10 +39,11 @@ from pathlib import Path
 import pandas as pd
 
 from .io import Metadata
-from .rna_evidence import (
+from .evidence import (
     LENS_PEP_CONTEXT,
     RNA_DEPTH_X_SOURCE_VAF,
-    attach_read_evidence,
+    attach_rna_evidence,
+    source_column,
     attach_sequence_source,
 )
 from .result import TopiaryResult
@@ -364,12 +365,27 @@ def read_lens(
     # DNA VAF, so it is not used to scale expression — doing so would
     # assert an assay nobody stated. LENS rows carried no expression
     # estimate anyway.
-    df = attach_read_evidence(
+    df = attach_rna_evidence(
         df,
         overlapping=df.get("rna_reads_covering_genomic_origin"),
         vaf=df.get("vaf"),
         vaf_method=RNA_DEPTH_X_SOURCE_VAF,
     )
+    # LENS's own numbers keep LENS's name. `vaf` especially: an
+    # unqualified fraction landing in a frame beside pVACseq's
+    # `pvacseq_tumor_rna_vaf` would be the one column a caller could not
+    # attribute. No DNA columns are written — LENS never says its
+    # fraction is from DNA, and asserting it would be a guess.
+    df = df.rename(columns={
+        name: source_column("lens", name)
+        for name in (
+            "vaf",
+            "rna_reads_covering_genomic_origin",
+            "rna_reads_covering_genomic_origin_with_peptide_cds",
+            "proportion_rna_reads_covering_genomic_origin_with_peptide_cds",
+        )
+        if name in df.columns
+    })
     df = attach_sequence_source(df, LENS_PEP_CONTEXT)
     df = _add_source_sequence_name(df)
     df["peptide_offset"] = 0

--- a/topiary/io_pvacseq.py
+++ b/topiary/io_pvacseq.py
@@ -55,9 +55,10 @@ import numpy as np
 import pandas as pd
 
 from .ranking import stated_values
-from .rna_evidence import (
+from .evidence import (
     PVACSEQ_EPITOPE,
-    attach_read_evidence,
+    attach_dna_evidence,
+    attach_rna_evidence,
     attach_sequence_source,
 )
 from .io import Metadata
@@ -211,9 +212,9 @@ _AGG_ANNOTATIONS = {
     # vocabularies depending on which flavour of its own format it was
     # given means no single filter works across two pVACseq files.
     "RNA Expr":                "transcript_expression",
-    "RNA VAF":                 "tumor_rna_vaf",
-    "RNA Depth":               "tumor_rna_depth",
-    "DNA VAF":                 "tumor_dna_vaf",
+    "RNA VAF":                 "pvacseq_tumor_rna_vaf",
+    "RNA Depth":               "pvacseq_tumor_rna_depth",
+    "DNA VAF":                 "pvacseq_tumor_dna_vaf",
     "Tier":                    "pvacseq_tier",
     "Num Passing Transcripts": "pvacseq_num_passing_transcripts",
     "Num Included Peptides":   "pvacseq_num_included_peptides",
@@ -234,12 +235,12 @@ _ALL_ANNOTATIONS = {
     "Transcript":            "transcript",
     "Gene Expression":       "gene_expression",
     "Transcript Expression": "transcript_expression",
-    "Tumor DNA Depth":       "tumor_dna_depth",
-    "Tumor DNA VAF":         "tumor_dna_vaf",
-    "Tumor RNA Depth":       "tumor_rna_depth",
-    "Tumor RNA VAF":         "tumor_rna_vaf",
-    "Normal Depth":          "normal_depth",
-    "Normal VAF":            "normal_vaf",
+    "Tumor DNA Depth":       "pvacseq_tumor_dna_depth",
+    "Tumor DNA VAF":         "pvacseq_tumor_dna_vaf",
+    "Tumor RNA Depth":       "pvacseq_tumor_rna_depth",
+    "Tumor RNA VAF":         "pvacseq_tumor_rna_vaf",
+    "Normal Depth":          "pvacseq_normal_depth",
+    "Normal VAF":            "pvacseq_normal_vaf",
     "Protein Position":      "protein_position",
     "HGVSc":                 "hgvsc",
     "HGVSp":                 "hgvsp",
@@ -472,7 +473,7 @@ def _parse_aggregated(df):
     # aggregated report supplies "Allele Expr" itself, so that value is
     # kept and labelled source_reported rather than being recomputed or
     # passed through unlabelled.
-    out = attach_read_evidence(
+    out = attach_rna_evidence(
         out,
         overlapping=df["RNA Depth"] if "RNA Depth" in df else None,
         vaf=df["RNA VAF"] if "RNA VAF" in df else None,
@@ -481,6 +482,11 @@ def _parse_aggregated(df):
         reported_rna_alt_expression=(
             df["Allele Expr"] if "Allele Expr" in df else None
         ),
+    )
+    # The aggregated report states a DNA VAF but no DNA depth, so the
+    # fraction is all topiary can carry: no depth means no alt/ref split.
+    out = attach_dna_evidence(
+        out, vaf=df["DNA VAF"] if "DNA VAF" in df else None,
     )
     return attach_sequence_source(out, PVACSEQ_EPITOPE)
 
@@ -523,8 +529,8 @@ def _parse_all_epitopes(df):
 
     # RNA read-level evidence. pVACseq reports a depth and a variant
     # allele fraction, so the alt/ref split is arithmetic rather than
-    # counted — attach_read_evidence names that on every row it derives.
-    out = attach_read_evidence(
+    # counted — attach_rna_evidence names that on every row it derives.
+    out = attach_rna_evidence(
         out,
         overlapping=df["Tumor RNA Depth"] if "Tumor RNA Depth" in df else None,
         vaf=df["Tumor RNA VAF"] if "Tumor RNA VAF" in df else None,
@@ -534,6 +540,13 @@ def _parse_all_epitopes(df):
             else df.get("Gene Expression")
         ),
         dna_vaf=df["Tumor DNA VAF"] if "Tumor DNA VAF" in df else None,
+    )
+    # all_epitopes states both a DNA depth and a DNA VAF, so the same
+    # depth x VAF arithmetic that produces n_rna_* produces n_dna_*.
+    out = attach_dna_evidence(
+        out,
+        depth=df["Tumor DNA Depth"] if "Tumor DNA Depth" in df else None,
+        vaf=df["Tumor DNA VAF"] if "Tumor DNA VAF" in df else None,
     )
     out = attach_sequence_source(out, PVACSEQ_EPITOPE)
 

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -36,7 +36,7 @@ from .io import _model_version_str
 from mhctools.pred import COLUMNS as _PRED_COLUMNS
 
 from .protein_fragment import ProteinFragment
-from .rna_evidence import VARCODE_TRANSLATION
+from .evidence import VARCODE_TRANSLATION
 from .sequence_helpers import (
     check_padding_around_mutation,
     peptide_mutation_interval,
@@ -1495,7 +1495,7 @@ class TopiaryPredictor(object):
         # column says what it holds; attach_rna_evidence_columns then
         # adds the n_rna_* columns a threshold should be written
         # against, preferring fragments where both exist.
-        from .rna_evidence import attach_rna_evidence_columns
+        from .evidence import attach_rna_evidence_columns
         for attr in (
             "n_overlapping_reads", "n_alt_reads", "n_ref_reads",
             "n_alt_reads_supporting_protein_sequence",

--- a/topiary/protein_fragment.py
+++ b/topiary/protein_fragment.py
@@ -92,10 +92,10 @@ class ProteinFragment:
         Ensembl id.
     gene_expression, transcript_expression : float, optional
         Expression evidence carried forward into prediction rows.
-    n_overlapping_reads, n_alt_reads, n_ref_reads, \
+    n_overlapping_reads, n_alt_reads, n_ref_reads, n_other_reads, \
 n_alt_reads_supporting_protein_sequence : int, optional
         RNA evidence counted in **reads**.
-    n_overlapping_fragments, n_alt_fragments, n_ref_fragments, \
+    n_overlapping_fragments, n_alt_fragments, n_ref_fragments, n_other_fragments, \
 n_alt_fragments_supporting_protein_sequence : int, optional
         The same evidence counted in **fragments**. A paired-end
         fragment is one molecule read twice, so it is one piece of
@@ -169,11 +169,13 @@ n_alt_fragments_supporting_protein_sequence : int, optional
     n_overlapping_reads: Optional[int] = None
     n_alt_reads: Optional[int] = None
     n_ref_reads: Optional[int] = None
+    n_other_reads: Optional[int] = None
     n_alt_reads_supporting_protein_sequence: Optional[int] = None
 
     n_overlapping_fragments: Optional[int] = None
     n_alt_fragments: Optional[int] = None
     n_ref_fragments: Optional[int] = None
+    n_other_fragments: Optional[int] = None
     n_alt_fragments_supporting_protein_sequence: Optional[int] = None
 
     field_provenance: dict = field(default_factory=dict)
@@ -275,6 +277,16 @@ n_alt_fragments_supporting_protein_sequence : int, optional
         return self._rna_evidence("ref")[0]
 
     @property
+    def n_rna_other(self) -> Optional[int]:
+        """Support for neither the reference nor the alt allele, or ``None``.
+
+        A third allele at the locus, a sequencing error, or a nearby
+        indel. ``None`` where the source counted only alt and depth, in
+        which case the reference count already absorbs these.
+        """
+        return self._rna_evidence("other")[0]
+
+    @property
     def n_rna_overlapping(self) -> Optional[int]:
         """RNA evidence covering the variant position."""
         return self._rna_evidence("overlapping")[0]
@@ -305,6 +317,7 @@ n_alt_fragments_supporting_protein_sequence : int, optional
     _RNA_FIELDS = {
         "alt": ("n_alt_fragments", "n_alt_reads"),
         "ref": ("n_ref_fragments", "n_ref_reads"),
+        "other": ("n_other_fragments", "n_other_reads"),
         "overlapping": ("n_overlapping_fragments", "n_overlapping_reads"),
         "supporting": (
             "n_alt_fragments_supporting_protein_sequence",
@@ -314,7 +327,7 @@ n_alt_fragments_supporting_protein_sequence : int, optional
 
     def _rna_evidence(self, name):
         """``(value, subject)`` — fragments if present, else reads."""
-        from .rna_evidence import FRAGMENTS, READS
+        from .evidence import FRAGMENTS, READS
 
         fragment_field, read_field = self._RNA_FIELDS[name]
         value = getattr(self, fragment_field, None)
@@ -691,7 +704,7 @@ def fragments_from_dataframe(df, *, sequence_column=None):
     Read counts carry the provenance their derivation implies —
     ``rna_reads`` is ``measured``, ``rna_depth_x_vaf`` and
     ``cds_overlap_reads`` are ``approximated`` — via one mapping in
-    :mod:`topiary.rna_evidence`, so a frame and a fragment cannot
+    :mod:`topiary.evidence`, so a frame and a fragment cannot
     disagree about whether a number was counted.
 
     Parameters
@@ -716,7 +729,7 @@ def fragments_from_dataframe(df, *, sequence_column=None):
     """
     import pandas as pd
 
-    from .rna_evidence import provenance_for_method
+    from .evidence import provenance_for_method
     from .ranking import is_stated
 
     if df is None or len(df) == 0:


### PR DESCRIPTION
Answers four asks about how evidence reaches vaxrank: make DNA symmetric with
RNA, add other-allele and total-coverage counts, prefix each tool's own
numbers, and make the cache key public under a readable name.

## Three layers of column

Filter against layer 1.

1. **Canonical cross-source** — `n_rna_alt`, `rna_vaf`, `n_dna_alt`, `dna_vaf`.
   Same meaning from every reader.
2. **Canonical unit-specific** — `n_alt_reads` / `n_alt_fragments`, present
   only where a source reports both units and they genuinely differ.
3. **Source-prefixed originals** — `lens_vaf`, `pvacseq_tumor_dna_vaf`, exactly
   as the tool printed them. Found with `source_columns(df)`.

## DNA, mirroring RNA

pVACseq carried `Tumor DNA Depth` and `Tumor DNA VAF` as raw passthroughs: no
derived counts, no method, no subject, while RNA had all three. The same
depth × VAF arithmetic now produces `n_dna_alt` / `n_dna_ref` /
`n_dna_overlapping` / `dna_vaf` / `dna_evidence_subject` /
`dna_evidence_method`. A filter written against RNA depth becomes the DNA one
by changing three letters.

No DNA expression pair — abundance is a transcript property.

LENS gets no DNA columns at all. Its single `vaf` never names its assay, so
populating `n_dna_*` from it would assert something nobody stated.

## Other-allele support

`n_rna_other` / `n_dna_other` count support belonging to neither allele: a
third allele, a sequencing error, a nearby indel. A variant with 40 alt, 10 ref
and 50 other reads is a messy locus and should be distinguishable from a clean
40/60.

**Absent unless the source counted ref independently.** Where topiary derived
`ref` as `depth - alt`, that figure already absorbs the other alleles, so a
difference of zero would assert a clean locus nobody checked.

## Absent vs empty, at the column level

A column is **omitted, not nulled**, where a source cannot answer it. pVACseq
aggregated states a DNA VAF but no DNA depth, so it gets `dna_vaf` and no
`n_dna_*`. An earlier draft of this branch emitted six all-null DNA columns
there, which made `available_evidence_columns()` report a capability the
source lacks — the same absent-vs-empty defect class this codebase has been
working through, caught by checking the output rather than the tests.

| source | evidence columns | DNA |
|---|---|---|
| pVACseq all_epitopes | 16/18 | full set |
| pVACseq aggregated | 10/18 | `dna_vaf` only |
| LENS | 10/18 | none |

## Public cache key

`_KEY_COLS` → `PREDICTION_KEY_COLUMNS`. It encodes which columns make two rows
the same prediction — a decision anyone building or de-duplicating a cache
table has to agree with rather than guess at, carrying 20 lines of rationale no
consumer could read from outside. Its `concat` error also named a stale
4-tuple; it now names the key it actually used.

## Multi-sample

Already works per row: `sample_name` is a first-class column and a DSL group
key, so a stacked multi-sample frame carries each sample's own counts and each
stays attributable. The cross-sample **aggregate** is filed as #247 rather than
guessed at — counts sum, fractions do not, and a partially-stated group needs a
decision about whether "not measured here" becomes "contributed zero".

## Renames, no compatibility shims

| old | new | why |
|---|---|---|
| `topiary.rna_evidence` | `topiary.evidence` | it defines DNA columns now |
| `attach_read_evidence` | `attach_rna_evidence` | symmetric with the DNA twin |
| `vaf` (LENS) | `lens_vaf` | unattributable beside another tool's VAF |
| `tumor_dna_vaf`, `normal_vaf`, … | `pvacseq_*` | same |

## Testing

2280 passed, 3 skipped. `tests/test_symmetric_evidence.py` adds 19 covering the
name-for-name symmetry, the omission rule, other-allele arithmetic clipping at
zero, two tools' VAFs coexisting attributably in one stacked frame, and the
concat error naming its real key.

Touches #231 (the error message) without closing it; the substantive half —
`concat` raising on identical rows while the constructor accepts contradictory
ones — stays open.

https://claude.ai/code/session_01BAUqjqDDPXaTdtUDJqapJG