### PR TITLE
Test the PirlyGenes integration explicitly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-cov ruff
-          pip install -e .
+          python -m pip install -e .
+      - name: Verify PirlyGenes is absent from the base environment
+        run: |
+          python -c "import importlib.util; assert importlib.util.find_spec('pirlygenes') is None, 'base CI unexpectedly installed PirlyGenes'"
       - name: Lint with ruff
         run: |
           ./lint.sh
@@ -115,6 +118,40 @@ jobs:
         with:
           parallel: true
           flag-name: python-${{ matrix.python-version }}
+
+  pirlygenes-integration:
+    needs: build
+    runs-on: ubuntu-22.04
+    env:
+      PYENSEMBL_CACHE_DIR: ${{ github.workspace }}/pyensembl-data
+      TOPIARY_TEST_REQUIRE_PIRLYGENES: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+      - name: Restore Ensembl data from the base jobs
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/pyensembl-data
+          key: pyensembl-GRCh37.75-GRCm38.102-GRCh38.93-GRCm38.93-v2
+          fail-on-cache-miss: true
+      - name: Install Topiary with PirlyGenes
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-cov pytest-xdist
+          python -m pip install -e '.[pirlygenes]'
+      - name: Verify PirlyGenes imports
+        run: |
+          python -c "from importlib.metadata import version; import pirlygenes; print('PirlyGenes', version('pirlygenes'))"
+      - name: Test PirlyGenes integration
+        run: |
+          ./test.sh -m pirlygenes --strict-markers
 
   coveralls-finish:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.52.7
+
+**Required PirlyGenes integration coverage (#267).** Base CI now proves the
+optional package is absent, while a dedicated job installs
+`topiary[pirlygenes]` and runs the real CTA and tissue-expression workflows as
+required tests. Integration tests skip only a genuinely absent top-level
+package; broken or transitively incomplete installations fail with their
+original import error instead of being hidden by `pytest.importorskip`.
+
 ## 5.52.6
 
 **Symmetric distances for ambiguous amino acids (#268).** Nearest-self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ ignore = ["F821", "E501", "F841", "E731", "E741", "E722", "E721"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "test*/*" = ["F401"]
+
+[tool.pytest.ini_options]
+markers = [
+    "pirlygenes: exercises the installed PirlyGenes optional integration",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared pytest configuration."""
+
+from tests.optional_dependencies import require_pirlygenes
+
+
+def pytest_runtest_setup(item):
+    """Require a usable PirlyGenes import for its integration tests."""
+    if item.get_closest_marker("pirlygenes") is not None:
+        require_pirlygenes()

--- a/tests/optional_dependencies.py
+++ b/tests/optional_dependencies.py
@@ -1,0 +1,30 @@
+"""Test selection for optional dependency integrations."""
+
+from importlib import import_module
+import os
+
+import pytest
+
+
+PIRLYGENES_REQUIRED_ENV = "TOPIARY_TEST_REQUIRE_PIRLYGENES"
+
+
+def require_pirlygenes():
+    """Load PirlyGenes, skipping only when the package is truly absent.
+
+    A transitive ``ModuleNotFoundError`` or any other import failure is a
+    broken installation, not an absent optional dependency, so it propagates
+    unchanged. CI's dedicated integration job makes absence an error too.
+    """
+    try:
+        return import_module("pirlygenes")
+    except ModuleNotFoundError as error:
+        if error.name != "pirlygenes":
+            raise
+        if os.environ.get(PIRLYGENES_REQUIRED_ENV) == "1":
+            pytest.fail(
+                "PirlyGenes is required in the optional-integration job but "
+                "is not installed",
+                pytrace=False,
+            )
+        pytest.skip("PirlyGenes optional integration is not installed")

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -337,8 +337,8 @@ def test_sequences_from_transcript_ids_unknown():
     assert len(seqs) == 0
 
 
+@pytest.mark.pirlygenes
 def test_available_tissues_has_testis():
-    pytest.importorskip("pirlygenes")
     from topiary.sources import available_tissues
     tissues = available_tissues()
     assert "testis" in tissues

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+import pytest
 from mhctools import NetMHC
 from topiary import TopiaryPredictor
 from .data import cancer_test_variants
@@ -8,12 +9,15 @@ alleles = [
     "HLA-C*07:02",
 ]
 
-mhc_model = NetMHC(alleles=alleles, default_peptide_lengths=[8, 9, 10])
-
 DEFAULT_FPKM = 1.0
 
 
-def test_epitopes_to_dataframe_transcript_expression():
+@pytest.fixture(scope="module")
+def mhc_model():
+    return NetMHC(alleles=alleles, default_peptide_lengths=[8, 9, 10])
+
+
+def test_epitopes_to_dataframe_transcript_expression(mhc_model):
     predictor = TopiaryPredictor(mhc_model=mhc_model, only_novel_epitopes=False)
     df = predictor.predict_from_variants(
         variants=cancer_test_variants,
@@ -32,7 +36,7 @@ def test_epitopes_to_dataframe_transcript_expression():
     ).all(), "Invalid FPKM values in DataFrame transcript_expression column"
 
 
-def test_epitopes_to_dataframe_gene_expression():
+def test_epitopes_to_dataframe_gene_expression(mhc_model):
     predictor = TopiaryPredictor(mhc_model=mhc_model, only_novel_epitopes=False)
 
     df = predictor.predict_from_variants(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -53,9 +53,9 @@ def test_gene_names_to_predictions():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pirlygenes
 def test_tissue_restricted_predict():
     """Can predict from tissue-restricted sequences."""
-    pytest.importorskip("pirlygenes")
     seqs = tissue_expressed_sequences(["testis"], min_ntpm=100.0)
     small = dict(list(seqs.items())[:3])
     predictor = _small_predictor()
@@ -68,9 +68,9 @@ def test_tissue_restricted_predict():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pirlygenes
 def test_tissue_exclusion_reduces_predictions():
     """Excluding vital-organ peptides should reduce prediction count."""
-    pytest.importorskip("pirlygenes")
     seqs = sequences_from_gene_names(["BRAF"])
     predictor = _small_predictor()
     df = predictor.predict_from_named_sequences(seqs)
@@ -87,6 +87,7 @@ def test_tissue_exclusion_reduces_predictions():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pirlygenes
 def test_first_principles_workflow():
     """
     First-principles CTA-like workflow:
@@ -94,7 +95,6 @@ def test_first_principles_workflow():
       2. Exclude peptides that appear in vital organ proteins
          (substring match — 8-mer from heart in 9-mer from testis → excluded)
     """
-    pytest.importorskip("pirlygenes")
     # 1. Targets: genes expressed in reproductive tissues
     target_seqs = tissue_expressed_sequences(
         ["testis", "placenta", "ovary"], min_ntpm=1.0,

--- a/tests/test_mutant_epitope_predictions_class1.py
+++ b/tests/test_mutant_epitope_predictions_class1.py
@@ -29,10 +29,12 @@ variants = VariantCollection(
 
 alleles = ["A02:01", "a0204", "B*07:02", "HLA-B14:02", "HLA-C*07:02", "hla-c07:01"]
 
-mhc_model = NetMHCpan(alleles=alleles, default_peptide_lengths=[9])
+@pytest.fixture(scope="module")
+def mhc_model():
+    return NetMHCpan(alleles=alleles, default_peptide_lengths=[9])
 
 
-def test_epitope_prediction_without_padding():
+def test_epitope_prediction_without_padding(mhc_model):
     output_without_padding = TopiaryPredictor(
         mhc_model=mhc_model, only_novel_epitopes=True
     ).predict_from_variants(variants=variants)
@@ -44,21 +46,21 @@ def test_epitope_prediction_without_padding():
     assert "pMHC_affinity" in output_without_padding["kind"].values
 
 
-def test_epitope_prediction_with_invalid_padding():
+def test_epitope_prediction_with_invalid_padding(mhc_model):
     with pytest.raises(ValueError):
         TopiaryPredictor(
             mhc_model=mhc_model, padding_around_mutation=7
         ).predict_from_variants(variants=variants)
 
 
-def test_epitope_prediction_with_invalid_zero_padding():
+def test_epitope_prediction_with_invalid_zero_padding(mhc_model):
     with pytest.raises(ValueError):
         TopiaryPredictor(
             mhc_model=mhc_model, padding_around_mutation=7
         ).predict_from_variants(variants=variants)
 
 
-def test_epitope_prediction_with_valid_padding():
+def test_epitope_prediction_with_valid_padding(mhc_model):
     predictor = TopiaryPredictor(
         mhc_model=mhc_model, padding_around_mutation=8, only_novel_epitopes=True
     )

--- a/tests/test_mutant_epitope_predictions_class2.py
+++ b/tests/test_mutant_epitope_predictions_class2.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from mhctools import NetMHCIIpan
 from pyensembl import ensembl_grch37
 from topiary import TopiaryPredictor
@@ -28,10 +29,12 @@ variants = VariantCollection(
 
 alleles = ["HLA-DPA1*01:05/DPB1*100:01", "DRB10102"]
 
-mhc_model = NetMHCIIpan(alleles=alleles, default_peptide_lengths=[15, 16])
+@pytest.fixture(scope="module")
+def mhc_model():
+    return NetMHCIIpan(alleles=alleles, default_peptide_lengths=[15, 16])
 
 
-def test_netmhcii_pan_epitopes():
+def test_netmhcii_pan_epitopes(mhc_model):
     epitope_predictions = TopiaryPredictor(
         mhc_model=mhc_model, only_novel_epitopes=True
     ).predict_from_variants(variants=variants)

--- a/tests/test_pirlygenes_test_selection.py
+++ b/tests/test_pirlygenes_test_selection.py
@@ -1,0 +1,88 @@
+"""Regression tests for explicit PirlyGenes integration selection."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tests.optional_dependencies as optional_dependencies
+
+
+def _raise(error):
+    def raising_import(module_name):
+        assert module_name == "pirlygenes"
+        raise error
+
+    return raising_import
+
+
+def test_absent_pirlygenes_skips_in_base_environment(monkeypatch):
+    error = ModuleNotFoundError(
+        "No module named 'pirlygenes'", name="pirlygenes",
+    )
+    monkeypatch.delenv(optional_dependencies.PIRLYGENES_REQUIRED_ENV, False)
+    monkeypatch.setattr(optional_dependencies, "import_module", _raise(error))
+
+    with pytest.raises(pytest.skip.Exception):
+        optional_dependencies.require_pirlygenes()
+
+
+def test_absent_pirlygenes_fails_in_required_environment(monkeypatch):
+    error = ModuleNotFoundError(
+        "No module named 'pirlygenes'", name="pirlygenes",
+    )
+    monkeypatch.setenv(optional_dependencies.PIRLYGENES_REQUIRED_ENV, "1")
+    monkeypatch.setattr(optional_dependencies, "import_module", _raise(error))
+
+    with pytest.raises(pytest.fail.Exception, match="required"):
+        optional_dependencies.require_pirlygenes()
+
+
+def test_transitively_missing_dependency_is_not_skipped(monkeypatch):
+    error = ModuleNotFoundError(
+        "No module named 'broken_transitive_dependency'",
+        name="broken_transitive_dependency",
+    )
+    monkeypatch.delenv(optional_dependencies.PIRLYGENES_REQUIRED_ENV, False)
+    monkeypatch.setattr(optional_dependencies, "import_module", _raise(error))
+
+    with pytest.raises(ModuleNotFoundError) as raised:
+        optional_dependencies.require_pirlygenes()
+
+    assert raised.value is error
+
+
+def test_broken_import_is_not_skipped(monkeypatch):
+    error = ImportError("cannot import name 'therapy_evidence' from 'oncoref'")
+    monkeypatch.delenv(optional_dependencies.PIRLYGENES_REQUIRED_ENV, False)
+    monkeypatch.setattr(optional_dependencies, "import_module", _raise(error))
+
+    with pytest.raises(ImportError) as raised:
+        optional_dependencies.require_pirlygenes()
+
+    assert raised.value is error
+
+
+def test_usable_pirlygenes_is_returned(monkeypatch):
+    module = SimpleNamespace()
+    monkeypatch.setattr(
+        optional_dependencies, "import_module", lambda module_name: module,
+    )
+
+    assert optional_dependencies.require_pirlygenes() is module
+
+
+def test_no_pirlygenes_importorskip_calls_remain():
+    deprecated_call = "importorskip(" + '"pirlygenes")'
+    for path in Path("tests").glob("test_*.py"):
+        assert deprecated_call not in path.read_text()
+
+
+def test_ci_requires_both_absent_and_installed_environments():
+    workflow = Path(".github/workflows/tests.yml").read_text()
+
+    assert "Verify PirlyGenes is absent from the base environment" in workflow
+    assert "pirlygenes-integration:" in workflow
+    assert "python -m pip install -e '.[pirlygenes]'" in workflow
+    assert 'TOPIARY_TEST_REQUIRE_PIRLYGENES: "1"' in workflow
+    assert "./test.sh -m pirlygenes --strict-markers" in workflow

--- a/tests/test_pirlygenes_test_selection.py
+++ b/tests/test_pirlygenes_test_selection.py
@@ -1,5 +1,6 @@
 """Regression tests for explicit PirlyGenes integration selection."""
 
+import ast
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -86,3 +87,24 @@ def test_ci_requires_both_absent_and_installed_environments():
     assert "python -m pip install -e '.[pirlygenes]'" in workflow
     assert 'TOPIARY_TEST_REQUIRE_PIRLYGENES: "1"' in workflow
     assert "./test.sh -m pirlygenes --strict-markers" in workflow
+
+
+def test_external_predictors_are_not_created_during_test_collection():
+    """Marker selection must not require unrelated licensed executables."""
+    external_predictors = {"NetMHC", "NetMHCpan", "NetMHCIIpan"}
+    offenders = []
+
+    for path in Path("tests").glob("test_*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for statement in tree.body:
+            value = getattr(statement, "value", None)
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id in external_predictors
+            ):
+                offenders.append(f"{path}:{statement.lineno}")
+
+    assert not offenders, "external predictor constructed at import time: " + ", ".join(
+        offenders,
+    )

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -43,8 +43,8 @@ def test_sequences_from_transcript_ids():
     assert len(seqs) == 1
 
 
+@pytest.mark.pirlygenes
 def test_cta_sequences():
-    pytest.importorskip("pirlygenes")
     seqs = cta_sequences()
     assert len(seqs) > 100  # ~257 CTA genes, some may lack protein
     # All should be non-empty protein sequences
@@ -52,8 +52,8 @@ def test_cta_sequences():
         assert len(seq) > 0
 
 
+@pytest.mark.pirlygenes
 def test_available_tissues():
-    pytest.importorskip("pirlygenes")
     tissues = available_tissues()
     assert "heart_muscle" in tissues
     assert "lung" in tissues
@@ -61,14 +61,14 @@ def test_available_tissues():
     assert len(tissues) >= 40
 
 
+@pytest.mark.pirlygenes
 def test_tissue_expressed_gene_ids():
-    pytest.importorskip("pirlygenes")
     gene_ids = tissue_expressed_gene_ids(["testis"], min_ntpm=1.0)
     assert len(gene_ids) > 1000  # many genes expressed in testis
 
 
+@pytest.mark.pirlygenes
 def test_tissue_expressed_gene_ids_strict():
-    pytest.importorskip("pirlygenes")
     loose = tissue_expressed_gene_ids(["heart_muscle"], min_ntpm=1.0)
     strict = tissue_expressed_gene_ids(["heart_muscle"], min_ntpm=100.0)
     assert len(strict) < len(loose)

--- a/tests/test_validation_and_edge_cases.py
+++ b/tests/test_validation_and_edge_cases.py
@@ -239,7 +239,6 @@ def test_sequences_from_transcript_names_empty_raises():
 
 
 def test_tissue_expressed_gene_ids_empty_raises():
-    pytest.importorskip("pirlygenes")
     from topiary.sources import tissue_expressed_gene_ids
     with pytest.raises(ValueError, match="non-empty"):
         tissue_expressed_gene_ids([])
@@ -453,9 +452,9 @@ def test_sequences_from_transcript_names_unknown():
     assert len(seqs) == 0
 
 
+@pytest.mark.pirlygenes
 def test_non_cta_sequences_excludes_cta_genes():
     """non_cta_sequences should return proteins whose genes are NOT in the CTA set."""
-    pytest.importorskip("pirlygenes")
     from topiary.sources import non_cta_sequences, _pirlygenes_cta_gene_ids
     from pyensembl import ensembl_grch38
 

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -168,7 +168,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.6"
+__version__ = "5.52.7"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
Fixes #267.

- marks the nine real PirlyGenes workflows as an explicit integration group
- skips only a top-level `ModuleNotFoundError` when the optional package is genuinely absent
- propagates transitive and other import failures unchanged
- makes the base CI matrix prove PirlyGenes was not installed
- adds a required job that installs `topiary[pirlygenes]`, verifies the import, and runs every marked workflow
- removes the pytest 9.1-incompatible `importorskip` behavior
- defers licensed NetMHC predictor construction until selected tests execute, so unrelated marker selection can collect without proprietary binaries
- guards against future import-time construction of external MHC predictors

Adversarial verification:
- broken installed PirlyGenes 6.0.1/oncoref 1.8.174 fails with the original `therapy_evidence` ImportError
- clean base env, pytest 9.1.1: 2,811 passed, 9 expected skips, 92% coverage
- clean extra env, PirlyGenes 6.0.2/oncoref 1.8.193: all 9 marked workflows passed under a PATH without NetMHC executables
- full clean extra env, pytest 9.1.1: 2,820 passed, zero skips, 92% coverage
- both environments pass `pip check`
- lint, build, and twine checks pass

The artifact audit also found the separate pre-existing wheel-content bug #276.
