### PR TITLE
Fix lazy mhctools model discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.48.1
+
+**Fixed lazy mhctools model-name discovery.** String model names now resolve
+through mhctools' public predictor registry, so lazily exported predictors such
+as `mhcflurry` work in a fresh process without first being imported by some
+unrelated caller. The regression test no longer skips when MHCflurry has not
+already been loaded, and the frameshift overlap grid now parameterizes only
+cases that contain a peptide window rather than reporting inapplicable cases as
+skips.
+
 ## 5.48.0
 
 **Made evidence units and absence explicit across every path.** RNA

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,6 +1,8 @@
 """Tests targeting coverage gaps found in the audit."""
 
 import os
+import subprocess
+import sys
 import tempfile
 
 import pandas as pd
@@ -91,18 +93,19 @@ def test_model_name_string_mixed_case():
 
 
 def test_model_name_string_mhcflurry():
-    """MHCflurry class can be resolved by string name.
+    """MHCflurry resolves in a fresh process without an eager import."""
+    code = """
+import sys
+from topiary.predictor import _build_model_lookup, _resolve_model_name
 
-    Skips when mhctools does not expose MHCflurry via getmembers (e.g. CI
-    environments without the mhcflurry package or its model downloads).
-    """
-    from topiary.predictor import _build_model_lookup, _resolve_model_name
-    lookup = _build_model_lookup()
-    if "mhcflurry" not in lookup:
-        pytest.skip("MHCflurry not discoverable in this mhctools install")
-    from mhctools import MHCflurry
-    cls = _resolve_model_name("mhcflurry")
-    assert cls is MHCflurry
+assert "mhctools.mhcflurry" not in sys.modules
+assert "mhcflurry" in _build_model_lookup()
+assert "mhctools.mhcflurry" not in sys.modules
+cls = _resolve_model_name("mhcflurry")
+from mhctools import MHCflurry
+assert cls is MHCflurry
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
 
 
 def test_model_name_string_list():

--- a/tests/test_frameshift_fragments.py
+++ b/tests/test_frameshift_fragments.py
@@ -232,14 +232,24 @@ class TestFrameShiftTargetInterval:
 
 
 # ---------------------------------------------------------------------------
-# Per-peptide overlaps_target: every 9-mer inside the shifted tail should
-# be marked as novel; 9-mers entirely upstream of the shift should not.
+# Per-peptide overlaps_target: every peptide touching the shifted tail should
+# be marked as novel; peptides entirely upstream of the shift should not.
 # ---------------------------------------------------------------------------
 
 
+_FRAMESHIFT_WINDOW_CASES = [
+    (shift_at, shifted_tail, padding, peptide_length)
+    for shift_at, shifted_tail, padding in _FRAMESHIFT_GRID
+    for peptide_length in (8, 9, 10, 11)
+    if min(shift_at, padding) + len(shifted_tail) >= peptide_length
+]
+
+
 class TestFrameShiftPerPeptideOverlap:
-    @pytest.mark.parametrize("shift_at,shifted_tail,padding", _FRAMESHIFT_GRID)
-    @pytest.mark.parametrize("peptide_length", [8, 9, 10, 11])
+    @pytest.mark.parametrize(
+        "shift_at,shifted_tail,padding,peptide_length",
+        _FRAMESHIFT_WINDOW_CASES,
+    )
     def test_every_peptide_touching_shift_is_novel(
         self, shift_at, shifted_tail, padding, peptide_length,
     ):
@@ -249,12 +259,6 @@ class TestFrameShiftPerPeptideOverlap:
         frag = fragment_from_effect(effect, padding_around_mutation=padding)
         seq_start = max(0, shift_at - padding)
         rel_shift = shift_at - seq_start
-
-        if len(frag.sequence) < peptide_length:
-            pytest.skip(
-                f"subsequence ({len(frag.sequence)} aa) smaller than "
-                f"peptide_length ({peptide_length}); no windows to enumerate"
-            )
 
         seen_novel, seen_reference = False, False
         for offset in range(0, len(frag.sequence) - peptide_length + 1):

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -156,7 +156,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.48.0"
+__version__ = "5.48.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -125,14 +125,25 @@ def _model_metadata_versions(models):
 
 
 def _build_model_lookup():
-    """Build a lowercase name → mhctools predictor class mapping."""
-    import inspect
-    import mhctools
+    """Build a normalized name → mhctools predictor factory mapping.
+
+    Use mhctools' public CLI registry rather than module introspection.  Some
+    heavyweight predictors are PEP 562 lazy exports, so they do not appear in
+    ``inspect.getmembers(mhctools)`` until another caller has already loaded
+    them.  The registry keeps those predictors lazy while still naming them.
+    """
+    from mhctools.cli import mhc_predictors
+
+    def normalized(name):
+        return name.lower().replace("-", "").replace("_", "").replace(" ", "")
 
     lookup = {}
-    for attr_name, obj in inspect.getmembers(mhctools):
-        if inspect.isclass(obj) and hasattr(obj, "predict_peptides_dataframe"):
-            lookup[attr_name.lower()] = obj
+    for registry_name, factory in mhc_predictors.items():
+        names = (registry_name, getattr(factory, "__name__", ""))
+        for name in names:
+            if name:
+                lookup[name.lower()] = factory
+                lookup[normalized(name)] = factory
     return lookup
 
 
@@ -150,14 +161,30 @@ def _resolve_model_name(name):
         _MODEL_LOOKUP = _build_model_lookup()
 
     key = name.lower().replace("-", "").replace("_", "").replace(" ", "")
-    cls = _MODEL_LOOKUP.get(key)
-    if cls is None:
-        cls = _MODEL_LOOKUP.get(name.lower())
-    if cls is None:
+    factory = _MODEL_LOOKUP.get(key)
+    if factory is None:
+        factory = _MODEL_LOOKUP.get(name.lower())
+    if factory is None:
         available = sorted(_MODEL_LOOKUP.keys())
         raise ValueError(
             f"Unknown model name {name!r}. Available: {available}"
         )
+
+    # mhctools represents heavyweight entries with lazy callable factories.
+    # Resolve only the selected factory through the corresponding public root
+    # export; building the lookup must not import every optional ML runtime.
+    if isinstance(factory, type):
+        cls = factory
+    else:
+        import mhctools
+
+        export_name = getattr(factory, "__name__", "")
+        cls = getattr(mhctools, export_name, None)
+    if not isinstance(cls, type) or not (
+        hasattr(cls, "predict_dataframe")
+        or hasattr(cls, "predict_peptides_dataframe")
+    ):
+        raise ValueError(f"mhctools model {name!r} is not a peptide predictor")
     return cls
 
 
@@ -686,7 +713,7 @@ class TopiaryPredictor(object):
         """
         Parameters
         ----------
-        models : class, instance, or list
+        models : class, instance, str, or list
             Predictor model(s). Can be:
 
             - A model class or list of classes (requires ``alleles``)::
@@ -696,6 +723,13 @@ class TopiaryPredictor(object):
             - A model instance or list of instances::
 
                   TopiaryPredictor(models=NetMHCpan(alleles=["A0201"]))
+
+            - A case-insensitive mhctools registry name or list of names::
+
+                  TopiaryPredictor(
+                      models=["netmhcpan41", "mhcflurry"],
+                      alleles=["A0201"],
+                  )
 
         alleles : list of str, optional
             HLA alleles. When provided, model classes in ``models`` are


### PR DESCRIPTION
## Summary

- resolve string model names through the public mhctools CLI predictor registry
- keep heavyweight predictors lazy until the selected name is resolved
- replace the MHCflurry skip with a fresh-process import-order regression test
- parameterize the frameshift overlap test only over cases with real peptide windows
- bump Topiary to 5.48.1

## Root cause

mhctools 3.12.0 made MHCflurry and BigMHC PEP 562 lazy exports on 2026-04-12. Topiary model discovery used inspect.getmembers, which cannot see those exports until another caller accesses them. The result depended on import order. A test skip added later that day masked the broken fresh-process workflow.

## Verification

- ./lint.sh
- ./test.sh -rs: 2323 passed, 0 skipped
- real TopiaryPredictor models="mhcflurry" prediction: affinity, presentation, and antigen_processing emitted
- Vaxrank suite with Homebrew libraries visible to dyld: 1192 passed, 0 skipped

Closes #251