### PR TITLE
Add cross-sample evidence aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.49.0
+
+**Added strict cross-sample aggregation for canonical evidence.**
+`aggregate_evidence_across_samples` returns a separate pooled DataFrame while
+leaving each sample's evidence intact. Repeated prediction rows count once,
+complete canonical counts sum, and RNA/DNA VAFs are recomputed from pooled
+alternate and overlapping counts rather than averaged.
+
+Partial measurements stay absent instead of becoming zero. Samples must name
+the same evidence subject and derivation method before their counts can be
+combined, so reads cannot be mixed with fragments and measured counts cannot
+be flattened together with estimates. Expression remains per-sample, and the
+pooled result reports `n_samples` for each represented candidate identity.
+
 ## 5.48.1
 
 **Fixed lazy mhctools model-name discovery.** String model names now resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ complete canonical counts sum, and RNA/DNA VAFs are recomputed from pooled
 alternate and overlapping counts rather than averaged.
 
 Partial measurements stay absent instead of becoming zero. Samples must name
-the same evidence subject and derivation method before their counts can be
-combined, so reads cannot be mixed with fragments and measured counts cannot
-be flattened together with estimates. Expression remains per-sample, and the
-pooled result reports `n_samples` for each represented candidate identity.
+the same evidence subject before counts can be combined. Allele-support counts
+must also share a derivation method, so measured counts cannot be flattened
+together with estimates; coverage-only depths need no invented method.
+Expression remains per-sample, and the pooled result reports `n_samples` for
+each represented candidate identity.
+
+The test runner now probes pytest plugins and launches pytest with the same
+Python interpreter, avoiding false xdist detection across environments.
 
 ## 5.48.1
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,21 @@ internally. Fresh `TopiaryPredictor` DataFrame outputs may also be passed to
 `combine_predictions`; they are first wrapped as `TopiaryResult` objects and
 then validated with the same rules.
 
+### Cross-sample evidence
+
+`topiary.aggregate_evidence_across_samples(df, group_keys=None)` returns one
+pooled row per prediction identity while leaving the input's per-sample rows
+unchanged. It collapses repeated prediction rows within a sample before
+summing canonical RNA and DNA counts, recomputes VAF from pooled alternate and
+overlapping counts, and reports the number of represented samples as
+`n_samples`.
+
+A count is omitted unless every represented sample states it. Poolable counts
+must also share an evidence subject and derivation method across samples;
+incompatible units or methods raise rather than being mixed. Expression is not
+aggregated. By default the standard Topiary prediction identity is inferred,
+or callers can supply explicit `group_keys` (excluding `sample_name`).
+
 ## CachedPredictor
 
 Drop-in replacement for a live predictor that serves scores from a

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,9 @@ A count is omitted unless every represented sample states it. Poolable counts
 must also share an evidence subject and derivation method across samples;
 incompatible units or methods raise rather than being mixed. Expression is not
 aggregated. By default the standard Topiary prediction identity is inferred,
-or callers can supply explicit `group_keys` (excluding `sample_name`).
+or callers can supply explicit `group_keys`. These exclude `sample_name` and
+the canonical counts/VAFs, which are aggregation values rather than candidate
+identity.
 
 ## CachedPredictor
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,11 +70,12 @@ overlapping counts, and reports the number of represented samples as
 `n_samples`.
 
 A count is omitted unless every represented sample states it. Poolable counts
-must also share an evidence subject and derivation method across samples;
-incompatible units or methods raise rather than being mixed. Expression is not
-aggregated. By default the standard Topiary prediction identity is inferred,
-or callers can supply explicit `group_keys`. These exclude `sample_name` and
-the canonical counts/VAFs, which are aggregation values rather than candidate
+must share an evidence subject across samples; allele-support counts must also
+share a derivation method. Coverage-only depths need no invented method.
+Incompatible units or methods raise rather than being mixed. Expression is not
+aggregated. By default the standard Topiary candidate identity is inferred, or
+callers can supply explicit `group_keys`. These exclude `sample_name` and the
+canonical counts/VAFs, which are aggregation values rather than candidate
 identity.
 
 ## CachedPredictor

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -1,7 +1,7 @@
 # Consumer guide
 
-What topiary offers a downstream consumer, as of **5.45.0**, and what changed
-across 5.28.2–5.45.0.
+What topiary offers a downstream consumer, as of **5.49.0**, and what changed
+across 5.28.2–5.49.0.
 
 Written for vaxrank, but nothing here is vaxrank-specific.
 
@@ -165,9 +165,25 @@ merged = stack_results([per_sample_result(name) for name in samples])
 merged.df[["sample_name", "n_rna_alt", "n_rna_overlapping", "rna_vaf"]]
 ```
 
-**There is no built-in cross-sample aggregate yet** — summing counts across
-samples is currently a `groupby` you write yourself. Tracked in
-[#247](https://github.com/openvax/topiary/issues/247).
+Build a separate pooled view with the same canonical count names:
+
+```python
+pooled = aggregate_evidence_across_samples(merged.df)
+pooled[["n_samples", "n_rna_alt", "n_rna_overlapping", "rna_vaf"]]
+```
+
+The original frame is unchanged, so both the per-sample and pooled answers stay
+available. Repeated prediction rows within one sample count once. Counts are
+summed only when every represented sample states them; an unmeasured sample is
+not silently converted to zero. VAF is recomputed as pooled alternate count /
+pooled overlapping count, never averaged across samples.
+
+Pooling also requires the samples to agree on evidence subject and method. A
+read count cannot be added to a fragment count, and a measured count cannot be
+flattened together with a derived estimate. Expression remains per-sample
+because it has no generally valid cross-sample sum. `n_samples` records how many
+samples actually contain rows for each candidate; a candidate absent from a
+sample is not treated as a zero-observation row.
 
 ---
 

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -178,12 +178,13 @@ summed only when every represented sample states them; an unmeasured sample is
 not silently converted to zero. VAF is recomputed as pooled alternate count /
 pooled overlapping count, never averaged across samples.
 
-Pooling also requires the samples to agree on evidence subject and method. A
-read count cannot be added to a fragment count, and a measured count cannot be
-flattened together with a derived estimate. Expression remains per-sample
-because it has no generally valid cross-sample sum. `n_samples` records how many
-samples actually contain rows for each candidate; a candidate absent from a
-sample is not treated as a zero-observation row.
+Pooling also requires the samples to agree on evidence subject. Allele-support
+counts must agree on method as well: a read count cannot be added to a fragment
+count, and a measured count cannot be flattened together with a derived
+estimate. Coverage-only depths need no invented allele-derivation method.
+Expression remains per-sample because it has no generally valid cross-sample
+sum. `n_samples` records how many samples actually contain rows for each
+candidate; a candidate absent from a sample is not treated as a zero row.
 
 ---
 

--- a/test.sh
+++ b/test.sh
@@ -99,10 +99,10 @@ XDIST_FLAGS=()
 if python -c "import xdist" 2>/dev/null; then
     XDIST_FLAGS=(-n "$WORKERS")
     log "platform=${OS} cpus=${CPUS} cpu_cap=${CPU_CAP} ${mem_note} per_worker=${PER_WORKER_GB}GB"
-    log "workers=${WORKERS} → exec pytest -n ${WORKERS} --cov=topiary/ --cov-report=term-missing tests $*"
+    log "workers=${WORKERS} → exec python -m pytest -n ${WORKERS} --cov=topiary/ --cov-report=term-missing tests $*"
 else
     log "platform=${OS} cpus=${CPUS} (pytest-xdist not installed; running serial)"
-    log "→ exec pytest --cov=topiary/ --cov-report=term-missing tests $*"
+    log "→ exec python -m pytest --cov=topiary/ --cov-report=term-missing tests $*"
 fi
 
-exec pytest "${XDIST_FLAGS[@]}" --cov=topiary/ --cov-report=term-missing tests "$@"
+exec python -m pytest "${XDIST_FLAGS[@]}" --cov=topiary/ --cov-report=term-missing tests "$@"

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -19,6 +19,8 @@ import pytest
 
 from topiary import (
     EvalContext,
+    TopiaryResult,
+    aggregate_evidence_across_samples,
     apply_filter,
     apply_sort,
     describe_read_evidence,
@@ -30,6 +32,7 @@ from topiary import (
     read_pvacseq,
     resolve_default_methods,
     resolve_default_versions,
+    stack_results,
 )
 from topiary.ranking import parse
 
@@ -42,6 +45,46 @@ def _long(reader, path):
         warnings.simplefilter("ignore", UserWarning)
         result = reader(path)
         return result.to_long().df if result.metadata.form == "wide" else result.df
+
+
+# ---------------------------------------------------------------------------
+# Per-sample results, stacked and pooled without losing either view
+# ---------------------------------------------------------------------------
+
+
+def test_stacked_sample_evidence_can_be_pooled_as_a_separate_view():
+    def result(sample_name, alt, overlapping):
+        return TopiaryResult(pd.DataFrame([{
+            "fragment_id": "fragment-1",
+            "peptide": "SIINFEKL",
+            "peptide_offset": 3,
+            "allele": "HLA-A*02:01",
+            "sample_name": sample_name,
+            "kind": "pMHC_affinity",
+            "prediction_method_name": "netmhcpan",
+            "predictor_version": "4.1",
+            "value": 50.0,
+            "n_rna_alt": alt,
+            "n_rna_overlapping": overlapping,
+            "rna_vaf": alt / overlapping,
+            "rna_evidence_subject": "reads",
+            "rna_evidence_method": "rna_alignment",
+        }]))
+
+    stacked = stack_results([
+        result("tumor_pre", 40, 100),
+        result("tumor_post", 20, 80),
+    ])
+
+    pooled = aggregate_evidence_across_samples(stacked.df)
+
+    assert list(stacked.df["sample_name"]) == ["tumor_pre", "tumor_post"]
+    assert list(stacked.df["n_rna_alt"]) == [40, 20]
+    assert len(pooled) == 1
+    assert pooled.loc[0, "n_samples"] == 2
+    assert pooled.loc[0, "n_rna_alt"] == 60
+    assert pooled.loc[0, "n_rna_overlapping"] == 180
+    assert pooled.loc[0, "rna_vaf"] == pytest.approx(60 / 180)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -23,6 +23,8 @@ from topiary import (
     aggregate_evidence_across_samples,
     apply_filter,
     apply_sort,
+    attach_dna_evidence,
+    attach_rna_evidence,
     describe_read_evidence,
     evaluate_scores,
     fragment_from_isovar_result,
@@ -85,6 +87,43 @@ def test_stacked_sample_evidence_can_be_pooled_as_a_separate_view():
     assert pooled.loc[0, "n_rna_alt"] == 60
     assert pooled.loc[0, "n_rna_overlapping"] == 180
     assert pooled.loc[0, "rna_vaf"] == pytest.approx(60 / 180)
+
+
+@pytest.mark.parametrize(
+    ("attach", "argument", "assay"),
+    [
+        (attach_rna_evidence, "overlapping", "rna"),
+        (attach_dna_evidence, "depth", "dna"),
+    ],
+)
+def test_topiary_depth_only_evidence_can_be_stacked_and_pooled(
+    attach, argument, assay,
+):
+    """Both evidence writers compose with the cross-sample aggregator."""
+    base = pd.DataFrame([{
+        "fragment_id": "fragment-1",
+        "peptide": "SIINFEKL",
+        "peptide_offset": 3,
+        "allele": "HLA-A*02:01",
+        "kind": "pMHC_affinity",
+        "prediction_method_name": "netmhcpan",
+        "predictor_version": "4.1",
+        "value": 50.0,
+    }])
+
+    results = []
+    for sample_name, depth in (("tumor_pre", 50), ("tumor_post", 70)):
+        frame = attach(base, **{argument: pd.Series([depth])})
+        frame["sample_name"] = sample_name
+        results.append(TopiaryResult(frame))
+
+    stacked = stack_results(results)
+    pooled = aggregate_evidence_across_samples(stacked.df)
+
+    assert pooled.loc[0, "n_samples"] == 2
+    assert pooled.loc[0, f"n_{assay}_overlapping"] == 120
+    assert pooled.loc[0, f"{assay}_evidence_subject"] == "reads"
+    assert f"{assay}_evidence_method" not in pooled.columns
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -121,7 +121,23 @@ def test_repeated_prediction_rows_must_agree_within_a_sample():
         aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
 
 
-@pytest.mark.parametrize("value", [-1, 1.5, float("inf"), True, "many"])
+@pytest.mark.parametrize(
+    "values",
+    [(1, True), (True, 1), (0, False), (False, 0)],
+)
+def test_boolean_counts_cannot_hide_as_duplicate_integers(values):
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=value) for value in values
+    ])
+
+    with pytest.raises(ValueError, match="boolean values are not counts"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-1, 1.5, float("inf"), True, 1 + 2j, "many"],
+)
 def test_invalid_counts_are_rejected(value):
     df = pd.DataFrame([_row("pre", n_rna_alt=value)])
 
@@ -129,7 +145,10 @@ def test_invalid_counts_are_rejected(value):
         aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
 
 
-@pytest.mark.parametrize("value", [-1, 1.5, float("inf"), True, "many"])
+@pytest.mark.parametrize(
+    "value",
+    [-1, 1.5, float("inf"), True, 1 + 2j, "many"],
+)
 def test_invalid_stated_counts_are_rejected_even_when_pool_is_incomplete(value):
     df = pd.DataFrame([
         _row("pre", n_rna_alt=value),
@@ -204,3 +223,45 @@ def test_equivalent_missing_identity_spellings_pool_as_one_group():
     assert pd.isna(pooled.loc[0, "allele"])
     assert pooled.loc[0, "n_samples"] == 2
     assert pooled.loc[0, "n_rna_alt"] == 40
+
+
+def test_evidence_column_used_as_group_key_appears_once():
+    df = pd.DataFrame([
+        _row("pre", sequence_source="rna"),
+        _row("post", sequence_source="rna"),
+    ])
+
+    pooled = aggregate_evidence_across_samples(
+        df,
+        group_keys=[*GROUP_KEYS, "sequence_source"],
+    )
+
+    assert pooled.columns.is_unique
+    assert pooled.loc[0, "sequence_source"] == "rna"
+    assert pooled.loc[0, "n_rna_alt"] == 40
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["n_rna_alt", "n_rna_overlapping", "rna_vaf", "dna_vaf"],
+)
+def test_aggregate_values_cannot_be_used_as_group_keys(column):
+    df = pd.DataFrame([_row("pre"), _row("post")])
+
+    with pytest.raises(ValueError, match="not canonical counts or VAFs"):
+        aggregate_evidence_across_samples(
+            df,
+            group_keys=[*GROUP_KEYS, column],
+        )
+
+
+def test_large_integer_counts_are_summed_exactly():
+    count = 2 ** 60 + 1
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=count),
+        _row("post", n_rna_alt=count),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_alt"] == 2 * count

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -82,6 +82,17 @@ def test_counts_are_summed_once_per_sample_and_vafs_are_recomputed():
     assert "rna_alt_expression" not in pooled.columns
 
 
+def test_native_protein_sequence_support_is_pooled():
+    df = pd.DataFrame([
+        _row("pre", n_rna_supporting_protein_sequence=7),
+        _row("post", n_rna_supporting_protein_sequence=5),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_supporting_protein_sequence"] == 12
+
+
 def test_partial_counts_stay_absent_instead_of_becoming_zero():
     df = pd.DataFrame([
         _row("pre"),
@@ -196,6 +207,8 @@ def test_group_keys_are_validated_and_must_exclude_sample_name():
         )
     with pytest.raises(ValueError, match="missing_key"):
         aggregate_evidence_across_samples(df, group_keys=["missing_key"])
+    with pytest.raises(ValueError, match="not canonical counts or VAFs"):
+        aggregate_evidence_across_samples(df, group_keys=["n_rna_alt"])
 
 
 def test_one_tuple_valued_group_key_remains_one_identity_value():

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -129,6 +129,17 @@ def test_invalid_counts_are_rejected(value):
         aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
 
 
+@pytest.mark.parametrize("value", [-1, 1.5, float("inf"), True, "many"])
+def test_invalid_stated_counts_are_rejected_even_when_pool_is_incomplete(value):
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=value),
+        _row("post", n_rna_alt=pd.NA),
+    ])
+
+    with pytest.raises(ValueError, match="n_rna_alt"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
 @pytest.mark.parametrize("sample_name", [None, "", " ", "nan"])
 def test_every_row_needs_a_real_sample_name(sample_name):
     df = pd.DataFrame([_row(sample_name)])
@@ -178,4 +189,18 @@ def test_one_tuple_valued_group_key_remains_one_identity_value():
     pooled = aggregate_evidence_across_samples(df, group_keys=["variant"])
 
     assert pooled.loc[0, "variant"] == variant
+    assert pooled.loc[0, "n_rna_alt"] == 40
+
+
+def test_equivalent_missing_identity_spellings_pool_as_one_group():
+    df = pd.DataFrame([
+        _row("pre", allele=None),
+        _row("post", allele="nan"),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert len(pooled) == 1
+    assert pd.isna(pooled.loc[0, "allele"])
+    assert pooled.loc[0, "n_samples"] == 2
     assert pooled.loc[0, "n_rna_alt"] == 40

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -1,0 +1,181 @@
+"""Cross-sample aggregation of canonical evidence columns."""
+
+import pandas as pd
+import pytest
+
+from topiary import aggregate_evidence_across_samples
+
+
+GROUP_KEYS = ["fragment_id", "peptide", "peptide_offset", "allele"]
+
+
+def _row(sample_name, **overrides):
+    row = {
+        "fragment_id": "fragment-1",
+        "peptide": "SIINFEKL",
+        "peptide_offset": 3,
+        "allele": "HLA-A*02:01",
+        "sample_name": sample_name,
+        "prediction_method_name": "netmhcpan",
+        "kind": "pMHC_affinity",
+        "n_rna_alt": 20,
+        "n_rna_ref": 80,
+        "n_rna_overlapping": 100,
+        "rna_vaf": 0.2,
+        "rna_evidence_subject": "reads",
+        "rna_evidence_method": "rna_alignment",
+        "rna_alt_expression": 7.5,
+        "n_dna_alt": 3,
+        "n_dna_overlapping": 10,
+        "dna_vaf": 0.3,
+        "dna_evidence_subject": "reads",
+        "dna_evidence_method": "dna_alignment",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_counts_are_summed_once_per_sample_and_vafs_are_recomputed():
+    rows = []
+    for sample_name, values in (
+        ("pre", {"n_rna_alt": 20, "n_rna_ref": 80,
+                 "n_rna_overlapping": 100, "rna_vaf": 0.2,
+                 "n_dna_alt": 3, "n_dna_overlapping": 10,
+                 "dna_vaf": 0.3}),
+        ("post", {"n_rna_alt": 20, "n_rna_ref": 30,
+                  "n_rna_overlapping": 50, "rna_vaf": 0.4,
+                  "n_dna_alt": 1, "n_dna_overlapping": 10,
+                  "dna_vaf": 0.1}),
+    ):
+        for method, kind in (
+            ("netmhcpan", "pMHC_affinity"),
+            ("mhcflurry", "pMHC_presentation"),
+        ):
+            rows.append(_row(
+                sample_name,
+                prediction_method_name=method,
+                kind=kind,
+                **values,
+            ))
+    df = pd.DataFrame(rows)
+    original = df.copy(deep=True)
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    pd.testing.assert_frame_equal(df, original)
+    assert len(pooled) == 1
+    row = pooled.iloc[0]
+    assert row["n_samples"] == 2
+    assert row["n_rna_alt"] == 40
+    assert row["n_rna_ref"] == 110
+    assert row["n_rna_overlapping"] == 150
+    assert row["rna_vaf"] == pytest.approx(40 / 150)
+    assert row["rna_vaf"] != pytest.approx((0.2 + 0.4) / 2)
+    assert row["n_dna_alt"] == 4
+    assert row["n_dna_overlapping"] == 20
+    assert row["dna_vaf"] == pytest.approx(4 / 20)
+    assert row["rna_evidence_subject"] == "reads"
+    assert row["rna_evidence_method"] == "rna_alignment"
+    assert row["dna_evidence_subject"] == "reads"
+    assert row["dna_evidence_method"] == "dna_alignment"
+    assert "sample_name" not in pooled.columns
+    assert "rna_alt_expression" not in pooled.columns
+
+
+def test_partial_counts_stay_absent_instead_of_becoming_zero():
+    df = pd.DataFrame([
+        _row("pre"),
+        _row("post", n_rna_alt=pd.NA, n_rna_ref=30,
+             n_rna_overlapping=50),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert "n_rna_alt" not in pooled.columns
+    assert "rna_vaf" not in pooled.columns
+    assert pooled.loc[0, "n_rna_ref"] == 110
+    assert pooled.loc[0, "n_rna_overlapping"] == 150
+
+
+@pytest.mark.parametrize(
+    ("column", "second_value", "message"),
+    [
+        ("rna_evidence_subject", "fragments", "different.*subject"),
+        ("rna_evidence_method", "rna_depth_x_vaf", "different.*method"),
+    ],
+)
+def test_incompatible_evidence_is_not_flattened(column, second_value, message):
+    df = pd.DataFrame([_row("pre"), _row("post", **{column: second_value})])
+
+    with pytest.raises(ValueError, match=message):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+def test_repeated_prediction_rows_must_agree_within_a_sample():
+    df = pd.DataFrame([
+        _row("pre"),
+        _row("pre", prediction_method_name="mhcflurry", n_rna_alt=21),
+    ])
+
+    with pytest.raises(ValueError, match="Contradictory 'n_rna_alt'.*pre"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+@pytest.mark.parametrize("value", [-1, 1.5, float("inf"), True, "many"])
+def test_invalid_counts_are_rejected(value):
+    df = pd.DataFrame([_row("pre", n_rna_alt=value)])
+
+    with pytest.raises(ValueError, match="n_rna_alt"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+@pytest.mark.parametrize("sample_name", [None, "", " ", "nan"])
+def test_every_row_needs_a_real_sample_name(sample_name):
+    df = pd.DataFrame([_row(sample_name)])
+
+    with pytest.raises(ValueError, match="every row.*sample_name"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+def test_missing_assay_metadata_is_rejected_when_a_count_can_be_pooled():
+    df = pd.DataFrame([_row("pre")]).drop(columns="rna_evidence_method")
+
+    with pytest.raises(ValueError, match="must state 'rna_evidence_method'"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+def test_zero_depth_does_not_invent_a_vaf():
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=0, n_rna_ref=0, n_rna_overlapping=0),
+        _row("post", n_rna_alt=0, n_rna_ref=0, n_rna_overlapping=0),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_overlapping"] == 0
+    assert "rna_vaf" not in pooled.columns
+
+
+def test_group_keys_are_validated_and_must_exclude_sample_name():
+    df = pd.DataFrame([_row("pre")])
+
+    with pytest.raises(ValueError, match="exclude 'sample_name'"):
+        aggregate_evidence_across_samples(
+            df,
+            group_keys=[*GROUP_KEYS, "sample_name"],
+        )
+    with pytest.raises(ValueError, match="missing_key"):
+        aggregate_evidence_across_samples(df, group_keys=["missing_key"])
+
+
+def test_one_tuple_valued_group_key_remains_one_identity_value():
+    variant = ("chr1", 101, "A", "T")
+    df = pd.DataFrame([
+        _row("pre", variant=variant),
+        _row("post", variant=variant),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=["variant"])
+
+    assert pooled.loc[0, "variant"] == variant
+    assert pooled.loc[0, "n_rna_alt"] == 40

--- a/tests/test_symmetric_evidence.py
+++ b/tests/test_symmetric_evidence.py
@@ -48,14 +48,15 @@ def test_the_dna_columns_mirror_the_rna_columns_name_for_name():
     expression_only = {
         "rna_alt_expression", "rna_alt_expression_method",
         "gene_expression", "transcript_expression",
+        "n_rna_supporting_protein_sequence",
     }
     rna_shape = {
         c.replace("rna", "", 1) for c in RNA_EVIDENCE_COLUMNS
         if c not in expression_only
     }
     dna_shape = {c.replace("dna", "", 1) for c in DNA_EVIDENCE_COLUMNS}
-    # Expression and abundance have no DNA meaning; everything else must
-    # exist on both sides.
+    # Expression, abundance, and assembled-protein support have no DNA
+    # meaning; everything else must exist on both sides.
     assert rna_shape == dna_shape
 
 

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -129,6 +129,7 @@ from .evidence import (
     READ_SUBJECTS,
     SOURCE_REPORTED,
     TPM_X_DNA_VAF,
+    aggregate_evidence_across_samples,
     attach_dna_evidence,
     attach_rna_evidence,
     attach_sequence_source,
@@ -156,7 +157,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.48.1"
+__version__ = "5.49.0"
 
 __all__ = [
     "TopiaryPredictor",
@@ -277,6 +278,7 @@ __all__ = [
     "FRAGMENTS",
     "READS",
     "READ_SUBJECTS",
+    "aggregate_evidence_across_samples",
     "attach_rna_evidence_columns",
     "available_evidence_columns",
     "EVIDENCE_COLUMNS",

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -940,6 +940,7 @@ RNA_EVIDENCE_COLUMNS = (
     "n_rna_ref",
     "n_rna_overlapping",
     "n_rna_other",
+    "n_rna_supporting_protein_sequence",
     "rna_vaf",
     "rna_evidence_subject",
     "rna_evidence_method",
@@ -950,8 +951,8 @@ RNA_EVIDENCE_COLUMNS = (
 )
 
 #: Canonical DNA columns — the same shape as
-#: :data:`RNA_EVIDENCE_COLUMNS`, minus expression and abundance, which have
-#: no DNA meaning.
+#: :data:`RNA_EVIDENCE_COLUMNS`, minus expression, abundance, and assembled
+#: protein-sequence support, which have no DNA meaning.
 DNA_EVIDENCE_COLUMNS = (
     "n_dna_alt",
     "n_dna_ref",
@@ -977,6 +978,7 @@ _COUNT_EVIDENCE_COLUMNS = (
     "n_rna_ref",
     "n_rna_overlapping",
     "n_rna_other",
+    "n_rna_supporting_protein_sequence",
     "n_dna_alt",
     "n_dna_ref",
     "n_dna_overlapping",
@@ -1072,7 +1074,13 @@ def _common_assay_metadata(group, assay, identity, pooled_counts):
     if not pooled_counts:
         return {}
     result = {}
-    for suffix in ("subject", "method"):
+    suffixes = ["subject"]
+    if any(
+        column != f"n_{assay}_overlapping"
+        for column in pooled_counts
+    ):
+        suffixes.append("method")
+    for suffix in suffixes:
         column = f"{assay}_evidence_{suffix}"
         if column not in group.columns or not stated_values(group[column]).all():
             raise ValueError(
@@ -1103,10 +1111,12 @@ def aggregate_evidence_across_samples(
     divided by pooled overlapping count; per-sample VAFs are never averaged.
 
     Assay counts can be pooled only when every represented sample names the
-    same evidence subject and derivation method. Mixing reads with fragments,
-    or measured counts with arithmetic estimates, raises instead of flattening
-    unlike quantities into one number. Expression is intentionally not pooled:
-    unlike read counts, it has no generally valid cross-sample sum.
+    same evidence subject. Allele-support counts must also share a derivation
+    method; coverage-only depths need no method because no allele split was
+    derived. Mixing reads with fragments, or measured counts with arithmetic
+    estimates, raises instead of flattening unlike quantities into one number.
+    Expression is intentionally not pooled: unlike read counts, it has no
+    generally valid cross-sample sum.
 
     The returned DataFrame is separate from *df*, whose per-sample values stay
     unchanged and available for sample-specific reporting and thresholds.

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -1019,19 +1019,21 @@ def _single_sample_evidence_rows(df, group_keys, evidence_columns):
 def _sum_complete_counts(group, column, identity):
     """Sum a count only when every represented sample states it."""
     values = group[column]
-    if not stated_values(values).all():
-        return pd.NA
-    if values.map(lambda value: isinstance(value, (bool, np.bool_))).any():
+    stated = stated_values(values)
+    stated_counts = values[stated]
+    if stated_counts.map(
+        lambda value: isinstance(value, (bool, np.bool_))
+    ).any():
         raise ValueError(
             f"Evidence count {column!r} must be a non-negative integer for "
             f"{identity}; boolean values are not counts."
         )
     try:
-        numeric = pd.to_numeric(values, errors="raise").astype(float)
+        numeric = pd.to_numeric(stated_counts, errors="raise").astype(float)
     except (TypeError, ValueError):
         raise ValueError(
             f"Evidence count {column!r} must be numeric for {identity}: "
-            f"{values.tolist()!r}."
+            f"{stated_counts.tolist()!r}."
         ) from None
     if (
         not np.isfinite(numeric).all()
@@ -1040,8 +1042,10 @@ def _sum_complete_counts(group, column, identity):
     ):
         raise ValueError(
             f"Evidence count {column!r} must contain non-negative finite "
-            f"integers for {identity}: {values.tolist()!r}."
+            f"integers for {identity}: {stated_counts.tolist()!r}."
         )
+    if not stated.all():
+        return pd.NA
     return int(numeric.sum())
 
 
@@ -1140,8 +1144,10 @@ def aggregate_evidence_across_samples(
             key for key in EvalContext(df).group_keys
             if key != "sample_name"
         ]
+        context = EvalContext(df, group_keys=keys)
     else:
-        keys = EvalContext(df, group_keys=group_keys).group_keys
+        context = EvalContext(df, group_keys=group_keys)
+        keys = context.group_keys
     if "sample_name" in keys:
         raise ValueError(
             "group_keys must exclude 'sample_name'; this function pools "
@@ -1168,7 +1174,14 @@ def aggregate_evidence_across_samples(
         if column in df.columns
     ]
     evidence_columns = [*count_columns, *metadata_columns]
-    per_sample = _single_sample_evidence_rows(df, keys, evidence_columns)
+    normalized_df = df.assign(**{
+        key: context.key_frame[key] for key in keys
+    })
+    per_sample = _single_sample_evidence_rows(
+        normalized_df,
+        keys,
+        evidence_columns,
+    )
 
     rows = []
     for key, group in _groupby(per_sample, keys):

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -996,15 +996,54 @@ def _identity(columns, key):
     return dict(zip(columns, values))
 
 
-def _single_sample_evidence_rows(df, group_keys, evidence_columns):
+def _validated_stated_counts(values, column, identity):
+    """Validate and coerce every stated count, returning its stated mask."""
+    stated = stated_values(values)
+    stated_counts = values[stated]
+    if stated_counts.map(
+        lambda value: isinstance(value, (bool, np.bool_))
+    ).any():
+        raise ValueError(
+            f"Evidence count {column!r} must be a non-negative integer for "
+            f"{identity}; boolean values are not counts."
+        )
+    try:
+        numeric = pd.to_numeric(stated_counts, errors="raise")
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Evidence count {column!r} must be numeric for {identity}: "
+            f"{stated_counts.tolist()!r}."
+        ) from None
+    if (
+        np.iscomplexobj(numeric.to_numpy())
+        or not np.isfinite(numeric).all()
+        or (numeric < 0).any()
+        or (numeric % 1 != 0).any()
+    ):
+        raise ValueError(
+            f"Evidence count {column!r} must contain non-negative finite "
+            f"integers for {identity}: {stated_counts.tolist()!r}."
+        )
+    return stated, numeric
+
+
+def _single_sample_evidence_rows(
+    df,
+    group_keys,
+    evidence_columns,
+    count_columns,
+):
     """Collapse repeated prediction rows to one evidence row per sample."""
     identity_columns = [*group_keys, "sample_name"]
     rows = []
     for key, group in _groupby(df, identity_columns):
         identity = _identity(identity_columns, key)
         row = dict(identity)
+        for column in count_columns:
+            _validated_stated_counts(group[column], column, identity)
         for column in evidence_columns:
-            stated = group.loc[stated_values(group[column]), column]
+            stated_mask = stated_values(group[column])
+            stated = group.loc[stated_mask, column]
             distinct = stated.drop_duplicates()
             if len(distinct) > 1:
                 raise ValueError(
@@ -1018,35 +1057,14 @@ def _single_sample_evidence_rows(df, group_keys, evidence_columns):
 
 def _sum_complete_counts(group, column, identity):
     """Sum a count only when every represented sample states it."""
-    values = group[column]
-    stated = stated_values(values)
-    stated_counts = values[stated]
-    if stated_counts.map(
-        lambda value: isinstance(value, (bool, np.bool_))
-    ).any():
-        raise ValueError(
-            f"Evidence count {column!r} must be a non-negative integer for "
-            f"{identity}; boolean values are not counts."
-        )
-    try:
-        numeric = pd.to_numeric(stated_counts, errors="raise").astype(float)
-    except (TypeError, ValueError):
-        raise ValueError(
-            f"Evidence count {column!r} must be numeric for {identity}: "
-            f"{stated_counts.tolist()!r}."
-        ) from None
-    if (
-        not np.isfinite(numeric).all()
-        or (numeric < 0).any()
-        or (numeric % 1 != 0).any()
-    ):
-        raise ValueError(
-            f"Evidence count {column!r} must contain non-negative finite "
-            f"integers for {identity}: {stated_counts.tolist()!r}."
-        )
+    stated, numeric = _validated_stated_counts(
+        group[column],
+        column,
+        identity,
+    )
     if not stated.all():
         return pd.NA
-    return int(numeric.sum())
+    return sum(int(value) for value in numeric)
 
 
 def _common_assay_metadata(group, assay, identity, pooled_counts):
@@ -1101,7 +1119,9 @@ def aggregate_evidence_across_samples(
     group_keys : sequence of str, optional
         Candidate identity excluding ``sample_name``. By default Topiary's
         normal prediction identity is inferred, including ``allele_set`` when
-        populated but deliberately excluding the sample dimension.
+        populated but deliberately excluding the sample dimension. Canonical
+        counts and VAFs are measurements to aggregate, not valid identity
+        keys.
 
     Returns
     -------
@@ -1155,9 +1175,20 @@ def aggregate_evidence_across_samples(
         )
     if "n_samples" in keys:
         raise ValueError("group_keys cannot contain the output column 'n_samples'.")
+    aggregate_value_keys = [
+        key for key in keys
+        if key in (*_COUNT_EVIDENCE_COLUMNS, "rna_vaf", "dna_vaf")
+    ]
+    if aggregate_value_keys:
+        raise ValueError(
+            "group_keys must identify candidates, not canonical counts or "
+            f"VAFs; remove {aggregate_value_keys!r}."
+        )
 
     count_columns = [
-        column for column in _COUNT_EVIDENCE_COLUMNS if column in df.columns
+        column
+        for column in _COUNT_EVIDENCE_COLUMNS
+        if column in df.columns
     ]
     if not count_columns:
         raise ValueError(
@@ -1171,7 +1202,7 @@ def aggregate_evidence_across_samples(
             f"{assay}_evidence_subject",
             f"{assay}_evidence_method",
         )
-        if column in df.columns
+        if column in df.columns and column not in keys
     ]
     evidence_columns = [*count_columns, *metadata_columns]
     normalized_df = df.assign(**{
@@ -1181,6 +1212,7 @@ def aggregate_evidence_across_samples(
         normalized_df,
         keys,
         evidence_columns,
+        count_columns,
     )
 
     rows = []
@@ -1199,8 +1231,18 @@ def aggregate_evidence_across_samples(
             )
             alt = row.get(f"n_{assay}_alt", pd.NA)
             overlapping = row.get(f"n_{assay}_overlapping", pd.NA)
-            if is_stated(alt) and is_stated(overlapping) and overlapping > 0:
-                row[f"{assay}_vaf"] = alt / overlapping
+            vaf_column = f"{assay}_vaf"
+            required_count_columns = {
+                f"n_{assay}_alt",
+                f"n_{assay}_overlapping",
+            }
+            if (
+                required_count_columns.issubset(count_columns)
+                and is_stated(alt)
+                and is_stated(overlapping)
+                and overlapping > 0
+            ):
+                row[vaf_column] = alt / overlapping
         rows.append(row)
 
     result = pd.DataFrame(rows)
@@ -1215,7 +1257,10 @@ def aggregate_evidence_across_samples(
     ordered = [
         *keys,
         "n_samples",
-        *(column for column in EVIDENCE_COLUMNS if column in result.columns),
+        *(
+            column for column in EVIDENCE_COLUMNS
+            if column in result.columns and column not in keys
+        ),
     ]
     return result.loc[:, ordered]
 

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -53,7 +53,7 @@ import pandas as pd
 
 from types import MappingProxyType
 
-from .ranking import is_stated, stated_values
+from .ranking import EvalContext, is_stated, stated_values
 
 #: Counted directly from an RNA alignment.
 #:
@@ -970,6 +970,241 @@ DNA_EVIDENCE_COLUMNS = (
 EVIDENCE_COLUMNS = (
     RNA_EVIDENCE_COLUMNS + DNA_EVIDENCE_COLUMNS + ("sequence_source",)
 )
+
+
+_COUNT_EVIDENCE_COLUMNS = (
+    "n_rna_alt",
+    "n_rna_ref",
+    "n_rna_overlapping",
+    "n_rna_other",
+    "n_dna_alt",
+    "n_dna_ref",
+    "n_dna_overlapping",
+    "n_dna_other",
+)
+
+
+def _groupby(df, columns):
+    """Group by one or more columns without pandas' length-one warning."""
+    grouper = columns[0] if len(columns) == 1 else columns
+    return df.groupby(grouper, sort=False, dropna=False, observed=True)
+
+
+def _identity(columns, key):
+    """Return a readable identity mapping for one groupby key."""
+    values = (key,) if len(columns) == 1 else key
+    return dict(zip(columns, values))
+
+
+def _single_sample_evidence_rows(df, group_keys, evidence_columns):
+    """Collapse repeated prediction rows to one evidence row per sample."""
+    identity_columns = [*group_keys, "sample_name"]
+    rows = []
+    for key, group in _groupby(df, identity_columns):
+        identity = _identity(identity_columns, key)
+        row = dict(identity)
+        for column in evidence_columns:
+            stated = group.loc[stated_values(group[column]), column]
+            distinct = stated.drop_duplicates()
+            if len(distinct) > 1:
+                raise ValueError(
+                    f"Contradictory {column!r} values within one sample for "
+                    f"{identity}: {distinct.tolist()!r}."
+                )
+            row[column] = distinct.iloc[0] if len(distinct) else pd.NA
+        rows.append(row)
+    return pd.DataFrame(rows, columns=[*identity_columns, *evidence_columns])
+
+
+def _sum_complete_counts(group, column, identity):
+    """Sum a count only when every represented sample states it."""
+    values = group[column]
+    if not stated_values(values).all():
+        return pd.NA
+    if values.map(lambda value: isinstance(value, (bool, np.bool_))).any():
+        raise ValueError(
+            f"Evidence count {column!r} must be a non-negative integer for "
+            f"{identity}; boolean values are not counts."
+        )
+    try:
+        numeric = pd.to_numeric(values, errors="raise").astype(float)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Evidence count {column!r} must be numeric for {identity}: "
+            f"{values.tolist()!r}."
+        ) from None
+    if (
+        not np.isfinite(numeric).all()
+        or (numeric < 0).any()
+        or (numeric % 1 != 0).any()
+    ):
+        raise ValueError(
+            f"Evidence count {column!r} must contain non-negative finite "
+            f"integers for {identity}: {values.tolist()!r}."
+        )
+    return int(numeric.sum())
+
+
+def _common_assay_metadata(group, assay, identity, pooled_counts):
+    """Return metadata shared by every sample contributing assay counts."""
+    if not pooled_counts:
+        return {}
+    result = {}
+    for suffix in ("subject", "method"):
+        column = f"{assay}_evidence_{suffix}"
+        if column not in group.columns or not stated_values(group[column]).all():
+            raise ValueError(
+                f"Cannot pool {assay.upper()} evidence for {identity}: every "
+                f"represented sample must state {column!r}."
+            )
+        distinct = group[column].drop_duplicates()
+        if len(distinct) != 1:
+            raise ValueError(
+                f"Cannot pool {assay.upper()} evidence for {identity}: samples "
+                f"use different {column!r} values {distinct.tolist()!r}."
+            )
+        result[column] = distinct.iloc[0]
+    return result
+
+
+def aggregate_evidence_across_samples(
+    df: pd.DataFrame,
+    *,
+    group_keys=None,
+) -> pd.DataFrame:
+    """Pool canonical read counts across samples without losing attribution.
+
+    Repeated prediction rows for the same candidate and sample are collapsed
+    before summing, so evidence copied onto several prediction kinds or methods
+    is counted once. A canonical count is emitted only when every represented
+    sample states it. RNA and DNA VAFs are recomputed as pooled alternate count
+    divided by pooled overlapping count; per-sample VAFs are never averaged.
+
+    Assay counts can be pooled only when every represented sample names the
+    same evidence subject and derivation method. Mixing reads with fragments,
+    or measured counts with arithmetic estimates, raises instead of flattening
+    unlike quantities into one number. Expression is intentionally not pooled:
+    unlike read counts, it has no generally valid cross-sample sum.
+
+    The returned DataFrame is separate from *df*, whose per-sample values stay
+    unchanged and available for sample-specific reporting and thresholds.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Long-form prediction rows with a stated ``sample_name`` and at least
+        one canonical RNA or DNA count column.
+    group_keys : sequence of str, optional
+        Candidate identity excluding ``sample_name``. By default Topiary's
+        normal prediction identity is inferred, including ``allele_set`` when
+        populated but deliberately excluding the sample dimension.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per candidate identity. ``n_samples`` is the number of samples
+        represented by rows for that identity. Complete canonical counts keep
+        their original names, and computable VAFs are pooled from those counts.
+
+    Raises
+    ------
+    ValueError
+        If samples are unnamed, evidence conflicts within a sample, a count is
+        invalid, or pooled values would mix evidence subjects or methods.
+
+    Notes
+    -----
+    A candidate absent from a sample has no row to aggregate. ``n_samples``
+    makes that visible; completeness is evaluated across the samples actually
+    represented for each candidate.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(
+            "aggregate_evidence_across_samples expects a pandas.DataFrame, "
+            f"got {type(df).__name__}."
+        )
+    if df.empty:
+        raise ValueError("Cannot aggregate evidence from an empty DataFrame.")
+    if "sample_name" not in df.columns:
+        raise ValueError(
+            "Cross-sample aggregation requires a 'sample_name' column."
+        )
+    if not stated_values(df["sample_name"]).all():
+        raise ValueError(
+            "Cross-sample aggregation requires every row to state "
+            "'sample_name'."
+        )
+
+    if group_keys is None:
+        keys = [
+            key for key in EvalContext(df).group_keys
+            if key != "sample_name"
+        ]
+    else:
+        keys = EvalContext(df, group_keys=group_keys).group_keys
+    if "sample_name" in keys:
+        raise ValueError(
+            "group_keys must exclude 'sample_name'; this function pools "
+            "across that dimension."
+        )
+    if "n_samples" in keys:
+        raise ValueError("group_keys cannot contain the output column 'n_samples'.")
+
+    count_columns = [
+        column for column in _COUNT_EVIDENCE_COLUMNS if column in df.columns
+    ]
+    if not count_columns:
+        raise ValueError(
+            "Cross-sample aggregation requires at least one canonical count "
+            f"column from {list(_COUNT_EVIDENCE_COLUMNS)!r}."
+        )
+    metadata_columns = [
+        column
+        for assay in ("rna", "dna")
+        for column in (
+            f"{assay}_evidence_subject",
+            f"{assay}_evidence_method",
+        )
+        if column in df.columns
+    ]
+    evidence_columns = [*count_columns, *metadata_columns]
+    per_sample = _single_sample_evidence_rows(df, keys, evidence_columns)
+
+    rows = []
+    for key, group in _groupby(per_sample, keys):
+        identity = _identity(keys, key)
+        row = {**identity, "n_samples": len(group)}
+        for column in count_columns:
+            row[column] = _sum_complete_counts(group, column, identity)
+        for assay in ("rna", "dna"):
+            assay_counts = [
+                column for column in count_columns
+                if column.startswith(f"n_{assay}_") and is_stated(row[column])
+            ]
+            row.update(
+                _common_assay_metadata(group, assay, identity, assay_counts)
+            )
+            alt = row.get(f"n_{assay}_alt", pd.NA)
+            overlapping = row.get(f"n_{assay}_overlapping", pd.NA)
+            if is_stated(alt) and is_stated(overlapping) and overlapping > 0:
+                row[f"{assay}_vaf"] = alt / overlapping
+        rows.append(row)
+
+    result = pd.DataFrame(rows)
+    for column in count_columns:
+        if column in result and stated_values(result[column]).any():
+            result[column] = result[column].astype("Int64")
+        elif column in result:
+            result = result.drop(columns=column)
+    for column in ("rna_vaf", "dna_vaf"):
+        if column in result and not stated_values(result[column]).any():
+            result = result.drop(columns=column)
+    ordered = [
+        *keys,
+        "n_samples",
+        *(column for column in EVIDENCE_COLUMNS if column in result.columns),
+    ]
+    return result.loc[:, ordered]
 
 
 def available_evidence_columns(df: pd.DataFrame) -> tuple:


### PR DESCRIPTION
## Summary

- add the public `aggregate_evidence_across_samples` API for canonical RNA and DNA counts
- return a separate pooled DataFrame so original per-sample evidence remains attributable
- collapse repeated prediction rows within each sample before summing
- keep partially stated counts absent, recompute VAF from pooled counts, and reject mixed subjects or derivation methods
- allow Topiary-produced coverage-only evidence to pool without inventing a derivation method
- include native assembled-protein RNA support and validate every raw count before duplicate collapse
- preserve exact large integers and reject boolean, complex, fractional, non-finite, and negative counts
- keep provenance identity keys usable while rejecting counts and VAFs as grouping keys
- run pytest with the same Python interpreter used to detect xdist
- document the consumer workflow and bump Topiary to 5.49.0

## Semantics

`n_samples` reports the samples represented by rows for each candidate. A candidate absent from a sample is not treated as zero. Expression stays per-sample because it has no generally valid cross-sample sum. A threshold-dependent `n_samples_supporting` is deliberately not invented by this generic aggregation; callers can calculate it from the preserved per-sample frame.

## Verification

- `./lint.sh`
- `./test.sh -rs` — 2363 passed, 0 skipped, 92% coverage
- Vaxrank suite against this checkout — 1193 passed, 0 skipped

Closes #247
Closes #254
Closes #255
