### PR TITLE
Use one Python interpreter for every release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.52.5
+
+**One release interpreter (#261).** `deploy.sh`, `lint.sh`, and `test.sh`
+now share one Python resolver and invoke Ruff, pytest, xdist detection, build,
+and Twine through that exact interpreter. Selection follows explicit `PYTHON`,
+an active virtual environment, the repository `.venv`, then `python3`; invalid
+explicit choices fail instead of silently falling back.
+
 ## 5.52.4
 
 **Normal ProteinFragment construction (#265).** `ProteinFragment` now defines

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Deploy topiary to PyPI
 # Usage: ./deploy.sh
 # Override the interpreter with PYTHON=/path/to/python ./deploy.sh
 
-PYTHON=${PYTHON:-python3}
-PYTHON_BIN=$("${PYTHON}" -c "import sys; print(sys.executable)")
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/scripts/resolve_python.sh"
+resolve_topiary_python
+unset SCRIPT_DIR
+
 VERSION=$("${PYTHON}" -c "import topiary; print(topiary.__version__)")
 echo "Deploying topiary v${VERSION}"
-echo "Using Python: ${PYTHON_BIN}"
+echo "Using Python: ${PYTHON}"
 
 # Check we're on master
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/lint.sh
+++ b/lint.sh
@@ -1,6 +1,11 @@
-#!/bin/bash
-set -o errexit
+#!/usr/bin/env bash
+set -euo pipefail
 
-ruff check topiary/ tests/
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/scripts/resolve_python.sh"
+resolve_topiary_python
+unset SCRIPT_DIR
+
+"${PYTHON}" -m ruff check topiary/ tests/
 
 echo 'Passes ruff check'

--- a/scripts/resolve_python.sh
+++ b/scripts/resolve_python.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Select one Python interpreter for Topiary's development and release scripts.
+# Callers may set PYTHON explicitly; otherwise an active virtual environment,
+# the repository virtual environment, and finally PATH are considered in that
+# order. The exported absolute path is the contract shared by every gate.
+resolve_topiary_python() {
+    local repo_root
+    local candidate
+    local resolved_python
+
+    repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+    if [[ -n "${PYTHON:-}" ]]; then
+        candidate="${PYTHON}"
+    elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+        candidate="${VIRTUAL_ENV}/bin/python"
+    elif [[ -x "${repo_root}/.venv/bin/python" ]]; then
+        candidate="${repo_root}/.venv/bin/python"
+    else
+        candidate="python3"
+    fi
+
+    if ! resolved_python="$(command -v "${candidate}" 2>/dev/null)" || \
+            [[ ! -f "${resolved_python}" || ! -x "${resolved_python}" ]]; then
+        echo "Python interpreter not found or not executable: ${candidate}" >&2
+        return 1
+    fi
+    if [[ "${resolved_python}" != /* ]]; then
+        resolved_python="${PWD}/${resolved_python#./}"
+    fi
+    PYTHON="${resolved_python}"
+    export PYTHON
+}

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,11 @@
 
 set -eo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/scripts/resolve_python.sh"
+resolve_topiary_python
+unset SCRIPT_DIR
+
 PER_WORKER_GB="${PER_WORKER_GB:-1.5}"
 TEST_SH_MIN="${TEST_SH_MIN:-1}"
 TEST_SH_MAX="${TEST_SH_MAX:-0}"
@@ -96,13 +101,14 @@ if (( TEST_SH_MAX > 0 && WORKERS > TEST_SH_MAX )); then WORKERS=$TEST_SH_MAX; fi
 if (( WORKERS < TEST_SH_MIN )); then WORKERS=$TEST_SH_MIN; fi
 
 XDIST_FLAGS=()
-if python -c "import xdist" 2>/dev/null; then
+if "${PYTHON}" -c "import xdist" 2>/dev/null; then
     XDIST_FLAGS=(-n "$WORKERS")
-    log "platform=${OS} cpus=${CPUS} cpu_cap=${CPU_CAP} ${mem_note} per_worker=${PER_WORKER_GB}GB"
-    log "workers=${WORKERS} → exec python -m pytest -n ${WORKERS} --cov=topiary/ --cov-report=term-missing tests $*"
+    log "python=${PYTHON} platform=${OS} cpus=${CPUS} cpu_cap=${CPU_CAP} ${mem_note} per_worker=${PER_WORKER_GB}GB"
+    log "workers=${WORKERS} → exec pytest -n ${WORKERS} --cov=topiary/ --cov-report=term-missing tests $*"
 else
-    log "platform=${OS} cpus=${CPUS} (pytest-xdist not installed; running serial)"
-    log "→ exec python -m pytest --cov=topiary/ --cov-report=term-missing tests $*"
+    log "python=${PYTHON} platform=${OS} cpus=${CPUS} (pytest-xdist not installed; running serial)"
+    log "→ exec pytest --cov=topiary/ --cov-report=term-missing tests $*"
 fi
 
-exec python -m pytest "${XDIST_FLAGS[@]}" --cov=topiary/ --cov-report=term-missing tests "$@"
+exec "${PYTHON}" -m pytest \
+    "${XDIST_FLAGS[@]}" --cov=topiary/ --cov-report=term-missing tests "$@"

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -1,26 +1,175 @@
 """Regression tests for deploy.sh release safety checks."""
 
-import re
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(command, cwd, env):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _fake_python(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("""#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$PYTHON_INVOCATION_LOG"
+if [[ "${1:-}" == "-c" ]]; then
+    printf '%s\\n' "5.52.5"
+elif [[ "${1:-}" == "-m" && "${2:-}" == "pip" ]]; then
+    exit 1
+elif [[ "${1:-}" == "-m" && "${2:-}" == "build" ]]; then
+    mkdir -p dist
+    touch dist/topiary-5.52.5-py3-none-any.whl
+elif [[ "${1:-}" == "-m" && "${2:-}" == "twine" ]]; then
+    exit 0
+else
+    exec "$REAL_PYTHON" "$@"
+fi
+""")
+    path.chmod(0o755)
+    return path
+
+
+def _release_repo(tmp_path):
+    repo = tmp_path / "release-repo"
+    (repo / "topiary").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    for name in ("deploy.sh",):
+        shutil.copy2(SOURCE_ROOT / name, repo / name)
+    shutil.copy2(
+        SOURCE_ROOT / "scripts" / "resolve_python.sh",
+        repo / "scripts" / "resolve_python.sh",
+    )
+    (repo / "topiary" / "__init__.py").write_text('__version__ = "5.52.5"\n')
+    (repo / ".gitignore").write_text(".venv/\nbuild/\ndist/\n")
+    for name in ("lint.sh", "test.sh"):
+        (repo / name).write_text(
+            "#!/bin/sh\nprintf '%s\\n' \"$PYTHON\" >> \"$GATE_PYTHON_LOG\"\n"
+        )
+        (repo / name).chmod(0o755)
+
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "master")
+    _git(repo, "config", "user.name", "Test Release")
+    _git(repo, "config", "user.email", "release@example.com")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Release fixture")
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _git(repo, "remote", "add", "origin", str(origin))
+    return repo
+
+
+def _deploy(repo, env_updates):
+    env = os.environ.copy()
+    env.update({
+        "GATE_PYTHON_LOG": str(repo.parent / "gate-python.log"),
+        "PYTHON_INVOCATION_LOG": str(repo.parent / "python-invocations.log"),
+        "REAL_PYTHON": sys.executable,
+    })
+    for name, value in env_updates.items():
+        if value is None:
+            env.pop(name, None)
+        else:
+            env[name] = value
+    return _run(["bash", "deploy.sh"], repo, env)
+
+
+@pytest.mark.parametrize(
+    "selection",
+    ("explicit", "active-venv", "repo-venv", "path"),
+)
+def test_deploy_uses_one_interpreter_for_every_release_step(tmp_path, selection):
+    repo = _release_repo(tmp_path)
+    path_dir = tmp_path / "path-bin"
+    path_python = _fake_python(path_dir / "python3")
+    active_python = _fake_python(tmp_path / "active venv" / "bin" / "python")
+    repo_python = _fake_python(repo / ".venv" / "bin" / "python")
+    explicit_python = _fake_python(tmp_path / "explicit python")
+    env = {
+        "PYTHON": None,
+        "VIRTUAL_ENV": None,
+        "PATH": f"{path_dir}{os.pathsep}{os.environ['PATH']}",
+    }
+    expected = path_python
+    if selection == "repo-venv":
+        expected = repo_python
+    elif selection == "active-venv":
+        env["VIRTUAL_ENV"] = str(active_python.parents[1])
+        expected = active_python
+    elif selection == "explicit":
+        env["PYTHON"] = str(explicit_python)
+        env["VIRTUAL_ENV"] = str(active_python.parents[1])
+        expected = explicit_python
+    else:
+        shutil.rmtree(repo / ".venv")
+
+    result = _deploy(repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "gate-python.log").read_text().splitlines() == [
+        str(expected), str(expected),
+    ]
+    invocations = (tmp_path / "python-invocations.log").read_text().splitlines()
+    assert any(command.startswith("-c import topiary") for command in invocations)
+    assert "-m pip index versions topiary" in invocations
+    assert "-m build" in invocations
+    assert "-m twine upload dist/topiary-5.52.5-py3-none-any.whl" in invocations
+    assert "v5.52.5" in _git(repo, "tag", "--list").stdout
+
+
+@pytest.mark.parametrize("kind", ("missing", "not-executable", "directory"))
+def test_deploy_rejects_invalid_explicit_python_without_fallback(tmp_path, kind):
+    repo = _release_repo(tmp_path)
+    invalid = tmp_path / "invalid-python"
+    if kind == "not-executable":
+        invalid.write_text("#!/bin/sh\nexit 0\n")
+    elif kind == "directory":
+        invalid.mkdir()
+
+    result = _deploy(repo, {"PYTHON": str(invalid)})
+
+    assert result.returncode == 1
+    assert f"Python interpreter not found or not executable: {invalid}" in result.stderr
+    assert not (tmp_path / "gate-python.log").exists()
 
 
 def test_deploy_script_uses_one_configured_python():
-    """deploy.sh should not mix python3 and a different pip executable."""
+    """Every Python release tool is invoked as a selected-Python module."""
     script = Path("deploy.sh").read_text()
-    assert "PYTHON=${PYTHON:-python3}" in script
+    assert "resolve_topiary_python" in script
     assert 'VERSION=$("${PYTHON}" -c' in script
     assert '"${PYTHON}" -m pip index versions topiary' in script
     assert '"${PYTHON}" -m build' in script
     assert '"${PYTHON}" -m twine upload dist/*' in script
     assert "rm -rf dist build" in script
-
-    for line in script.splitlines():
-        command = line.strip()
-        if (
-            not command
-            or command.startswith("#")
-            or command.startswith("PYTHON=")
-        ):
-            continue
-        assert re.search(r"(^|[;&|]\s*)python3(\s|$)", command) is None
-        assert re.search(r"(^|[;&|]\s*)pip(\s|$)", command) is None

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -1,0 +1,152 @@
+"""Executable contracts for the lint and test shell gates."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fake_python(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$PYTHON_INVOCATION_LOG"
+if [[ "${1:-}" == "-c" && "${2:-}" == "import xdist" ]]; then
+    exit "${XDIST_IMPORT_STATUS:-0}"
+fi
+exit 0
+""")
+    path.chmod(0o755)
+    return path
+
+
+def _path_traps(tmp_path):
+    trap_dir = tmp_path / "path-traps"
+    trap_dir.mkdir()
+    for name in ("python", "python3", "pytest", "ruff"):
+        path = trap_dir / name
+        path.write_text("""#!/bin/sh
+printf '%s\\n' "$0 $*" >> "$PATH_TRAP_LOG"
+exit 97
+""")
+        path.chmod(0o755)
+    return trap_dir
+
+
+def _run_gate(tmp_path, script_name, *args, env_updates=None):
+    script = tmp_path / script_name
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    shutil.copy2(SOURCE_ROOT / script_name, script)
+    shutil.copy2(
+        SOURCE_ROOT / "scripts" / "resolve_python.sh",
+        scripts / "resolve_python.sh",
+    )
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{_path_traps(tmp_path)}{os.pathsep}{env['PATH']}",
+        "PATH_TRAP_LOG": str(tmp_path / "path-trap.log"),
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYTHON_INVOCATION_LOG": str(tmp_path / "python-invocations.log"),
+        "TEST_SH_MAX": "1",
+        "TEST_SH_MIN": "1",
+    })
+    if env_updates:
+        for name, value in env_updates.items():
+            if value is None:
+                env.pop(name, None)
+            else:
+                env[name] = value
+    result = subprocess.run(
+        ["bash", str(script), *args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    invocation_log = tmp_path / "python-invocations.log"
+    invocations = (
+        invocation_log.read_text().splitlines()
+        if invocation_log.exists()
+        else []
+    )
+    return result, invocations, tmp_path / "path-trap.log"
+
+
+def test_lint_uses_selected_python_module_not_path_ruff(tmp_path):
+    result, invocations, trap_log = _run_gate(tmp_path, "lint.sh")
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == ["-m ruff check topiary/ tests/"]
+    assert not trap_log.exists()
+
+
+@pytest.mark.parametrize("script_name", ("lint.sh", "test.sh"))
+@pytest.mark.parametrize("environment", ("active-venv", "repo-venv"))
+def test_gate_resolves_virtualenv_python_when_python_is_unset(
+        tmp_path, script_name, environment):
+    if environment == "active-venv":
+        venv = tmp_path / "active venv"
+        env_updates = {"PYTHON": None, "VIRTUAL_ENV": str(venv)}
+    else:
+        venv = tmp_path / ".venv"
+        env_updates = {"PYTHON": None, "VIRTUAL_ENV": None}
+    selected = _fake_python(venv / "bin" / "python")
+
+    result, invocations, trap_log = _run_gate(
+        tmp_path, script_name, env_updates=env_updates,
+    )
+
+    assert result.returncode == 0, result.stderr
+    expected = ["-m ruff check topiary/ tests/"]
+    if script_name == "test.sh":
+        expected = [
+            "-c import xdist",
+            "-m pytest -n 1 --cov=topiary/ --cov-report=term-missing tests",
+        ]
+        assert f"python={selected}" in result.stderr
+    assert invocations == expected
+    assert not trap_log.exists()
+
+
+@pytest.mark.parametrize(
+    "xdist_status, expected_pytest",
+    (
+        ("0", "-m pytest -n 1 --cov=topiary/ --cov-report=term-missing tests selected-test"),
+        ("1", "-m pytest --cov=topiary/ --cov-report=term-missing tests selected-test"),
+    ),
+)
+def test_test_gate_uses_same_python_for_xdist_probe_and_pytest(
+        tmp_path, xdist_status, expected_pytest):
+    result, invocations, trap_log = _run_gate(
+        tmp_path,
+        "test.sh",
+        "selected-test",
+        env_updates={"XDIST_IMPORT_STATUS": xdist_status},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == ["-c import xdist", expected_pytest]
+    assert not trap_log.exists()
+
+
+@pytest.mark.parametrize("script_name", ("lint.sh", "test.sh"))
+def test_gate_rejects_invalid_explicit_python_without_path_fallback(
+        tmp_path, script_name):
+    invalid = tmp_path / "missing-python"
+
+    result, invocations, trap_log = _run_gate(
+        tmp_path,
+        script_name,
+        env_updates={"PYTHON": str(invalid)},
+    )
+
+    assert result.returncode == 1
+    assert f"Python interpreter not found or not executable: {invalid}" in result.stderr
+    assert invocations == []
+    assert not trap_log.exists()

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -165,7 +165,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.4"
+__version__ = "5.52.5"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
## Summary
- centralize Python selection for deploy, lint, and test scripts
- prefer explicit PYTHON, active virtualenv, repository .venv, then PATH python3
- invoke Ruff, xdist detection, pytest, build, and Twine through the selected absolute interpreter
- fail clearly on an invalid explicit interpreter
- replace static script assertions with hostile-PATH and end-to-end release simulations

## Verification
- ./lint.sh
- ./test.sh (2,771 passed, 10 skipped; 92% coverage)
- python -m build
- python -m twine check

Closes #261