### PR TITLE
Keep custom DSL nodes aligned with normalized identity keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ nodes see one set of keys. The caller's DataFrame is still never mutated:
 normalization lands on a copy, and only when a spelling actually needs it.
 
 Reading `ctx.df` is unchanged for everything that treats it as the context's
-prediction rows. Code that relied on `ctx.df is the_frame_i_passed_in` should
-compare against its own reference instead; `EvalContext` keeps the caller's
-frame privately and validates identity on it.
+prediction rows. What does change is identity: `ctx.df` is now a different
+object from the frame you passed whenever a key needed normalizing, so
+`ctx.df is my_frame` is no longer the way to ask whether a context belongs to
+a frame. New `ctx.is_built_on(my_frame)` answers that — the same check
+`apply_filter`, `apply_sort` and `evaluate_scores` make before accepting a
+`context=`.
 
 ## 5.49.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 5.50.0
+
+**`EvalContext.df` now returns the frame nodes are grouped against.** Custom
+DSL nodes are documented to group `ctx.df` by `ctx.group_keys` and reindex onto
+`ctx.group_index`. That only holds if the frame carries the same identity keys
+the group index was built from, and it did not: `ctx.df` handed back the
+caller's raw frame, where a missing allele spelled `"nan"` is a different
+groupby key than one spelled `None`. A node outside Topiary keyed its results
+to groups that do not exist and its values silently became `NaN`, or — when a
+text spelling came first — the wrong row won. Built-in nodes were unaffected;
+they already read the normalized frame.
+
+`ctx.df` now returns that same normalized frame, so built-in and third-party
+nodes see one set of keys. The caller's DataFrame is still never mutated:
+normalization lands on a copy, and only when a spelling actually needs it.
+
+Reading `ctx.df` is unchanged for everything that treats it as the context's
+prediction rows. Code that relied on `ctx.df is the_frame_i_passed_in` should
+compare against its own reference instead; `EvalContext` keeps the caller's
+frame privately and validates identity on it.
+
 ## 5.49.1
 
 **Hardened cross-sample evidence aggregation after review.** Equivalent

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -131,7 +131,7 @@ ordered = apply_sort(df, [Affinity.value], context=ctx)
 
 `context=` replaces the four options above rather than combining with them — passing both raises, so there is no question of which one won.
 
-**A context belongs to one frame.** `apply_filter` and `apply_sort` both return *new* frames, so a context cannot be threaded down a filter → sort → score pipeline; each step needs its own. Reuse applies to several operations on one unchanged frame. Passing a context built on a different frame raises rather than mapping rows to another frame's groups, and the check is identity rather than equality — a copy has its own row order to account for.
+**A context belongs to one frame.** `apply_filter` and `apply_sort` both return *new* frames, so a context cannot be threaded down a filter → sort → score pipeline; each step needs its own. Reuse applies to several operations on one unchanged frame. Passing a context built on a different frame raises rather than mapping rows to another frame's groups, and the check is identity rather than equality — a copy has its own row order to account for. `ctx.is_built_on(df)` makes that check yourself; don't compare against `ctx.df`, which is the normalized frame and a different object whenever a key needed normalizing.
 
 `apply_filter` evaluates with `filter_context=True` (unqualified same-kind references auto-aggregate) while `apply_sort` deliberately does not. Handing one context to both is still fine: `apply_filter` derives the variant it needs, inheriting the grouping rather than recomputing it, and leaves your context's own flag alone. To vary an option yourself:
 

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -11,9 +11,24 @@ from topiary import (
     aggregate_evidence_across_samples,
     evaluate_scores,
 )
+from topiary.ranking.nodes import DSLNode
 
 
 GROUP_KEYS = ["fragment_id", "peptide", "peptide_offset", "allele"]
+
+
+class CustomGroupingNode(DSLNode):
+    """A consumer-written node that groups ``ctx.df`` itself.
+
+    Built-in nodes read ``ctx.evaluation_df``, so they were already
+    aligned with ``ctx.group_index``. This stands in for a node outside
+    Topiary, which reaches for the plain ``ctx.df`` the DSL documents.
+    """
+
+    def eval(self, ctx):
+        return ctx.df.groupby(
+            ctx.group_keys, sort=False, dropna=False, observed=True,
+        )["n_rna_alt"].first().reindex(ctx.group_index)
 
 
 def _row(sample_name, **overrides):
@@ -251,24 +266,66 @@ def test_one_tuple_valued_group_key_remains_one_identity_value():
     assert pooled.loc[0, "n_rna_alt"] == 40
 
 
+# Both spellings mean "not stated", so row order must not decide the
+# pooled identity. Real nulls happen to survive a raw ``groupby`` as the
+# same key ``group_index`` carries, so a null-first pair passes even
+# without normalization; put the *text* spelling first and a node that
+# groups the raw frame keys its result to a group that does not exist.
 @pytest.mark.parametrize("dtype", [object, "string", "category"])
-def test_equivalent_missing_identity_spellings_pool_as_one_group(dtype):
+@pytest.mark.parametrize("spellings", [
+    (None, "nan"),
+    ("nan", None),
+    ("NaN", "none"),
+    ("null", "<NA>"),
+])
+def test_equivalent_missing_identity_spellings_pool_as_one_group(
+    dtype, spellings,
+):
+    first, second = spellings
     df = pd.DataFrame([
-        _row("pre", allele=None),
-        _row("post", allele="nan", n_rna_alt=21),
+        _row("pre", allele=first),
+        _row("post", allele=second, n_rna_alt=21),
+    ])
+    df["allele"] = df["allele"].astype(dtype)
+    original = df.copy(deep=True)
+
+    context = EvalContext(df, group_keys=GROUP_KEYS)
+    scores = evaluate_scores(df, Column("n_rna_alt"), context=context)
+    custom_scores = evaluate_scores(
+        df, CustomGroupingNode(), context=context,
+    )
+    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+
+    assert len(context.group_index) == 1
+    assert scores.tolist() == [20, 20]
+    assert custom_scores.tolist() == [20, 20]
+    pd.testing.assert_frame_equal(df, original)
+    assert len(pooled) == 1
+    assert pd.isna(pooled.loc[0, "allele"])
+    assert pooled.loc[0, "n_samples"] == 2
+    assert pooled.loc[0, "n_rna_alt"] == 41
+
+
+# "NA" is not a spelling of missing (only "<na>" is), so this frame has
+# two real groups. A custom node grouping the raw frame keys one result
+# to the literal "none" and reads NaN for the normalized null group.
+@pytest.mark.parametrize("dtype", [object, "string", "category"])
+def test_custom_nodes_align_when_one_identity_spelling_is_null(dtype):
+    df = pd.DataFrame([
+        _row("pre", allele="NA"),
+        _row("post", allele="none", n_rna_alt=21),
     ])
     df["allele"] = df["allele"].astype(dtype)
 
     context = EvalContext(df, group_keys=GROUP_KEYS)
     scores = evaluate_scores(df, Column("n_rna_alt"), context=context)
-    pooled = aggregate_evidence_across_samples(df, group_keys=GROUP_KEYS)
+    custom_scores = evaluate_scores(
+        df, CustomGroupingNode(), context=context,
+    )
 
-    assert len(context.group_index) == 1
-    assert scores.tolist() == [20, 20]
-    assert len(pooled) == 1
-    assert pd.isna(pooled.loc[0, "allele"])
-    assert pooled.loc[0, "n_samples"] == 2
-    assert pooled.loc[0, "n_rna_alt"] == 41
+    assert len(context.group_index) == 2
+    assert scores.tolist() == [20, 21]
+    assert custom_scores.tolist() == [20, 21]
 
 
 def test_evidence_column_used_as_group_key_appears_once():

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -184,6 +184,36 @@ def test_an_equal_but_distinct_frame_is_still_refused():
         evaluate_scores(df.copy(), Affinity.value, context=ctx)
 
 
+def test_is_built_on_answers_the_question_the_check_asks():
+    """The public way to make the check apply_* makes internally."""
+    df = _frame()
+    ctx = EvalContext(df)
+
+    assert ctx.is_built_on(df)
+    assert not ctx.is_built_on(df.copy())
+    assert not ctx.is_built_on(apply_filter(df, Affinity.value <= 300))
+
+
+def test_is_built_on_is_not_the_same_as_comparing_against_df():
+    """``ctx.df`` normalizes, so identity against it is the wrong check."""
+    df = _frame()
+    df.loc[0, "allele"] = None
+    df.loc[1, "allele"] = "nan"
+    ctx = EvalContext(df, group_keys=["peptide", "allele"])
+
+    assert ctx.df is not df
+    assert ctx.is_built_on(df)
+
+
+def test_a_context_needing_no_normalization_still_answers_correctly():
+    """``ctx.df`` may be the caller's own object; the check must not care."""
+    df = _frame()
+    ctx = EvalContext(df)
+
+    assert ctx.df is df
+    assert ctx.is_built_on(df)
+
+
 def test_context_and_options_together_are_refused():
     df = _frame()
     ctx = EvalContext(df)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -157,7 +157,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.49.1"
+__version__ = "5.50.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/evidence.py
+++ b/topiary/evidence.py
@@ -1253,11 +1253,8 @@ def aggregate_evidence_across_samples(
     ]
     evidence_columns = [*count_columns, *metadata_columns]
     context = EvalContext(df, group_keys=keys)
-    normalized_df = df.assign(**{
-        key: context.key_frame[key] for key in keys
-    })
     per_sample = _single_sample_evidence_rows(
-        normalized_df,
+        context.df,
         keys,
         evidence_columns,
         count_columns,

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -265,7 +265,7 @@ def _resolve_context(df, context, *, filter_context, group_keys,
             f"not both; got context= with {', '.join(sorted(conflicting))}. "
             f"Use context.derive({conflicting[0]}=...) to change one."
         )
-    if context._source_df is not df:
+    if not context.is_built_on(df):
         raise ValueError(
             "context was built on a different DataFrame. A context caches "
             "its grouping against one frame, so reusing it on another "

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -265,7 +265,7 @@ def _resolve_context(df, context, *, filter_context, group_keys,
             f"not both; got context= with {', '.join(sorted(conflicting))}. "
             f"Use context.derive({conflicting[0]}=...) to change one."
         )
-    if context.df is not df:
+    if context._source_df is not df:
         raise ValueError(
             "context was built on a different DataFrame. A context caches "
             "its grouping against one frame, so reusing it on another "

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1141,12 +1141,27 @@ class EvalContext:
     def df(self) -> pd.DataFrame:
         """Prediction rows whose group keys match :attr:`group_index`.
 
-        This is the frame exposed to :class:`DSLNode` implementations.
-        Missing identity spellings are normalized on a copy when needed,
-        keeping both built-in and third-party nodes aligned with the
-        context's group index. The caller's DataFrame is never mutated.
+        This is the frame every node groups — the built-in ones and
+        your own alike. Missing identity spellings are normalized on a
+        copy when a key needs it, so no node can group by a key
+        ``group_index`` lacks. The DataFrame you passed to this context
+        is never mutated, and is not necessarily this object: to ask
+        whether a context belongs to a frame, use :meth:`is_built_on`.
         """
         return self.evaluation_df
+
+    def is_built_on(self, df) -> bool:
+        """Whether this context was built on ``df`` itself.
+
+        Identity, not equality: a copy has its own row order to account
+        for, so it needs its own context. This is the check
+        :func:`~topiary.ranking.apply_filter` and friends make before
+        accepting a ``context=``, and the one to make yourself before
+        reusing a context you did not build. Comparing against
+        :attr:`df` will not do it — that is the normalized frame, which
+        is a different object whenever a key needed normalizing.
+        """
+        return self._source_df is df
 
     @property
     def evaluation_df(self) -> pd.DataFrame:

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1000,7 +1000,7 @@ class EvalContext:
     """
 
     __slots__ = (
-        "df", "group_keys", "default_methods", "default_versions",
+        "_source_df", "group_keys", "default_methods", "default_versions",
         "filter_context", "kind_support", "alleles",
         "_group_index", "_key_frame", "_group_tuples_cache",
         "_group_codes_cache", "_evaluation_df", "_method_override",
@@ -1010,7 +1010,7 @@ class EvalContext:
         self, df, group_keys=None, default_methods=None, filter_context=False,
         kind_support=None, alleles=None, default_versions=None,
     ):
-        self.df = df
+        self._source_df = df
         if group_keys is None:
             self.group_keys = _pick_group_keys(df)
         else:
@@ -1064,7 +1064,7 @@ class EvalContext:
             raise TypeError(
                 f"Unknown EvalContext option(s): {sorted(unknown)}"
             )
-        df = overrides.get("df", self.df)
+        df = overrides.get("df", self._source_df)
         group_keys = overrides.get("group_keys", self.group_keys)
         alleles = overrides.get("alleles", self.alleles)
         derived = EvalContext(
@@ -1083,7 +1083,7 @@ class EvalContext:
             alleles=alleles,
         )
         reshaped = (
-            df is not self.df
+            df is not self._source_df
             or list(group_keys) != list(self.group_keys)
             or list(alleles or ()) != list(self.alleles or ())
         )
@@ -1114,7 +1114,7 @@ class EvalContext:
         frames use it as a group of its own.
         """
         if self._key_frame is None:
-            frame = self.df[self.group_keys]
+            frame = self._source_df[self.group_keys]
             text_keys = [
                 k for k in self.group_keys
                 if frame[k].dtype == object
@@ -1138,6 +1138,17 @@ class EvalContext:
         return self._key_frame
 
     @property
+    def df(self) -> pd.DataFrame:
+        """Prediction rows whose group keys match :attr:`group_index`.
+
+        This is the frame exposed to :class:`DSLNode` implementations.
+        Missing identity spellings are normalized on a copy when needed,
+        keeping both built-in and third-party nodes aligned with the
+        context's group index. The caller's DataFrame is never mutated.
+        """
+        return self.evaluation_df
+
+    @property
     def evaluation_df(self) -> pd.DataFrame:
         """Prediction rows with group keys matching :attr:`key_frame`.
 
@@ -1149,10 +1160,11 @@ class EvalContext:
             replacements = {
                 key: self.key_frame[key]
                 for key in self.group_keys
-                if not self.key_frame[key].equals(self.df[key])
+                if not self.key_frame[key].equals(self._source_df[key])
             }
             self._evaluation_df = (
-                self.df.assign(**replacements) if replacements else self.df
+                self._source_df.assign(**replacements)
+                if replacements else self._source_df
             )
         return self._evaluation_df
 
@@ -1336,6 +1348,13 @@ class DSLNode:
     ``ctx.group_index``.  Arithmetic and comparison/boolean operators
     produce composite nodes — the tree is built lazily and evaluated on
     demand.
+
+    Read prediction rows from :attr:`EvalContext.df` and group them by
+    ``ctx.group_keys``.  Those are the keys ``ctx.group_index`` was built
+    from, so a result grouped that way reindexes onto it cleanly.
+    Grouping some other frame — the one you passed to ``EvalContext``,
+    say — can key results to groups the index does not carry, and every
+    such value reads back as ``NaN``.
     """
 
     # -- subclass contract --


### PR DESCRIPTION
## Summary

`EvalContext.df` returned the caller's raw frame while `ctx.group_index` was
built from *normalized* identity keys. A custom DSL node that follows the
documented contract — group `ctx.df` by `ctx.group_keys`, reindex onto
`ctx.group_index` — therefore grouped by keys the index does not carry.

- make `EvalContext.df` a property over the normalized evaluation frame, keeping the caller's frame privately as `_source_df` for the "context built on a different DataFrame" check
- state the frame contract on `DSLNode`, which previously only documented the *return* shape and never said which frame to group
- drop the now-redundant local `assign` in `aggregate_evidence_across_samples`
- bump Topiary to 5.50.0

Built-in nodes already read `ctx.evaluation_df` and are unaffected. The
caller's DataFrame is still never mutated — normalization lands on a copy,
and only when a spelling needs it.

## The bug

With `allele` missing in two equivalent spellings, a node grouping `ctx.df`
disagrees with the built-in `Column("n_rna_alt")`:

| row 0 / row 1 alleles | groups | built-in | custom node (before) | custom node (after) |
|---|---|---|---|---|
| `None`, `"nan"` | 1 | `[20, 20]` | `[20, 20]` | `[20, 20]` |
| `"nan"`, `None` | 1 | `[20, 20]` | **`[21, 21]`** | `[20, 20]` |
| `"NaN"`, `"none"` | 1 | `[20, 20]` | **`[21, 21]`** | `[20, 20]` |
| `"NA"`, `"none"` | 2 | `[20, 21]` | **`[20, nan]`** | `[20, 21]` |

Identical across `object`, `string`, and `category` dtypes.

## Note on the tests

The test that shipped with this change in #256 passed *without* the fix. A
real null survives a raw `groupby` as the same key `group_index` carries, so
a null-first pair matches by coincidence and the reindex quietly discards the
extra text-spelled group. Putting the text spelling first is what
discriminates. The test is now parametrized over four spelling pairs × three
dtypes; 12 of those 15 cases fail against `c6dffb6` and all pass here.

## Breaking change, and the replacement for it

Reading `ctx.df` is unchanged for anything treating it as the context's
prediction rows. What changes is *identity*: `ctx.df` is a different object
from the frame you passed whenever a key needed normalizing, so
`ctx.df is my_frame` no longer answers "does this context belong to my frame?"

That check is documented user-facing behavior in `docs/ranking.md`, and the
first draft of this PR left no public way to make it — `_resolve_context` was
reaching across modules for `context._source_df`. Added
`EvalContext.is_built_on(df)`, which `_resolve_context` now uses, and pointed
the docs and changelog at it.

Minor bump per this repo's convention.

## Verification

- `./lint.sh`
- `./test.sh` — 2390 passed, 0 skipped, 92% coverage
- Vaxrank suite with `PYTHONPATH` pointed at this checkout (confirmed `topiary 5.50.0`, not the stale 5.47.0 in site-packages) — 1193 passed, 0 skipped
- Reverted the fix in a scratch worktree at `c6dffb6` to confirm the new cases fail there

Follow-up to #253 and #256; carries the one commit that landed on the #256
branch after that PR was merged.

https://claude.ai/code/session_01AgA7gi5ynUA8BjHfxLshGc