### PR TITLE
Collapse EvalContext.evaluation_df into df, document custom nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 5.51.0
+
+**One name for the frame nodes group: `EvalContext.df`.** 5.50.0 left `df` and
+`evaluation_df` returning the identical object, which is one public name too
+many for a context that already exposes three frame-shaped attributes.
+`evaluation_df` is gone; read `ctx.df`.
+
+`evaluation_df` was added in 5.49.1 and never documented or exported, so it is
+removed outright rather than kept as an alias. Anything reading it becomes
+`ctx.df` with no other change — same object, same contents.
+
+The DSL docs now show how to write your own node, including the rule this
+pair of releases existed to fix: group `ctx.df`, not the frame you handed to
+`EvalContext`, and reindex onto `ctx.group_index`.
+
 ## 5.50.0
 
 **`EvalContext.df` now returns the frame nodes are grouped against.** Custom

--- a/docs/api.md
+++ b/docs/api.md
@@ -318,7 +318,7 @@ Apply with `apply_filter(df, node)` and `apply_sort(df, [nodes])`.
 
 ### Context options
 
-`apply_filter`, `apply_sort` and `evaluate_scores` share four keyword-only
+`apply_filter`, `apply_sort` and `evaluate_scores` share five keyword-only
 options, all forwarded to `EvalContext`:
 
 | Option | Meaning |
@@ -332,8 +332,25 @@ options, all forwarded to `EvalContext`:
 See [Group identity](ranking.md#group-identity) for when to pass `group_keys`.
 
 All three also accept `context=`, a prebuilt `EvalContext` used in place
-of the four options above — see [Sharing a
+of the five options above — see [Sharing a
 context](ranking.md#sharing-a-context).
+
+### EvalContext attributes
+
+What a node reads off the `ctx` handed to its `eval()` — see [Writing your
+own node](ranking.md#writing-your-own-node):
+
+| Attribute | Meaning |
+|-----------|---------|
+| `ctx.df` | The prediction rows to group. Identity keys are normalized, so a `groupby(ctx.group_keys)` over it cannot produce a key `group_index` lacks |
+| `ctx.group_keys` | The identity columns, in order |
+| `ctx.group_index` | Unique group keys — a flat `Index` for one key, a `MultiIndex` for several. Every `eval()` returns a Series indexed by this |
+| `ctx.key_frame` | Just the group-key columns of `ctx.df` |
+| `ctx.row_group_codes()` | Each row's position in `group_index`, for mapping a per-group result back onto rows |
+| `ctx.row_group_tuples()` | Each row's group key, aligned to `ctx.df.index` |
+| `ctx.empty_series(fill)` | A `group_index`-shaped Series, for a node with nothing to say |
+| `ctx.is_built_on(df)` | Whether this context was built on `df` itself — the identity check `apply_*` make before accepting a `context=` |
+| `ctx.derive(**opts)` | A context on the same frame with options changed, reusing the grouping |
 
 ## String parsing
 

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -99,6 +99,27 @@ With a single group key, `ctx.group_index` is a flat `Index` of bare values (mat
 
 To map a per-group result back onto rows, use `ctx.row_group_codes()`, which gives each row the position of its group in `group_index`. Looking group keys up by value is unreliable when a key is null: `NaN` never equals itself.
 
+### Writing your own node
+
+A node is any object with an `eval(ctx)` returning a Series indexed by `ctx.group_index`. Subclass `DSLNode` to get the operators, so your node composes with the built-in ones:
+
+```python
+from topiary.ranking import DSLNode
+
+class MeanRnaAlt(DSLNode):
+    def eval(self, ctx):
+        return ctx.df.groupby(ctx.group_keys, dropna=False, observed=True)[
+            "n_rna_alt"
+        ].mean().reindex(ctx.group_index)
+
+apply_sort(df, [MeanRnaAlt()])
+combined = (Affinity <= 500) & (MeanRnaAlt() >= 5)
+```
+
+**Group `ctx.df`, not the frame you passed to `EvalContext`.** They are usually the same object, but when an identity column spells a missing value more than one way — an `allele` that is `None` in one row and the string `"nan"` in another — `ctx.df` carries the collapsed keys that `ctx.group_index` was built from and your original does not. Grouping the original produces keys the index has no slot for, and `reindex` turns every one of them into `NaN`. `ctx.df` normalizes on a copy; your frame is never mutated.
+
+Reindexing onto `ctx.group_index` is what makes the result alignable, so do it even when the groupby looks like it already returned the right rows: a group your rows never name still needs a slot, and `alleles=` below can add groups that hold no rows at all.
+
 ### Declaring alleles
 
 Group keys come from the rows, so a peptide whose evidence is allele-free — an antigen-processing prediction with nothing in its `allele` column — has no per-allele group for a consumer to read. `alleles=` declares the genotype so `peptide_view` has somewhere to broadcast into.

--- a/tests/test_cross_sample_evidence.py
+++ b/tests/test_cross_sample_evidence.py
@@ -20,9 +20,9 @@ GROUP_KEYS = ["fragment_id", "peptide", "peptide_offset", "allele"]
 class CustomGroupingNode(DSLNode):
     """A consumer-written node that groups ``ctx.df`` itself.
 
-    Built-in nodes read ``ctx.evaluation_df``, so they were already
-    aligned with ``ctx.group_index``. This stands in for a node outside
-    Topiary, which reaches for the plain ``ctx.df`` the DSL documents.
+    Built-in nodes group the same frame, so this checks that a node
+    defined outside Topiary lands on the identity keys
+    ``ctx.group_index`` carries.
     """
 
     def eval(self, ctx):

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -157,7 +157,7 @@ from .result import (
 )
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.50.0"
+__version__ = "5.51.0"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/ranking/apply.py
+++ b/topiary/ranking/apply.py
@@ -154,7 +154,7 @@ def _keep_allele_free_evidence(ctx, node, mask):
     peptide_keys = _peptide_keys(ctx.group_keys)
     if "allele" not in ctx.group_keys or not peptide_keys:
         return mask
-    if "kind" not in ctx.evaluation_df.columns:
+    if "kind" not in ctx.df.columns:
         return mask
     node_kinds = _collect_kinds(node)
     if not node_kinds:
@@ -163,7 +163,7 @@ def _keep_allele_free_evidence(ctx, node, mask):
     # Groups holding at least one row of a kind this filter reads.
     read = np.zeros(len(ctx.group_index), dtype=bool)
     codes = ctx.row_group_codes()
-    read[codes[ctx.evaluation_df["kind"].isin(node_kinds).to_numpy()]] = True
+    read[codes[ctx.df["kind"].isin(node_kinds).to_numpy()]] = True
 
     candidates = _peptide_level_groups(ctx) & ~read & ~mask
     if not candidates.any():

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -1003,7 +1003,7 @@ class EvalContext:
         "_source_df", "group_keys", "default_methods", "default_versions",
         "filter_context", "kind_support", "alleles",
         "_group_index", "_key_frame", "_group_tuples_cache",
-        "_group_codes_cache", "_evaluation_df", "_method_override",
+        "_group_codes_cache", "_df", "_method_override",
     )
 
     def __init__(
@@ -1034,7 +1034,7 @@ class EvalContext:
         self._key_frame = None
         self._group_tuples_cache = None
         self._group_codes_cache = None
-        self._evaluation_df = None
+        self._df = None
         # Internal: when Comparison auto-aggregates across methods, it
         # binds Field(method=None, kind=K) references to a specific
         # method per iteration by setting (kind_value, method_name) here.
@@ -1092,7 +1092,7 @@ class EvalContext:
             derived._group_index = self._group_index
             derived._group_tuples_cache = self._group_tuples_cache
             derived._group_codes_cache = self._group_codes_cache
-            derived._evaluation_df = self._evaluation_df
+            derived._df = self._df
         return derived
 
     @property
@@ -1139,16 +1139,30 @@ class EvalContext:
 
     @property
     def df(self) -> pd.DataFrame:
-        """Prediction rows whose group keys match :attr:`group_index`.
+        """The prediction rows, keyed to match :attr:`group_index`.
 
-        This is the frame every node groups — the built-in ones and
-        your own alike. Missing identity spellings are normalized on a
-        copy when a key needs it, so no node can group by a key
-        ``group_index`` lacks. The DataFrame you passed to this context
-        is never mutated, and is not necessarily this object: to ask
-        whether a context belongs to a frame, use :meth:`is_built_on`.
+        This is the frame every node groups — built-in and yours alike.
+        Its group-key columns are :attr:`key_frame`'s, so a
+        ``groupby(ctx.group_keys)`` over it cannot produce a key
+        ``group_index`` lacks.
+
+        Normalization lands on a copy, and only when some key actually
+        spells a missing value more than one way; the DataFrame handed
+        to :class:`EvalContext` is never mutated, and is not necessarily
+        this object — to ask whether a context belongs to a frame, use
+        :meth:`is_built_on`.
         """
-        return self.evaluation_df
+        if self._df is None:
+            replacements = {
+                key: self.key_frame[key]
+                for key in self.group_keys
+                if not self.key_frame[key].equals(self._source_df[key])
+            }
+            self._df = (
+                self._source_df.assign(**replacements)
+                if replacements else self._source_df
+            )
+        return self._df
 
     def is_built_on(self, df) -> bool:
         """Whether this context was built on ``df`` itself.
@@ -1162,26 +1176,6 @@ class EvalContext:
         is a different object whenever a key needed normalizing.
         """
         return self._source_df is df
-
-    @property
-    def evaluation_df(self) -> pd.DataFrame:
-        """Prediction rows with group keys matching :attr:`key_frame`.
-
-        Nodes group this frame so their pandas groupby keys cannot diverge
-        from ``group_index`` or ``row_group_codes`` after missing-value
-        normalization. The caller's DataFrame remains unchanged.
-        """
-        if self._evaluation_df is None:
-            replacements = {
-                key: self.key_frame[key]
-                for key in self.group_keys
-                if not self.key_frame[key].equals(self._source_df[key])
-            }
-            self._evaluation_df = (
-                self._source_df.assign(**replacements)
-                if replacements else self._source_df
-            )
-        return self._evaluation_df
 
     @property
     def group_index(self) -> pd.Index:
@@ -1616,11 +1610,11 @@ class Column(DSLNode):
         self.col_name = col_name
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        if ctx.evaluation_df.empty:
+        if ctx.df.empty:
             return ctx.empty_series()
-        if self.col_name not in ctx.evaluation_df.columns:
-            raise _missing_column_error(self.col_name, ctx.evaluation_df.columns)
-        vals = ctx.evaluation_df.groupby(
+        if self.col_name not in ctx.df.columns:
+            raise _missing_column_error(self.col_name, ctx.df.columns)
+        vals = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[self.col_name].first()
         vals = vals.reindex(ctx.group_index)
@@ -1702,7 +1696,7 @@ class Includes(DSLNode):
         return Includes(self.col_name, self.value, negate=not self.negate)
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        df = ctx.evaluation_df
+        df = ctx.df
         if df.empty:
             return ctx.empty_series().astype("boolean")
         if self.col_name not in df.columns:
@@ -1768,7 +1762,7 @@ class IsIn(DSLNode):
         return []
 
     def eval(self, ctx: EvalContext) -> pd.Series:
-        df = ctx.evaluation_df
+        df = ctx.df
         if df.empty:
             # Mirror Column.eval's empty path so the result aligns with
             # ctx.group_index regardless of whether the context happens
@@ -1811,7 +1805,7 @@ def _filter_kind_method_version(ctx, kind, method, version):
     ambiguity. Centralizes the filter logic shared between
     :class:`Field` and :class:`BestAlleleField`.
     """
-    df = ctx.evaluation_df
+    df = ctx.df
     if df.empty or "kind" not in df.columns:
         return None
 
@@ -2875,9 +2869,9 @@ class Len(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         col = self.scope + "peptide_length"
-        if ctx.evaluation_df.empty or col not in ctx.evaluation_df.columns:
+        if ctx.df.empty or col not in ctx.df.columns:
             return ctx.empty_series()
-        vals = ctx.evaluation_df.groupby(
+        vals = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[col].first()
         return vals.reindex(ctx.group_index).astype(float)
@@ -2902,11 +2896,11 @@ class Count(DSLNode):
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
         if (
-            ctx.evaluation_df.empty
-            or peptide_col not in ctx.evaluation_df.columns
+            ctx.df.empty
+            or peptide_col not in ctx.df.columns
         ):
             return ctx.empty_series()
-        peptides = ctx.evaluation_df.groupby(
+        peptides = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[peptide_col].first()
         peptides = peptides.reindex(ctx.group_index)
@@ -2950,11 +2944,11 @@ class PeptideProperty(DSLNode):
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
         if (
-            ctx.evaluation_df.empty
-            or peptide_col not in ctx.evaluation_df.columns
+            ctx.df.empty
+            or peptide_col not in ctx.df.columns
         ):
             return ctx.empty_series()
-        peptides = ctx.evaluation_df.groupby(
+        peptides = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
         )[peptide_col].first()
         peptides = peptides.reindex(ctx.group_index)
@@ -3501,7 +3495,7 @@ class Comparison(DSLNode):
             return None
         kind_val = next(iter(kinds))
 
-        df = ctx.evaluation_df
+        df = ctx.df
         if df.empty or "kind" not in df.columns:
             return None
         kind_rows = df[df["kind"] == kind_val]

--- a/topiary/ranking/nodes.py
+++ b/topiary/ranking/nodes.py
@@ -2895,10 +2895,7 @@ class Count(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
-        if (
-            ctx.df.empty
-            or peptide_col not in ctx.df.columns
-        ):
+        if ctx.df.empty or peptide_col not in ctx.df.columns:
             return ctx.empty_series()
         peptides = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False
@@ -2943,10 +2940,7 @@ class PeptideProperty(DSLNode):
 
     def eval(self, ctx: EvalContext) -> pd.Series:
         peptide_col = self.scope + "peptide" if self.scope else "peptide"
-        if (
-            ctx.df.empty
-            or peptide_col not in ctx.df.columns
-        ):
+        if ctx.df.empty or peptide_col not in ctx.df.columns:
             return ctx.empty_series()
         peptides = ctx.df.groupby(
             ctx.group_keys, sort=False, dropna=False


### PR DESCRIPTION
## Summary

Follows #257, now merged; this PR targets master.

#257 made `EvalContext.df` return the normalized frame by turning it into a
property over `evaluation_df`. That left two public names returning the
*identical object*, on a context that already exposes three frame-shaped
attributes (`df`, `key_frame`, `group_index`). This drops one of them.

- remove `EvalContext.evaluation_df`; fold its body into `df`
- migrate the 20 internal readers to `ctx.df`
- rename the private cache slot `_evaluation_df` → `_df`
- document writing a custom node in `docs/ranking.md`
- add an `EvalContext` attribute table to `docs/api.md`, and correct "four keyword-only options" to five in the two places it appears — the table beneath already listed five, `default_versions` having been added without updating the prose
- bump Topiary to 5.51.0

## Why remove rather than alias

`evaluation_df` was added in 5.49.1, is not in `__all__`, is not in the docs,
and has no consumer outside this repo (checked against vaxrank). Per this
repo's convention, a breaking refactor drops the old name outright instead of
carrying a deprecated alias. Anything reading it becomes `ctx.df` — same
object, same contents.

It is a public attribute of a released version, so it gets its own minor bump.

## The docs gap this closes

The rule these two PRs exist to enforce — group `ctx.df`, reindex onto
`ctx.group_index` — was not written down anywhere a consumer would find it.
`DSLNode`'s docstring documented the *return* shape and never said which frame
to group, and `docs/ranking.md` had no section on writing a node at all. #257
added the docstring; this adds the docs section, with a worked example that
composes with the built-in operators:

```python
class MeanRnaAlt(DSLNode):
    def eval(self, ctx):
        return ctx.df.groupby(ctx.group_keys, dropna=False, observed=True)[
            "n_rna_alt"
        ].mean().reindex(ctx.group_index)

combined = (Affinity <= 500) & (MeanRnaAlt() >= 5)
```

The example was executed, not just written: it pools an `allele` spelled
`None` in one row and `"nan"` in another into one group, and leaves the input
frame untouched.

## Naming audit

The prompt for this was `_ThirdPartyGroupingNode` from #256. The underscore
turned out not to be the problem — 20 of the repo's test helper classes are
underscore-prefixed, so that is house style. The problem was that
"ThirdParty" named *who hypothetically writes it* rather than what it does; it
is now `CustomGroupingNode` with a docstring saying what it checks.

Surveying the rest:

- **`evaluation_df` vs `df`** — two public names, one object. Fixed here.
- **`_source_df`, `_Tokenizer`, `_Parser`, `_PeptideAlleleLookup`, `_MissingIdentityValue`, `_UnparseableVersion`** — all read as what they are. Left alone.
- **`filter_context`** — a boolean whose name reads like it takes a context object. Genuinely confusing, but it is long-established, documented in `docs/ranking.md`, and load-bearing in `derive()`. Not worth the churn; noted rather than renamed.
- **`key_frame`** — established since #176/#212 and reasonably descriptive. Left alone.
- **Test doubles mix `Fake*` / `Mock*` / `Stub` / `Toy*`** with inconsistent underscore prefixing. Cosmetic, spread across many files, no user-facing effect. Not touched.

## Verification

- `./lint.sh`
- `./test.sh` — 2390 passed, 0 skipped, 92% coverage
- Vaxrank suite with `PYTHONPATH` pointed at this checkout (confirmed `topiary 5.51.0`) — 1193 passed, 0 skipped
- Every attribute in the new `docs/api.md` table executed against a real context, including that `row_group_tuples()` is in fact aligned to `ctx.df.index` as documented
- Docs example executed against this branch
- `hasattr(EvalContext, "evaluation_df")` is `False`; no `evaluation_df` remains anywhere in the tree

https://claude.ai/code/session_01AgA7gi5ynUA8BjHfxLshGc