### PR TITLE
Declare optional dependency extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.52.1
+
+**Optional dependencies use package metadata (#262).** Isovar and PirlyGenes
+remain lazy, opt-in integrations, now installable as `topiary[isovar]` and
+`topiary[pirlygenes]`. Their minimum versions live once in standard package
+metadata instead of duplicated tuple/string globals and hand-written version
+parsers. Runtime checks validate the exact API Topiary needs and distinguish a
+missing package from an installed package whose import or transitive dependency
+is broken, preserving the original exception as the cause.
+
 ## 5.52.0
 
 **Fixed pVACtools prediction data loss (#259).** `read_pvacseq` now emits native

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ pyensembl install --release 112 --species human
 For cancer-testis antigen and tissue expression features:
 
 ```bash
-pip install pirlygenes
+pip install 'topiary[pirlygenes]'
+```
+
+For RNA-assembled protein fragments from Isovar:
+
+```bash
+pip install 'topiary[isovar]'
 ```
 
 **MHC predictors** (NetMHCpan, mhcflurry, etc.) are installed

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -208,8 +208,9 @@ def support(fragment):
     return fragment.n_rna_alt          # None where the source has no RNA
 ```
 
-**isovar is optional in the strong sense** — not in `requirements.txt`, and
-`import topiary` does not import it. Only `fragments_from_variants` with an
+**isovar is optional in the strong sense** — it is not a base requirement, and
+`import topiary` does not import it. Install it with
+`pip install 'topiary[isovar]'`; only `fragments_from_variants` with an
 `alignment_file` needs it.
 
 ### Reads and fragments

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -128,12 +128,12 @@ or not it can populate them.
 
 ### isovar is optional in the strong sense
 
-Not imported at module scope, not in `requirements.txt`, and topiary's shape is
-identical whether or not it is installed — `import topiary` does not import it.
-Only `fragments_from_variants` with an `alignment_file` imports it, and it says
-how to install it if missing. `fragment_from_isovar_result` needs nothing from
-isovar at all — it reads an already-built result by attribute. A consumer that only reads LENS reports should not pay for a package
-it never calls.
+Not imported at module scope and not in Topiary's base requirements, so
+`import topiary` does not import it. Install the optional integration with
+`pip install 'topiary[isovar]'`. Only `fragments_from_variants` with an
+`alignment_file` imports it. `fragment_from_isovar_result` needs nothing from
+isovar at all — it reads an already-built result by attribute. A consumer that
+only reads LENS reports should not pay for a package it never calls.
 
 isovar is also the only source that *counts* the reads supporting an assembled
 sequence. Everything else derives them or counts something adjacent, which is

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,13 @@ pyensembl install --release 112 --species human
 For cancer-testis antigen and tissue expression features:
 
 ```bash
-pip install pirlygenes
+pip install 'topiary[pirlygenes]'
+```
+
+For RNA-assembled protein fragments from Isovar:
+
+```bash
+pip install 'topiary[isovar]'
 ```
 
 See the [Quickstart](quickstart.md) for more examples, [Protein Fragments](fragments.md) for the universal antigen abstraction, [Cached Predictions](cached.md) for running from pre-computed scores, [Ranking DSL](ranking.md) for the expression system, and [API Reference](api.md) for full details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ exclude = ["test", "test.*"]
 [project.scripts]
 topiary = "topiary.cli.script:main"
 
+[project.optional-dependencies]
+isovar = ["isovar>=1.7.2"]
+pirlygenes = ["pirlygenes>=5.1.0"]
+
 [tool.ruff.lint]
 select = ["E", "F"]
 ignore = ["F821", "E501", "F841", "E731", "E741", "E722", "E721"]

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -25,6 +25,22 @@ def test_import_topiary_does_not_import_varcode():
     )
 
 
+def test_import_topiary_does_not_import_optional_dependencies():
+    _run_import_check(
+        """
+        import sys
+        import topiary
+
+        for package in ("isovar", "pirlygenes"):
+            if any(
+                k == package or k.startswith(package + ".")
+                for k in sys.modules
+            ):
+                raise SystemExit(f"import topiary imported {package}")
+        """
+    )
+
+
 def test_cli_variant_helpers_delegate_to_varcode():
     _run_import_check(
         """

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -74,34 +74,6 @@ def test_tissue_expressed_gene_ids_strict():
     assert len(strict) < len(loose)
 
 
-def test_check_pirlygenes_rejects_old_version(monkeypatch):
-    pirlygenes = pytest.importorskip("pirlygenes")
-    from topiary.sources import _check_pirlygenes
-
-    monkeypatch.setattr(pirlygenes, "__version__", "5.0.2")
-    with pytest.raises(ImportError, match="pirlygenes>=5.1.0"):
-        _check_pirlygenes()
-
-
-@pytest.mark.parametrize(
-    "version, accepted",
-    [
-        ("5.0.2", False),
-        ("5.1.0rc1", False),
-        ("5.1.0.dev1", False),
-        ("5.1.0", True),
-        ("5.1", True),
-        ("5.1.0+local", True),
-        ("5.1.0.post1", True),
-        ("5.1.1", True),
-    ],
-)
-def test_pirlygenes_version_check(version, accepted):
-    from topiary.sources import _pirlygenes_version_at_least
-
-    assert _pirlygenes_version_at_least(version) is accepted
-
-
 def test_predictor_with_alleles_and_model_classes():
     from mhctools import RandomBindingPredictor
     from topiary import TopiaryPredictor, Affinity

--- a/tests/test_sources_optional.py
+++ b/tests/test_sources_optional.py
@@ -1,22 +1,6 @@
-import builtins
-
 import pytest
 
 import topiary.sources as sources
-
-
-def test_check_pirlygenes_raises_clear_error(monkeypatch):
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "pirlygenes" or name.startswith("pirlygenes."):
-            raise ImportError("No module named 'pirlygenes'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    with pytest.raises(ImportError, match="pirlygenes>=5.1.0"):
-        sources._check_pirlygenes()
 
 
 # PirlyGenes has shipped per-tissue normalized-TPM columns under two

--- a/tests/test_twin_conformance.py
+++ b/tests/test_twin_conformance.py
@@ -22,13 +22,19 @@ variant, a format branch, a second constructor -- add the pair to
 """
 
 from dataclasses import dataclass, field
+from importlib.metadata import requires
+from types import SimpleNamespace
 from typing import Callable, Dict, Tuple
 
 import pandas as pd
 import pytest
+from packaging.requirements import Requirement
 
 from topiary.evidence import attach_dna_evidence, attach_rna_evidence
 from topiary import read_pvacseq
+from topiary.io_isovar import _check_isovar
+from topiary.sources import _check_pirlygenes
+import topiary.optional_dependencies as optional_dependencies
 
 
 @dataclass(frozen=True)
@@ -89,6 +95,153 @@ PVACSEQ_PRESENTATION_TWINS = (
         "tests/data/pvacseq/mhc_i_all_epitopes_presentation.tsv",
     ),
 )
+
+
+# ---------------------------------------------------------------------------
+# Optional integrations
+#
+# Isovar and PirlyGenes are independent doors, but both must distinguish an
+# absent optional package from a broken installed package in the same way.
+# ---------------------------------------------------------------------------
+
+OPTIONAL_DEPENDENCY_TWINS = (
+    (
+        "isovar",
+        "run_isovar",
+        _check_isovar,
+        "assembling protein fragments from RNA alignments",
+        ">=1.7.2",
+    ),
+    (
+        "pirlygenes",
+        "pan_cancer_expression",
+        lambda: _check_pirlygenes("pan_cancer_expression"),
+        "cancer-testis antigen and tissue-expression gene lists",
+        ">=5.1.0",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("dependency", "required_api", "check", "feature", "specifier"),
+    OPTIONAL_DEPENDENCY_TWINS,
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_optional_dependency_metadata_has_one_floor(
+    dependency, required_api, check, feature, specifier,
+):
+    del required_api, check, feature
+    declared = [
+        Requirement(text) for text in (requires("topiary") or ())
+        if Requirement(text).name == dependency
+    ]
+
+    assert len(declared) == 1
+    assert str(declared[0].specifier) == specifier
+    assert declared[0].marker.evaluate({"extra": dependency})
+    other = "pirlygenes" if dependency == "isovar" else "isovar"
+    assert not declared[0].marker.evaluate({"extra": other})
+
+
+@pytest.mark.parametrize(
+    ("dependency", "required_api", "check", "feature", "specifier"),
+    OPTIONAL_DEPENDENCY_TWINS,
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_optional_dependency_missing_errors_match(
+    monkeypatch, dependency, required_api, check, feature, specifier,
+):
+    del required_api, specifier
+    original = ModuleNotFoundError(
+        f"No module named '{dependency}'", name=dependency,
+    )
+
+    def missing(module_name):
+        del module_name
+        raise original
+
+    monkeypatch.setattr(optional_dependencies, "import_module", missing)
+
+    with pytest.raises(ImportError) as raised:
+        check()
+
+    message = str(raised.value)
+    assert feature in message
+    assert f"pip install 'topiary[{dependency}]'" in message
+    assert "installed but" not in message
+    assert raised.value.__cause__ is original
+
+
+@pytest.mark.parametrize(
+    ("dependency", "required_api", "check", "feature", "specifier"),
+    OPTIONAL_DEPENDENCY_TWINS,
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_optional_dependency_broken_import_errors_match(
+    monkeypatch, dependency, required_api, check, feature, specifier,
+):
+    del required_api, specifier
+    original = ModuleNotFoundError(
+        "No module named 'broken_transitive_dependency'",
+        name="broken_transitive_dependency",
+    )
+
+    def broken(module_name):
+        del module_name
+        raise original
+
+    monkeypatch.setattr(optional_dependencies, "import_module", broken)
+
+    with pytest.raises(ImportError) as raised:
+        check()
+
+    message = str(raised.value)
+    assert feature in message
+    assert "installed but could not be imported" in message
+    assert "broken_transitive_dependency" in message
+    assert f"pip install --upgrade 'topiary[{dependency}]'" in message
+    assert raised.value.__cause__ is original
+
+
+@pytest.mark.parametrize(
+    ("dependency", "required_api", "check", "feature", "specifier"),
+    OPTIONAL_DEPENDENCY_TWINS,
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_optional_dependency_capability_errors_match(
+    monkeypatch, dependency, required_api, check, feature, specifier,
+):
+    del feature, specifier
+    monkeypatch.setattr(
+        optional_dependencies,
+        "import_module",
+        lambda module_name: SimpleNamespace(__name__=module_name),
+    )
+
+    with pytest.raises(ImportError) as raised:
+        check()
+
+    message = str(raised.value)
+    assert "installed but does not provide the API" in message
+    assert required_api in message
+    assert f"pip install --upgrade 'topiary[{dependency}]'" in message
+
+
+@pytest.mark.parametrize(
+    ("dependency", "required_api", "check", "feature", "specifier"),
+    OPTIONAL_DEPENDENCY_TWINS,
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_optional_dependency_capabilities_load_through_both_doors(
+    monkeypatch, dependency, required_api, check, feature, specifier,
+):
+    del dependency, feature, specifier
+    module = SimpleNamespace(**{required_api: lambda: None})
+    monkeypatch.setattr(
+        optional_dependencies, "import_module", lambda module_name: module,
+    )
+
+    assert check() is module
 
 
 @pytest.mark.parametrize(

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -158,7 +158,7 @@ from .result import (
 from .prediction_columns import PredictionMetric, parse_prediction_metric
 from .wide import detect_form, from_wide, to_wide
 
-__version__ = "5.52.0"
+__version__ = "5.52.1"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -18,32 +18,16 @@ from typing import Optional
 
 from .protein_fragment import ProteinFragment
 from .evidence import ISOVAR_ASSEMBLY, RNA_ALIGNMENT
-
-_MIN_ISOVAR = (1, 7, 2)
-_MIN_ISOVAR_TEXT = "1.7.2"
+from .optional_dependencies import require_optional_dependency
 
 
 def _check_isovar():
-    """Import isovar or explain how to get it, the way pirlygenes is."""
-    try:
-        import isovar
-    except ImportError:
-        raise ImportError(
-            f"isovar is required to build fragments from RNA-assembled "
-            f"protein sequences. Install with: "
-            f"pip install 'isovar>={_MIN_ISOVAR_TEXT}'"
-        ) from None
-    version = getattr(isovar, "__version__", "0.0.0")
-    parts = []
-    for piece in str(version).split(".")[:3]:
-        digits = "".join(c for c in piece if c.isdigit())
-        parts.append(int(digits) if digits else 0)
-    if tuple(parts + [0, 0, 0][: 3 - len(parts)]) < _MIN_ISOVAR:
-        raise ImportError(
-            f"isovar>={_MIN_ISOVAR_TEXT} required; found {version}. "
-            f"Upgrade with: pip install -U 'isovar>={_MIN_ISOVAR_TEXT}'"
-        )
-    return isovar
+    """Load the Isovar API used to assemble variants from RNA reads."""
+    return require_optional_dependency(
+        "isovar",
+        feature="assembling protein fragments from RNA alignments",
+        required_callables=("run_isovar",),
+    )
 
 
 def fragment_from_isovar_result(
@@ -402,8 +386,13 @@ def fragments_from_variants(
     isovar = _check_isovar()
     creator = isovar_kwargs.pop("protein_sequence_creator", None)
     if creator is None:
-        from isovar.protein_sequence_creator import ProteinSequenceCreator
-        creator = ProteinSequenceCreator(
+        creator_module = require_optional_dependency(
+            "isovar.protein_sequence_creator",
+            feature="assembling protein fragments from RNA alignments",
+            extra="isovar",
+            required_callables=("ProteinSequenceCreator",),
+        )
+        creator = creator_module.ProteinSequenceCreator(
             protein_sequence_length=protein_sequence_length,
             # Without assembly a single read or fragment must span the
             # whole window, so a longer context quietly yields fewer

--- a/topiary/optional_dependencies.py
+++ b/topiary/optional_dependencies.py
@@ -1,0 +1,62 @@
+"""Shared lazy loading for Topiary's optional integrations."""
+
+from importlib import import_module
+
+
+def require_optional_dependency(
+    module_name,
+    *,
+    feature,
+    extra=None,
+    required_callables=(),
+):
+    """Import an optional module and report actionable failures.
+
+    Package-version floors belong in installer metadata. Runtime checks here
+    cover the question Topiary can answer reliably: whether the module and the
+    exact API needed by a feature can be loaded.
+    """
+    dependency_name = module_name.partition(".")[0]
+    extra = dependency_name if extra is None else extra
+    install = f"pip install 'topiary[{extra}]'"
+    upgrade = f"pip install --upgrade 'topiary[{extra}]'"
+
+    try:
+        module = import_module(module_name)
+    except ModuleNotFoundError as error:
+        if error.name == dependency_name:
+            raise ImportError(
+                f"{dependency_name} is required for {feature}. "
+                f"Install it with: {install}"
+            ) from error
+        raise ImportError(
+            f"{dependency_name} is installed but could not be imported for "
+            f"{feature}: {error}. Repair its dependencies or reinstall with: "
+            f"{upgrade}"
+        ) from error
+    except Exception as error:
+        raise ImportError(
+            f"{dependency_name} is installed but could not be imported for "
+            f"{feature}: {error}. Repair the installation or reinstall with: "
+            f"{upgrade}"
+        ) from error
+
+    try:
+        missing = [
+            name for name in required_callables
+            if not callable(getattr(module, name, None))
+        ]
+    except Exception as error:
+        raise ImportError(
+            f"{dependency_name} is installed, but loading the API required "
+            f"for {feature} failed: {error}. Repair the installation or "
+            f"reinstall with: {upgrade}"
+        ) from error
+    if missing:
+        raise ImportError(
+            f"{dependency_name} is installed but does not provide the API "
+            f"required for {feature}: {', '.join(missing)}. Install a "
+            f"compatible release with: {upgrade}"
+        )
+
+    return module

--- a/topiary/self_proteome.py
+++ b/topiary/self_proteome.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from collections import defaultdict
+from importlib.metadata import PackageNotFoundError, version as package_version
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -744,9 +745,9 @@ def _cta_label(species, cta_source, cta_set):
     if cta_source is None and species == "human":
         # Using pirlygenes default.
         try:
-            import pirlygenes
-            return f"non_cta+cta-pirlygenes-{pirlygenes.__version__}"
-        except (ImportError, AttributeError):
+            version = package_version("pirlygenes")
+            return f"non_cta+cta-pirlygenes-{version}"
+        except PackageNotFoundError:
             return "non_cta+cta-pirlygenes"
     if isinstance(cta_source, str):
         return f"non_cta+cta-{cta_source}"

--- a/topiary/sources.py
+++ b/topiary/sources.py
@@ -16,9 +16,10 @@ Ensembl data is downloaded on first use via pyensembl.
 """
 
 import logging
-import re
 
 from pyensembl import EnsemblRelease, ensembl_grch38
+
+from .optional_dependencies import require_optional_dependency
 
 
 # ---------------------------------------------------------------------------
@@ -212,9 +213,8 @@ def tissue_expressed_gene_ids(tissues, min_ntpm=1.0):
     """
     if not tissues:
         raise ValueError("tissues must be a non-empty list")
-    _check_pirlygenes()
-    from pirlygenes import pan_cancer_expression
-    pce = pan_cancer_expression()
+    pirlygenes = _check_pirlygenes("pan_cancer_expression")
+    pce = pirlygenes.pan_cancer_expression()
 
     cols = _tissue_columns(pce, tissues)
 
@@ -242,9 +242,8 @@ def tissue_expressed_sequences(tissues, min_ntpm=1.0, release=None):
 
 def available_tissues():
     """List all available tissue names from PirlyGenes expression data."""
-    _check_pirlygenes()
-    from pirlygenes import pan_cancer_expression
-    return sorted(_tissue_column_map(pan_cancer_expression()))
+    pirlygenes = _check_pirlygenes("pan_cancer_expression")
+    return sorted(_tissue_column_map(pirlygenes.pan_cancer_expression()))
 
 
 # ---------------------------------------------------------------------------
@@ -320,45 +319,20 @@ def _tissue_columns(pce, tissues):
     return [columns[t] for t in tissues]
 
 
-_PIRLYGENES_MIN = (5, 1, 0)
-_PIRLYGENES_MIN_TEXT = "5.1.0"
-_PIRLYGENES_VERSION_RE = re.compile(r"^\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?")
-_PIRLYGENES_PRERELEASE_RE = re.compile(
-    r"^\s*[-_.]?\s*(?:a|alpha|b|beta|rc|c|pre|preview|dev)",
-    re.I,
-)
-
-
-def _check_pirlygenes():
-    try:
-        import pirlygenes
-    except ImportError:
-        raise ImportError(
-            "pirlygenes is required for CTA/tissue gene lists. "
-            "Install with: pip install 'pirlygenes>=5.1.0'"
-        ) from None
-    version = getattr(pirlygenes, "__version__", "0.0.0")
-    if not _pirlygenes_version_at_least(version):
-        raise ImportError(
-            f"pirlygenes>={_PIRLYGENES_MIN_TEXT} required for CTA/tissue "
-            f"gene lists; found {version}. Upgrade with: "
-            f"pip install -U 'pirlygenes>={_PIRLYGENES_MIN_TEXT}'"
-        )
-
-
-def _pirlygenes_version_at_least(version):
-    text = str(version)
-    match = _PIRLYGENES_VERSION_RE.match(text)
-    if match is None:
-        return False
-    parts = tuple(int(p) if p is not None else 0 for p in match.groups())
-    if parts != _PIRLYGENES_MIN:
-        return parts > _PIRLYGENES_MIN
-    suffix = text[match.end():]
-    return _PIRLYGENES_PRERELEASE_RE.match(suffix) is None
+def _check_pirlygenes(*required_callables):
+    """Load the PirlyGenes API used for CTA and tissue-expression data."""
+    return require_optional_dependency(
+        "pirlygenes",
+        feature="cancer-testis antigen and tissue-expression gene lists",
+        required_callables=required_callables,
+    )
 
 
 def _pirlygenes_cta_gene_ids():
-    _check_pirlygenes()
-    from pirlygenes.gene_sets_cancer import CTA_gene_ids
-    return set(CTA_gene_ids())
+    gene_sets = require_optional_dependency(
+        "pirlygenes.gene_sets_cancer",
+        feature="cancer-testis antigen gene lists",
+        extra="pirlygenes",
+        required_callables=("CTA_gene_ids",),
+    )
+    return set(gene_sets.CTA_gene_ids())


### PR DESCRIPTION
## Summary

- declare `topiary[isovar]` and `topiary[pirlygenes]` with their supported version floors in package metadata
- replace duplicate version globals and custom parsers with one lazy capability loader
- distinguish a genuinely absent package from an installed package with a broken import, preserving the original exception
- validate the callable APIs each workflow uses and keep plain `import topiary` free of both optional packages
- document the exact extras users should install

Closes #262.

## Verification

- `./lint.sh`
- `./test.sh`: 2,678 passed, 10 skipped, 92% coverage
- isolated wheel and sdist build
- `twine check` passes for both artifacts
- wheel metadata verified for `Provides-Extra` and exact `Requires-Dist` entries
- real installed-but-broken PirlyGenes environment reports its `oncoref` failure as the chained cause rather than claiming PirlyGenes is absent