### PR TITLE
Remove mutable model lookup cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.52.3
+
+**Function-owned model registry cache (#264).** Model-name resolution now uses
+a bounded `lru_cache` on its immutable registry builder. This removes the last
+mutable lazy-cache global and its `global` mutation, while providing an
+explicit `cache_clear()` boundary for tests and registry refreshes. The
+independent BLOSUM cache was removed in 5.52.2 as part of #263.
+
 ## 5.52.2
 
 **Central amino-acid data API (#263).** `AMINO_ACIDS`,

--- a/tests/test_predictor_internals.py
+++ b/tests/test_predictor_internals.py
@@ -1,12 +1,59 @@
 """Direct unit tests for TopiaryPredictor private methods."""
 
+from types import MappingProxyType
+
 import numpy as np
 import pandas as pd
 import pytest
 from mhctools import RandomBindingPredictor
 
 from topiary import TopiaryPredictor
-from topiary.predictor import _attach_expression_data
+from topiary.predictor import (
+    _attach_expression_data,
+    _build_model_lookup,
+    _resolve_model_name,
+)
+
+
+def test_model_lookup_cache_is_immutable_and_reused():
+    _build_model_lookup.cache_clear()
+
+    first = _build_model_lookup()
+    second = _build_model_lookup()
+
+    assert first is second
+    assert isinstance(first, MappingProxyType)
+    with pytest.raises(TypeError):
+        first["new-model"] = object()
+
+
+def test_model_lookup_cache_has_explicit_invalidation(monkeypatch):
+    import mhctools.cli
+
+    class FirstPredictor:
+        def predict_dataframe(self):
+            pass
+
+    class SecondPredictor:
+        def predict_dataframe(self):
+            pass
+
+    monkeypatch.setattr(mhctools.cli, "mhc_predictors", {
+        "changing-model": FirstPredictor,
+    })
+    _build_model_lookup.cache_clear()
+    try:
+        assert _resolve_model_name("changing-model") is FirstPredictor
+
+        monkeypatch.setattr(mhctools.cli, "mhc_predictors", {
+            "changing-model": SecondPredictor,
+        })
+        assert _resolve_model_name("changing-model") is FirstPredictor
+
+        _build_model_lookup.cache_clear()
+        assert _resolve_model_name("changing-model") is SecondPredictor
+    finally:
+        _build_model_lookup.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -165,7 +165,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.2"
+__version__ = "5.52.3"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -13,6 +13,8 @@
 import logging
 from collections import Counter
 from collections.abc import Iterable, Mapping
+from functools import lru_cache
+from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -124,6 +126,7 @@ def _model_metadata_versions(models):
     return versions
 
 
+@lru_cache(maxsize=1)
 def _build_model_lookup():
     """Build a normalized name → mhctools predictor factory mapping.
 
@@ -144,10 +147,7 @@ def _build_model_lookup():
             if name:
                 lookup[name.lower()] = factory
                 lookup[normalized(name)] = factory
-    return lookup
-
-
-_MODEL_LOOKUP = None
+    return MappingProxyType(lookup)
 
 
 def _resolve_model_name(name):
@@ -156,16 +156,14 @@ def _resolve_model_name(name):
     Supports case-insensitive matching against mhctools class names,
     e.g. ``"netmhcpan41"`` → ``NetMHCpan41``, ``"mhcflurry"`` → ``MHCflurry``.
     """
-    global _MODEL_LOOKUP
-    if _MODEL_LOOKUP is None:
-        _MODEL_LOOKUP = _build_model_lookup()
+    model_lookup = _build_model_lookup()
 
     key = name.lower().replace("-", "").replace("_", "").replace(" ", "")
-    factory = _MODEL_LOOKUP.get(key)
+    factory = model_lookup.get(key)
     if factory is None:
-        factory = _MODEL_LOOKUP.get(name.lower())
+        factory = model_lookup.get(name.lower())
     if factory is None:
-        available = sorted(_MODEL_LOOKUP.keys())
+        available = sorted(model_lookup.keys())
         raise ValueError(
             f"Unknown model name {name!r}. Available: {available}"
         )


### PR DESCRIPTION
Closes #264.

Model-name resolution now gets its registry from a bounded lru_cache attached directly to the builder. The cached mapping is immutable, the mutable module global and global statement are gone, and cache_clear provides one explicit invalidation boundary. Tests prove reuse, immutability, and that clearing exposes a changed mhctools registry.

The second cache named in #264, BLOSUM62, was already removed through the centralized immutable amino-acid API in #263 / Topiary 5.52.2.

Verification:
- ./lint.sh
- ./test.sh: 2,691 passed, 10 skipped; 92% coverage
- fresh wheel and sdist built; twine check passed