### PR TITLE
Harden cross-sample evidence aggregation review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 5.49.1
+
+**Hardened cross-sample evidence aggregation after review.** Equivalent
+missing identity spellings now collapse through the same `EvalContext`
+normalization used by filtering, sorting, and scoring, including pandas string
+and categorical columns. Canonical counts are validated before duplicate rows
+are collapsed, so booleans and malformed values cannot disappear based on row
+order or an incomplete sample. Exact large numeric values and Arrow-backed
+columns are supported up to the canonical nullable-Int64 limit; larger
+individual or pooled counts raise a documented validation error.
+
 ## 5.49.0
 
 **Added strict cross-sample aggregation for canonical evidence.**

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -1,9 +1,16 @@
 """Cross-sample aggregation of canonical evidence columns."""
 
+from fractions import Fraction
+
 import pandas as pd
 import pytest
 
-from topiary import aggregate_evidence_across_samples
+from topiary import (
+    Column,
+    EvalContext,
+    aggregate_evidence_across_samples,
+    evaluate_scores,
+)
 
 
 GROUP_KEYS = ["fragment_id", "peptide", "peptide_offset", "allele"]
@@ -147,7 +154,17 @@ def test_boolean_counts_cannot_hide_as_duplicate_integers(values):
 
 @pytest.mark.parametrize(
     "value",
-    [-1, 1.5, float("inf"), True, 1 + 2j, "many"],
+    [
+        -1,
+        1.5,
+        Fraction(3, 2),
+        Fraction(10 ** 400, 1),
+        float("inf"),
+        True,
+        1 + 2j,
+        "many",
+        "1e999",
+    ],
 )
 def test_invalid_counts_are_rejected(value):
     df = pd.DataFrame([_row("pre", n_rna_alt=value)])
@@ -158,7 +175,17 @@ def test_invalid_counts_are_rejected(value):
 
 @pytest.mark.parametrize(
     "value",
-    [-1, 1.5, float("inf"), True, 1 + 2j, "many"],
+    [
+        -1,
+        1.5,
+        Fraction(3, 2),
+        Fraction(10 ** 400, 1),
+        float("inf"),
+        True,
+        1 + 2j,
+        "many",
+        "1e999",
+    ],
 )
 def test_invalid_stated_counts_are_rejected_even_when_pool_is_incomplete(value):
     df = pd.DataFrame([
@@ -224,18 +251,24 @@ def test_one_tuple_valued_group_key_remains_one_identity_value():
     assert pooled.loc[0, "n_rna_alt"] == 40
 
 
-def test_equivalent_missing_identity_spellings_pool_as_one_group():
+@pytest.mark.parametrize("dtype", [object, "string", "category"])
+def test_equivalent_missing_identity_spellings_pool_as_one_group(dtype):
     df = pd.DataFrame([
         _row("pre", allele=None),
-        _row("post", allele="nan"),
+        _row("post", allele="nan", n_rna_alt=21),
     ])
+    df["allele"] = df["allele"].astype(dtype)
 
+    context = EvalContext(df, group_keys=GROUP_KEYS)
+    scores = evaluate_scores(df, Column("n_rna_alt"), context=context)
     pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
 
+    assert len(context.group_index) == 1
+    assert scores.tolist() == [20, 20]
     assert len(pooled) == 1
     assert pd.isna(pooled.loc[0, "allele"])
     assert pooled.loc[0, "n_samples"] == 2
-    assert pooled.loc[0, "n_rna_alt"] == 40
+    assert pooled.loc[0, "n_rna_alt"] == 41
 
 
 def test_evidence_column_used_as_group_key_appears_once():
@@ -278,3 +311,50 @@ def test_large_integer_counts_are_summed_exactly():
     pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
 
     assert pooled.loc[0, "n_rna_alt"] == 2 * count
+
+
+def test_large_integral_float_counts_keep_their_exact_value():
+    count = float(2 ** 60)
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=count),
+        _row("post", n_rna_alt=count),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_alt"] == 2 * int(count)
+
+
+def test_integral_fraction_counts_are_accepted():
+    count = Fraction(2, 1)
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=count),
+        _row("post", n_rna_alt=count),
+    ])
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_alt"] == 4
+
+
+def test_pooled_counts_must_fit_the_canonical_int64_dtype():
+    count = 2 ** 62
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=count),
+        _row("post", n_rna_alt=count),
+    ])
+
+    with pytest.raises(ValueError, match="exceeds the supported maximum"):
+        aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+
+def test_arrow_backed_counts_are_accepted():
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame([
+        _row("pre", n_rna_alt=20),
+        _row("post", n_rna_alt=21),
+    ]).convert_dtypes(dtype_backend="pyarrow")
+
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert pooled.loc[0, "n_rna_alt"] == 41

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -157,7 +157,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.49.0"
+__version__ = "5.49.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -48,6 +48,10 @@ same as answering zero.
 
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
+import math
+from numbers import Integral, Real
+
 import numpy as np
 import pandas as pd
 
@@ -985,6 +989,8 @@ _COUNT_EVIDENCE_COLUMNS = (
     "n_dna_other",
 )
 
+_MAX_EVIDENCE_COUNT = int(np.iinfo(np.int64).max)
+
 
 def _groupby(df, columns):
     """Group by one or more columns without pandas' length-one warning."""
@@ -1009,23 +1015,50 @@ def _validated_stated_counts(values, column, identity):
             f"Evidence count {column!r} must be a non-negative integer for "
             f"{identity}; boolean values are not counts."
         )
-    try:
-        numeric = pd.to_numeric(stated_counts, errors="raise")
-    except (TypeError, ValueError):
-        raise ValueError(
-            f"Evidence count {column!r} must be numeric for {identity}: "
-            f"{stated_counts.tolist()!r}."
-        ) from None
-    if (
-        np.iscomplexobj(numeric.to_numpy())
-        or not np.isfinite(numeric).all()
-        or (numeric < 0).any()
-        or (numeric % 1 != 0).any()
-    ):
-        raise ValueError(
-            f"Evidence count {column!r} must contain non-negative finite "
-            f"integers for {identity}: {stated_counts.tolist()!r}."
-        )
+    numeric = []
+    for value in stated_counts:
+        if isinstance(value, Integral):
+            count = int(value)
+        elif isinstance(value, Real):
+            if (
+                value < 0
+                or value > _MAX_EVIDENCE_COUNT
+                or not math.isfinite(value)
+                or value != int(value)
+            ):
+                count = None
+            else:
+                count = int(value)
+        elif isinstance(value, (str, Decimal)):
+            try:
+                exact = value if isinstance(value, Decimal) else Decimal(
+                    value.strip()
+                )
+            except (InvalidOperation, TypeError, ValueError):
+                raise ValueError(
+                    f"Evidence count {column!r} must be numeric for "
+                    f"{identity}: {stated_counts.tolist()!r}."
+                ) from None
+            count = (
+                int(exact)
+                if exact.is_finite()
+                and exact >= 0
+                and exact <= _MAX_EVIDENCE_COUNT
+                and exact == exact.to_integral_value()
+                else None
+            )
+        else:
+            raise ValueError(
+                f"Evidence count {column!r} must be numeric for {identity}: "
+                f"{stated_counts.tolist()!r}."
+            )
+        if count is None or count < 0 or count > _MAX_EVIDENCE_COUNT:
+            raise ValueError(
+                f"Evidence count {column!r} must contain non-negative finite "
+                f"integers no greater than {_MAX_EVIDENCE_COUNT} for "
+                f"{identity}: {stated_counts.tolist()!r}."
+            )
+        numeric.append(count)
     return stated, numeric
 
 
@@ -1066,7 +1099,13 @@ def _sum_complete_counts(group, column, identity):
     )
     if not stated.all():
         return pd.NA
-    return sum(int(value) for value in numeric)
+    total = sum(numeric)
+    if total > _MAX_EVIDENCE_COUNT:
+        raise ValueError(
+            f"Pooled evidence count {column!r} exceeds the supported maximum "
+            f"of {_MAX_EVIDENCE_COUNT} for {identity}."
+        )
+    return total
 
 
 def _common_assay_metadata(group, assay, identity, pooled_counts):
@@ -1174,10 +1213,8 @@ def aggregate_evidence_across_samples(
             key for key in EvalContext(df).group_keys
             if key != "sample_name"
         ]
-        context = EvalContext(df, group_keys=keys)
     else:
-        context = EvalContext(df, group_keys=group_keys)
-        keys = context.group_keys
+        keys = EvalContext(df, group_keys=group_keys).group_keys
     if "sample_name" in keys:
         raise ValueError(
             "group_keys must exclude 'sample_name'; this function pools "
@@ -1215,6 +1252,7 @@ def aggregate_evidence_across_samples(
         if column in df.columns and column not in keys
     ]
     evidence_columns = [*count_columns, *metadata_columns]
+    context = EvalContext(df, group_keys=keys)
     normalized_df = df.assign(**{
         key: context.key_frame[key] for key in keys
     })

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -154,7 +154,7 @@ def _keep_allele_free_evidence(ctx, node, mask):
     peptide_keys = _peptide_keys(ctx.group_keys)
     if "allele" not in ctx.group_keys or not peptide_keys:
         return mask
-    if "kind" not in ctx.df.columns:
+    if "kind" not in ctx.evaluation_df.columns:
         return mask
     node_kinds = _collect_kinds(node)
     if not node_kinds:
@@ -163,7 +163,7 @@ def _keep_allele_free_evidence(ctx, node, mask):
     # Groups holding at least one row of a kind this filter reads.
     read = np.zeros(len(ctx.group_index), dtype=bool)
     codes = ctx.row_group_codes()
-    read[codes[ctx.df["kind"].isin(node_kinds).to_numpy()]] = True
+    read[codes[ctx.evaluation_df["kind"].isin(node_kinds).to_numpy()]] = True
 
     candidates = _peptide_level_groups(ctx) & ~read & ~mask
     if not candidates.any():

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1003,7 +1003,7 @@ class EvalContext:
         "df", "group_keys", "default_methods", "default_versions",
         "filter_context", "kind_support", "alleles",
         "_group_index", "_key_frame", "_group_tuples_cache",
-        "_group_codes_cache", "_method_override",
+        "_group_codes_cache", "_evaluation_df", "_method_override",
     )
 
     def __init__(
@@ -1034,6 +1034,7 @@ class EvalContext:
         self._key_frame = None
         self._group_tuples_cache = None
         self._group_codes_cache = None
+        self._evaluation_df = None
         # Internal: when Comparison auto-aggregates across methods, it
         # binds Field(method=None, kind=K) references to a specific
         # method per iteration by setting (kind_value, method_name) here.
@@ -1091,6 +1092,7 @@ class EvalContext:
             derived._group_index = self._group_index
             derived._group_tuples_cache = self._group_tuples_cache
             derived._group_codes_cache = self._group_codes_cache
+            derived._evaluation_df = self._evaluation_df
         return derived
 
     @property
@@ -1113,12 +1115,17 @@ class EvalContext:
         """
         if self._key_frame is None:
             frame = self.df[self.group_keys]
-            object_keys = [
-                k for k in self.group_keys if frame[k].dtype == object
+            text_keys = [
+                k for k in self.group_keys
+                if frame[k].dtype == object
+                or isinstance(frame[k].dtype, pd.CategoricalDtype)
+                or pd.api.types.is_string_dtype(frame[k].dtype)
             ]
             replacements = {}
-            for key in object_keys:
-                column = frame[key]
+            for key in text_keys:
+                # Object form lets every pandas string/categorical backend
+                # carry the same np.nan sentinel used by ordinary columns.
+                column = frame[key].astype(object)
                 # Null, or the *text* of a null. Not blank: a blank cell
                 # is a stated-but-empty value and stays its own group.
                 missing = column.isna() | column.astype(str).str.strip(
@@ -1129,6 +1136,25 @@ class EvalContext:
                 frame = frame.assign(**replacements)
             self._key_frame = frame
         return self._key_frame
+
+    @property
+    def evaluation_df(self) -> pd.DataFrame:
+        """Prediction rows with group keys matching :attr:`key_frame`.
+
+        Nodes group this frame so their pandas groupby keys cannot diverge
+        from ``group_index`` or ``row_group_codes`` after missing-value
+        normalization. The caller's DataFrame remains unchanged.
+        """
+        if self._evaluation_df is None:
+            replacements = {
+                key: self.key_frame[key]
+                for key in self.group_keys
+                if not self.key_frame[key].equals(self.df[key])
+            }
+            self._evaluation_df = (
+                self.df.assign(**replacements) if replacements else self.df
+            )
+        return self._evaluation_df
 
     @property
     def group_index(self) -> pd.Index:
@@ -1556,11 +1582,11 @@ class Column(DSLNode):
         self.col_name = col_name
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        if ctx.df.empty:
+        if ctx.evaluation_df.empty:
             return ctx.empty_series()
-        if self.col_name not in ctx.df.columns:
-            raise _missing_column_error(self.col_name, ctx.df.columns)
-        vals = ctx.df.groupby(
+        if self.col_name not in ctx.evaluation_df.columns:
+            raise _missing_column_error(self.col_name, ctx.evaluation_df.columns)
+        vals = ctx.evaluation_df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[self.col_name].first()
         vals = vals.reindex(ctx.group_index)
@@ -1642,7 +1668,7 @@ class Includes(DSLNode):
         return Includes(self.col_name, self.value, negate=not self.negate)
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        df = ctx.df
+        df = ctx.evaluation_df
         if df.empty:
             return ctx.empty_series().astype("boolean")
         if self.col_name not in df.columns:
@@ -1708,7 +1734,7 @@ class IsIn(DSLNode):
         return []
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        df = ctx.df
+        df = ctx.evaluation_df
         if df.empty:
             # Mirror Column.eval's empty path so the result aligns with
             # ctx.group_index regardless of whether the context happens
@@ -1751,7 +1777,7 @@ def _filter_kind_method_version(ctx, kind, method, version):
     ambiguity. Centralizes the filter logic shared between
     :class:`Field` and :class:`BestAlleleField`.
     """
-    df = ctx.df
+    df = ctx.evaluation_df
     if df.empty or "kind" not in df.columns:
         return None
 
@@ -2815,9 +2841,9 @@ class Len(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         col = self.scope + "peptide_length"
-        if ctx.df.empty or col not in ctx.df.columns:
+        if ctx.evaluation_df.empty or col not in ctx.evaluation_df.columns:
             return ctx.empty_series()
-        vals = ctx.df.groupby(
+        vals = ctx.evaluation_df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[col].first()
         return vals.reindex(ctx.group_index).astype(float)
@@ -2841,9 +2867,12 @@ class Count(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
-        if ctx.df.empty or peptide_col not in ctx.df.columns:
+        if (
+            ctx.evaluation_df.empty
+            or peptide_col not in ctx.evaluation_df.columns
+        ):
             return ctx.empty_series()
-        peptides = ctx.df.groupby(
+        peptides = ctx.evaluation_df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[peptide_col].first()
         peptides = peptides.reindex(ctx.group_index)
@@ -2886,9 +2915,12 @@ class PeptideProperty(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
-        if ctx.df.empty or peptide_col not in ctx.df.columns:
+        if (
+            ctx.evaluation_df.empty
+            or peptide_col not in ctx.evaluation_df.columns
+        ):
             return ctx.empty_series()
-        peptides = ctx.df.groupby(
+        peptides = ctx.evaluation_df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[peptide_col].first()
         peptides = peptides.reindex(ctx.group_index)
@@ -3435,7 +3467,7 @@ class Comparison(DSLNode):
             return None
         kind_val = next(iter(kinds))
 
-        df = ctx.df
+        df = ctx.evaluation_df
         if df.empty or "kind" not in df.columns:
             return None
         kind_rows = df[df["kind"] == kind_val]


### PR DESCRIPTION
## Summary

- centralize canonical missing-value normalization in `EvalContext` so the DSL and cross-sample pooling use identical candidate identities
- normalize object, pandas string, categorical, and Arrow-backed identity columns without mutating the caller's DataFrame
- validate every stated count before duplicate collapse, including booleans, fractions, non-finite values, and oversized exact numerics
- preserve exact large counts and reject individual or pooled values beyond the nullable-Int64 limit
- avoid duplicate output columns when a supported evidence metadata column is also an explicit identity key
- bump Topiary to 5.49.1

## Verification

- `./lint.sh`
- `./test.sh` — 2372 passed, 0 skipped, 92% coverage
- Vaxrank suite against this checkout — 1193 passed, 0 skipped

Follow-up to #253; contains the fixes completed by the final review after that PR was merged.
