### PR TITLE
Define ProteinFragment constructor without monkey-patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.52.4
+
+**Normal ProteinFragment construction (#265).** `ProteinFragment` now defines
+its compatibility-aware constructor and legacy read-only properties in the
+class itself. The import-time `__init__` replacement and post-definition class
+mutation are gone. Direct construction and serialized input still accept the
+5.x legacy evidence names, while current-name-only output, positional behavior,
+frozen dataclass semantics, and independent mapping defaults are preserved.
+
 ## 5.52.3
 
 **Function-owned model registry cache (#264).** Model-name resolution now uses

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -28,6 +28,7 @@ from topiary import (
     attach_rna_evidence,
     describe_read_evidence,
     evaluate_scores,
+    fragment_from_effect,
     fragment_from_isovar_result,
     fragments_from_dataframe,
     peptide_view,
@@ -319,6 +320,19 @@ class _IsovarResult:
     num_ref_reads = 60
 
 
+class _Effect:
+    mutant_protein_sequence = "MKTVRQERLK"
+    original_protein_sequence = "MKTVAQERLK"
+    aa_mutation_start_offset = 4
+    aa_mutation_end_offset = 5
+    gene_name = "BRAF"
+    gene_id = "ENSG1"
+    transcript_id = "ENST1"
+    transcript_name = "BRAF-204"
+    short_description = "p.A5R"
+    variant = type("Variant", (), {"short_description": "chr7:1A>T"})()
+
+
 def test_one_consumer_function_reads_every_source():
     """The multi-source premise, exercised rather than described."""
     def support(fragment):
@@ -328,12 +342,14 @@ def test_one_consumer_function_reads_every_source():
 
     sources = {
         "isovar": fragment_from_isovar_result(_IsovarResult()),
+        "varcode": fragment_from_effect(_Effect(), padding_around_mutation=2),
         "lens": fragments_from_dataframe(_long(read_lens, LENS))[0],
         "pvacseq": fragments_from_dataframe(_long(read_pvacseq, PVACSEQ))[0],
     }
     answers = {name: support(f) for name, f in sources.items()}
 
     assert answers["isovar"] is False        # counted
+    assert answers["varcode"] is None        # no RNA evidence
     assert answers["pvacseq"] is True        # derived
     assert "lens" in answers                 # whatever LENS has, one call
 

--- a/tests/test_protein_fragment.py
+++ b/tests/test_protein_fragment.py
@@ -1,5 +1,7 @@
 """Tests for topiary.protein_fragment (ProteinFragment + helpers)."""
 
+import dataclasses
+import inspect
 import json
 import tempfile
 from pathlib import Path
@@ -95,6 +97,57 @@ class TestIdentity:
         # on fragment_id.
         f = self._sample(annotations={"vaf": 0.5})
         hash(f)  # does not raise
+
+    def test_constructor_signature_tracks_the_dataclass_fields(self):
+        signature = inspect.signature(ProteinFragment)
+        parameters = list(signature.parameters.values())
+        fragment_fields = list(dataclasses.fields(ProteinFragment))
+
+        assert [parameter.name for parameter in parameters] == [
+            fragment_field.name for fragment_field in fragment_fields
+        ]
+        assert all(
+            parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in parameters
+        )
+        assert signature.return_annotation is None
+        assert not hasattr(ProteinFragment.__init__, "__wrapped__")
+        assert ProteinFragment.__dataclass_params__.init is True
+
+        implementation = inspect.signature(ProteinFragment.__init__)
+        legacy = list(implementation.parameters.values())[-1]
+        assert legacy.name == "legacy_fields"
+        assert legacy.kind is inspect.Parameter.VAR_KEYWORD
+
+        for parameter, fragment_field in zip(parameters, fragment_fields):
+            if fragment_field.default is not dataclasses.MISSING:
+                assert parameter.default == fragment_field.default
+            elif fragment_field.default_factory is not dataclasses.MISSING:
+                assert repr(parameter.default) == "<factory>"
+            else:
+                assert parameter.default is inspect.Parameter.empty
+
+    def test_positional_construction_is_preserved(self):
+        fragment = ProteinFragment("id", "variant:snv", "SIINFEKLA")
+
+        assert fragment.fragment_id == "id"
+        assert fragment.source_type == "variant:snv"
+        assert fragment.sequence == "SIINFEKLA"
+
+    def test_default_mappings_are_independent(self):
+        first = ProteinFragment("first")
+        second = ProteinFragment("second")
+
+        assert first.field_provenance == second.field_provenance == {}
+        assert first.annotations == second.annotations == {}
+        assert first.field_provenance is not second.field_provenance
+        assert first.annotations is not second.annotations
+
+    def test_frozen_assignment_is_preserved(self):
+        fragment = ProteinFragment("frozen")
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            fragment.sequence = "CHANGED"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_twin_conformance.py
+++ b/tests/test_twin_conformance.py
@@ -21,6 +21,7 @@ variant, a format branch, a second constructor -- add the pair to
 ``TWINS`` rather than trusting review to notice the next divergence.
 """
 
+import dataclasses
 from dataclasses import dataclass, field
 from importlib.metadata import requires
 from types import SimpleNamespace
@@ -30,8 +31,12 @@ import pandas as pd
 import pytest
 from packaging.requirements import Requirement
 
-from topiary.evidence import attach_dna_evidence, attach_rna_evidence
-from topiary import read_pvacseq
+from topiary.evidence import (
+    RENAMED_COLUMNS,
+    attach_dna_evidence,
+    attach_rna_evidence,
+)
+from topiary import APPROXIMATED, MEASURED, ProteinFragment, read_pvacseq
 from topiary.io_isovar import _check_isovar
 from topiary.sources import _check_pirlygenes
 import topiary.optional_dependencies as optional_dependencies
@@ -120,6 +125,92 @@ OPTIONAL_DEPENDENCY_TWINS = (
         ">=5.1.0",
     ),
 )
+
+
+# ---------------------------------------------------------------------------
+# ProteinFragment construction
+#
+# Direct construction and serialized input are two doors onto the same field
+# migration contract. Drive every applicable rename through both so adding a
+# constructor path cannot make old files and old Python calls mean different
+# things again.
+# ---------------------------------------------------------------------------
+
+_FRAGMENT_FIELD_NAMES = {
+    fragment_field.name for fragment_field in dataclasses.fields(ProteinFragment)
+}
+FRAGMENT_FIELD_RENAMES = tuple(sorted(
+    (old, new) for old, new in RENAMED_COLUMNS.items()
+    if new in _FRAGMENT_FIELD_NAMES
+))
+
+
+def _construct_fragment_directly(values):
+    return ProteinFragment(fragment_id="direct", sequence="SIINFEKLA", **values)
+
+
+def _construct_fragment_from_dict(values):
+    return ProteinFragment.from_dict({
+        "fragment_id": "direct",
+        "sequence": "SIINFEKLA",
+        **values,
+    })
+
+
+FRAGMENT_CONSTRUCTION_DOORS = (
+    ("direct", _construct_fragment_directly),
+    ("from_dict", _construct_fragment_from_dict),
+)
+
+
+@pytest.mark.parametrize(("old", "new"), FRAGMENT_FIELD_RENAMES)
+@pytest.mark.parametrize(
+    "style", ("legacy", "current", "matching", "empty-current"),
+)
+def test_fragment_construction_doors_agree_on_renames(old, new, style):
+    if style == "legacy":
+        values = {old: 12, "field_provenance": {old: APPROXIMATED}}
+    elif style == "current":
+        values = {new: 12, "field_provenance": {new: APPROXIMATED}}
+    elif style == "matching":
+        values = {
+            old: 12,
+            new: 12,
+            "field_provenance": {old: APPROXIMATED, new: APPROXIMATED},
+        }
+    else:
+        values = {
+            old: 12,
+            new: None,
+            "field_provenance": {old: APPROXIMATED},
+        }
+
+    fragments = [door(values) for _, door in FRAGMENT_CONSTRUCTION_DOORS]
+    assert fragments[0].to_dict() == fragments[1].to_dict()
+    for fragment in fragments:
+        assert getattr(fragment, old) == getattr(fragment, new) == 12
+        assert fragment.provenance_of(old) == APPROXIMATED
+        assert old not in fragment.to_dict()
+
+
+@pytest.mark.parametrize(("old", "new"), FRAGMENT_FIELD_RENAMES)
+@pytest.mark.parametrize("conflict", ("value", "provenance"))
+def test_fragment_construction_doors_agree_on_conflicts(old, new, conflict):
+    values = {old: 12, new: 13}
+    if conflict == "provenance":
+        values = {
+            old: 12,
+            "field_provenance": {old: MEASURED, new: APPROXIMATED},
+        }
+
+    errors = []
+    for _, door in FRAGMENT_CONSTRUCTION_DOORS:
+        with pytest.raises(ValueError) as raised:
+            door(values)
+        errors.append(str(raised.value))
+
+    assert errors[0] == errors[1]
+    assert "Conflicting ProteinFragment fields" in errors[0]
 
 
 @pytest.mark.parametrize(

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -165,7 +165,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.3"
+__version__ = "5.52.4"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/protein_fragment.py
+++ b/topiary/protein_fragment.py
@@ -13,8 +13,8 @@ and format-specific loaders live in sibling modules.
 from __future__ import annotations
 
 import dataclasses
-import functools
 import hashlib
+import inspect
 import json
 import re
 from dataclasses import dataclass, field
@@ -40,6 +40,18 @@ PROVENANCE_VALUES = frozenset({MEASURED, APPROXIMATED, SYNTHESIZED})
 
 #: Provenance values a consumer must not interpret as biology.
 _NOT_BIOLOGY = frozenset({SYNTHESIZED})
+
+
+class _DefaultFactory:
+    """Signature sentinel for fields whose default comes from a factory."""
+
+    __slots__ = ()
+
+    def __repr__(self):
+        return "<factory>"
+
+
+_DEFAULT_FACTORY = _DefaultFactory()
 
 
 def _fragment_field_renames(known_fields: set) -> dict:
@@ -242,6 +254,82 @@ n_rna_alt_fragments_supporting_protein_sequence : int, optional
 
     annotations: dict = field(default_factory=dict)
 
+    def __init__(
+        self,
+        fragment_id: str,
+        source_type: Optional[str] = None,
+        sequence: str = "",
+        reference_sequence: Optional[str] = None,
+        germline_sequence: Optional[str] = None,
+        target_intervals: Optional[list] = None,
+        variant: Optional[str] = None,
+        effect: Optional[str] = None,
+        effect_type: Optional[str] = None,
+        gene: Optional[str] = None,
+        gene_id: Optional[str] = None,
+        transcript_id: Optional[str] = None,
+        transcript_name: Optional[str] = None,
+        gene_expression: Optional[float] = None,
+        transcript_expression: Optional[float] = None,
+        n_rna_overlapping_reads: Optional[int] = None,
+        n_rna_alt_reads: Optional[int] = None,
+        n_rna_ref_reads: Optional[int] = None,
+        n_rna_other_reads: Optional[int] = None,
+        n_rna_alt_reads_supporting_protein_sequence: Optional[int] = None,
+        n_rna_overlapping_fragments: Optional[int] = None,
+        n_rna_alt_fragments: Optional[int] = None,
+        n_rna_ref_fragments: Optional[int] = None,
+        n_rna_other_fragments: Optional[int] = None,
+        n_rna_alt_fragments_supporting_protein_sequence: Optional[int] = None,
+        field_provenance: dict = _DEFAULT_FACTORY,
+        annotations: dict = _DEFAULT_FACTORY,
+        **legacy_fields,
+    ) -> None:
+        """Initialize a fragment, accepting legacy evidence names as keywords.
+
+        Current fields retain their dataclass order and positional behavior.
+        Evidence names from Topiary 5.47 and earlier are accepted only as
+        additional keywords and migrate through the same implementation used
+        by serialized input.
+        """
+        arguments = locals()
+        # Bind exactly the fields advertised by this constructor. A subclass
+        # may declare additional dataclass fields without making the inherited
+        # base initializer look for arguments it never accepted.
+        fragment_fields = dataclasses.fields(ProteinFragment)
+        values = {}
+        for fragment_field in fragment_fields:
+            value = arguments[fragment_field.name]
+            if value is _DEFAULT_FACTORY:
+                value = fragment_field.default_factory()
+            values[fragment_field.name] = value
+
+        values.update(legacy_fields)
+        known = {fragment_field.name for fragment_field in fragment_fields}
+        values = _migrate_fragment_dict(values, known)
+        unknown = set(values) - known
+        if unknown:
+            name = sorted(unknown)[0]
+            raise TypeError(
+                "ProteinFragment.__init__() got an unexpected keyword "
+                f"argument {name!r}"
+            )
+
+        for fragment_field in fragment_fields:
+            object.__setattr__(
+                self, fragment_field.name, values[fragment_field.name],
+            )
+        self.__post_init__()
+
+    # Legacy keywords are a 5.x compatibility input, not fields in the
+    # current data model. Keep the public class signature identical to the
+    # dataclass field surface while leaving the implementation's
+    # ``**legacy_fields`` visible on ``ProteinFragment.__init__`` itself.
+    __signature__ = inspect.signature(__init__).replace(
+        parameters=tuple(inspect.signature(__init__).parameters.values())[1:-1],
+        return_annotation=None,
+    )
+
     # ------------------------------------------------------------------
     # Identity: fragment_id is the canonical key.  Using all-field eq
     # would trip over unhashable list/dict members; keying on
@@ -290,6 +378,62 @@ n_rna_alt_fragments_supporting_protein_sequence : int, optional
                     f"field_provenance[{name!r}] is {value!r}; use one of "
                     f"{sorted(PROVENANCE_VALUES)}."
                 )
+
+    # ------------------------------------------------------------------
+    # Topiary 5.47 evidence-name compatibility. These are ordinary,
+    # read-only class properties so compatibility is visible to
+    # introspection and does not mutate the class after its definition.
+    # ------------------------------------------------------------------
+
+    @property
+    def n_alt_reads(self):
+        """Compatibility alias for :attr:`n_rna_alt_reads`."""
+        return self.n_rna_alt_reads
+
+    @property
+    def n_alt_fragments(self):
+        """Compatibility alias for :attr:`n_rna_alt_fragments`."""
+        return self.n_rna_alt_fragments
+
+    @property
+    def n_ref_reads(self):
+        """Compatibility alias for :attr:`n_rna_ref_reads`."""
+        return self.n_rna_ref_reads
+
+    @property
+    def n_ref_fragments(self):
+        """Compatibility alias for :attr:`n_rna_ref_fragments`."""
+        return self.n_rna_ref_fragments
+
+    @property
+    def n_other_reads(self):
+        """Compatibility alias for :attr:`n_rna_other_reads`."""
+        return self.n_rna_other_reads
+
+    @property
+    def n_other_fragments(self):
+        """Compatibility alias for :attr:`n_rna_other_fragments`."""
+        return self.n_rna_other_fragments
+
+    @property
+    def n_overlapping_reads(self):
+        """Compatibility alias for :attr:`n_rna_overlapping_reads`."""
+        return self.n_rna_overlapping_reads
+
+    @property
+    def n_overlapping_fragments(self):
+        """Compatibility alias for :attr:`n_rna_overlapping_fragments`."""
+        return self.n_rna_overlapping_fragments
+
+    @property
+    def n_alt_reads_supporting_protein_sequence(self):
+        """Compatibility alias for the corresponding RNA read count."""
+        return self.n_rna_alt_reads_supporting_protein_sequence
+
+    @property
+    def n_alt_fragments_supporting_protein_sequence(self):
+        """Compatibility alias for the corresponding RNA fragment count."""
+        return self.n_rna_alt_fragments_supporting_protein_sequence
 
     # ------------------------------------------------------------------
     # Knownness
@@ -657,44 +801,6 @@ n_rna_alt_fragments_supporting_protein_sequence : int, optional
             transcript_expression=extra_kwargs.pop("transcript_expression", None),
             annotations=extra_kwargs.pop("annotations", {}) or {},
         )
-
-
-# Keep the 5.x Python surface source-compatible while emitting only the
-# assay-scoped names. Serialized input uses the same migration helper; this
-# wrapper covers direct construction, and read-only properties cover callers
-# that still inspect the 5.47 attribute names. They are intentionally absent
-# from dataclasses.fields() and to_dict(), so new output has one name per fact.
-_PROTEIN_FRAGMENT_INIT = ProteinFragment.__init__
-
-
-@functools.wraps(_PROTEIN_FRAGMENT_INIT)
-def _compatible_protein_fragment_init(self, *args, **kwargs):
-    known = {field.name for field in dataclasses.fields(ProteinFragment)}
-    kwargs = _migrate_fragment_dict(kwargs, known)
-    _PROTEIN_FRAGMENT_INIT(self, *args, **kwargs)
-
-
-ProteinFragment.__init__ = _compatible_protein_fragment_init
-
-_FRAGMENT_FIELD_RENAMES = _fragment_field_renames({
-    field.name for field in dataclasses.fields(ProteinFragment)
-})
-
-
-def _legacy_fragment_property(current_name):
-    return property(
-        lambda self: getattr(self, current_name),
-        doc=f"Compatibility alias for :attr:`{current_name}`.",
-    )
-
-
-for _old_name, _current_name in _FRAGMENT_FIELD_RENAMES.items():
-    setattr(
-        ProteinFragment,
-        _old_name,
-        _legacy_fragment_property(_current_name),
-    )
-
 
 # =============================================================================
 # Helpers


### PR DESCRIPTION
## Summary
- define the compatibility-aware ProteinFragment constructor inside the class
- retain legacy evidence keywords and read-only aliases without post-definition mutation
- preserve the current public signature, positional behavior, frozen dataclass behavior, serialization, equality, and hash semantics
- run direct and serialized construction through the same migration logic
- exercise Isovar, varcode, LENS, and pVACseq fragment workflows together

## Verification
- ./lint.sh
- ./test.sh (2,755 passed, 10 skipped; 92% coverage)
- python -m build
- python -m twine check

Closes #265