### PR TITLE
Fix wheel contents, SPDX license metadata, and Actions runtimes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,36 +3,40 @@ name: Docs
 on:
   push:
     branches: [master]
+  pull_request:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - run: pip install mkdocs-material
+      - run: python -m pip install mkdocs-material
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
+          include-hidden-files: true
 
   deploy:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,22 +18,24 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
       - name: Cache pyensembl data
         id: ensembl-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/pyensembl-data
           key: pyensembl-GRCh37.75-GRCm38.102-GRCh38.93-GRCm38.93-v2
       - name: Checkout private netmhc-bundle repo
         if: env.HAS_NETMHC_TOKEN == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: openvax/netmhc-bundle
           token: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN }}
@@ -126,9 +128,9 @@ jobs:
       PYENSEMBL_CACHE_DIR: ${{ github.workspace }}/pyensembl-data
       TOPIARY_TEST_REQUIRE_PIRLYGENES: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -136,7 +138,7 @@ jobs:
             requirements.txt
             pyproject.toml
       - name: Restore Ensembl data from the base jobs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/pyensembl-data
           key: pyensembl-GRCh37.75-GRCm38.102-GRCh38.93-GRCm38.93-v2
@@ -152,6 +154,25 @@ jobs:
       - name: Test PirlyGenes integration
         run: |
           ./test.sh -m pirlygenes --strict-markers
+
+  packaging:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build distributions
+        run: |
+          python -m pip install build twine
+          python -m build
+      - name: Check distribution contents and metadata
+        run: |
+          python tests/check_distributions.py dist
+          python -m twine check --strict dist/*
 
   coveralls-finish:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.52.8
+
+**Packaging and CI cleanup (#276, #274, #270).** Wheels now install only
+Topiary's runtime packages; documentation, tests, and fixtures remain in the
+source archive. Distributions declare the SPDX license expression
+`Apache-2.0` and include the license text. CI checks the actual wheel and
+source archive contents and metadata. Test and documentation workflows use
+Node.js 24-compatible GitHub Actions.
+
 ## 5.52.7
 
 **Required PirlyGenes integration coverage (#267).** Base CI now proves the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,13 @@
-# Ship the docs with the source distribution.
-#
-# docs/consumer-guide.md is written as the reference a downstream
-# consumer reads instead of asking; a consumer working from an installed
-# package could not find it when it lived only in the repo.
+# Keep documentation and test resources in the source distribution.
+# Package discovery limits the installed wheel to topiary itself.
 include README.md
 include CHANGELOG.md
 include LICENSE
 include requirements.txt
+include mkdocs.yml
+include *.sh
 recursive-include docs *.md
-recursive-include topiary/data *
-# Keep the authoritative matrix fixture beside the regression test in sdists
-# and wheels, which currently ship the test package.
-include tests/data/BLOSUM62.ncbi
+recursive-include scripts *.sh
+recursive-include .github/workflows *.yml
+recursive-include tests *.py
+recursive-include tests/data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,12 +7,13 @@ name = "topiary"
 requires-python = ">=3.9"
 authors = [{name = "Alex Rubinsteyn"}, {name = "Tavi Nathanson"}]
 description = "Predict, filter, and rank MHC-presented peptides from any antigen source"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -24,7 +25,8 @@ version = {attr = "topiary.__version__"}
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["test", "test.*"]
+include = ["topiary", "topiary.*"]
+namespaces = false
 
 [project.urls]
 "Homepage" = "https://github.com/openvax/topiary"

--- a/tests/check_distributions.py
+++ b/tests/check_distributions.py
@@ -1,0 +1,92 @@
+"""Check built artifacts without importing Topiary or installing its dependencies.
+
+Run after ``python -m build`` with ``python tests/check_distributions.py dist``.
+The normal build creates the wheel from the sdist, so this checks both sides
+of the release pipeline. Only standard-library modules are needed.
+"""
+
+import argparse
+import configparser
+from email.parser import BytesParser
+from pathlib import Path
+import tarfile
+import zipfile
+
+
+def check_license_metadata(metadata):
+    """Require PEP 639 metadata without a deprecated license classifier."""
+    assert metadata["License-Expression"] == "Apache-2.0"
+    assert metadata.get_all("License-File") == ["LICENSE"]
+    assert not any(
+        value.startswith("License ::")
+        for value in metadata.get_all("Classifier", [])
+    )
+
+
+def check_distributions(dist_dir, source_root):
+    """Verify runtime files, source resources, license text, and the CLI entry."""
+    wheels = list(dist_dir.glob("*.whl"))
+    sdists = list(dist_dir.glob("*.tar.gz"))
+    assert len(wheels) == 1, f"Expected one wheel in {dist_dir}, found {wheels}"
+    assert len(sdists) == 1, f"Expected one sdist in {dist_dir}, found {sdists}"
+    runtime_files = {
+        path.relative_to(source_root).as_posix()
+        for path in (source_root / "topiary").rglob("*.py")
+    }
+    license_text = (source_root / "LICENSE").read_bytes()
+
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        names = set(wheel.namelist())
+        metadata_paths = [name for name in names if name.endswith(".dist-info/METADATA")]
+        assert len(metadata_paths) == 1
+        dist_info = metadata_paths[0].split("/")[0]
+        unexpected = {
+            name for name in names
+            if name.split("/")[0] not in {"topiary", dist_info}
+        }
+        assert not unexpected, f"Non-runtime files in wheel: {sorted(unexpected)}"
+        assert runtime_files <= names, f"Missing runtime modules: {runtime_files - names}"
+        assert wheel.read(f"{dist_info}/top_level.txt").decode().splitlines() == ["topiary"]
+        assert wheel.read(f"{dist_info}/licenses/LICENSE") == license_text
+        wheel_metadata = BytesParser().parsebytes(wheel.read(metadata_paths[0]))
+        check_license_metadata(wheel_metadata)
+        entry_points = configparser.ConfigParser()
+        entry_points.read_string(wheel.read(f"{dist_info}/entry_points.txt").decode())
+        assert entry_points["console_scripts"]["topiary"] == "topiary.cli.script:main"
+
+    with tarfile.open(sdists[0]) as sdist:
+        files = {member.name: member for member in sdist.getmembers() if member.isfile()}
+        roots = {name.split("/")[0] for name in files}
+        assert len(roots) == 1
+        root = roots.pop()
+        relative_names = {name[len(root) + 1:] for name in files}
+        source_resources = {
+            path.relative_to(source_root).as_posix()
+            for directory, pattern in (
+                ("docs", "*.md"), ("tests", "*.py"), ("tests/data", "*"),
+                ("scripts", "*.sh"), (".github/workflows", "*.yml"),
+            )
+            for path in (source_root / directory).rglob(pattern)
+            if path.is_file() and "__pycache__" not in path.parts
+        }
+        required = runtime_files | source_resources | {
+            "README.md", "CHANGELOG.md", "LICENSE", "pyproject.toml",
+            "requirements.txt", "mkdocs.yml", "lint.sh", "test.sh", "deploy.sh",
+        }
+        assert required <= relative_names, f"Missing source files: {required - relative_names}"
+        assert sdist.extractfile(files[f"{root}/LICENSE"]).read() == license_text
+        source_metadata = BytesParser().parsebytes(
+            sdist.extractfile(files[f"{root}/PKG-INFO"]).read()
+        )
+        check_license_metadata(source_metadata)
+        for field in ("Name", "Version", "Requires-Python", "Requires-Dist", "Provides-Extra"):
+            assert source_metadata.get_all(field) == wheel_metadata.get_all(field), field
+
+    print(f"Validated {wheels[0].name} and {sdists[0].name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist_dir", type=Path)
+    args = parser.parse_args()
+    check_distributions(args.dist_dir, Path(__file__).resolve().parents[1])

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -168,7 +168,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.7"
+__version__ = "5.52.8"
 
 __all__ = [
     "TopiaryPredictor",


### PR DESCRIPTION
Topiary wheels currently install the repository's `tests` and `docs` trees into site-packages, and every build emits deprecated license metadata warnings. Restrict package discovery to `topiary` and its subpackages, declare `Apache-2.0` with the license text, and upgrade the test and documentation workflows to Node.js 24-compatible actions.

Fixes #276. Fixes #274. Fixes #270.

- Wheels retain all runtime modules and the `topiary` console entry point; docs, tests, fixtures, and their supporting scripts remain in the source archive. The wheel shrinks from approximately 555 KB to 229 KB.
- Add artifact-content and metadata checks on Python 3.9 and 3.12. The normal build produces the wheel from the sdist, exercising the release path. Setuptools >=77.0.3 supports the SPDX metadata.
- Update checkout/setup-python to v7, cache/restore to v6, and Pages upload/deploy to v5. Keep the existing Ensembl cache paths and keys. Build and upload documentation artifacts on PRs; deployment remains restricted to master pushes, with separate concurrency groups per ref.
- Bump the version to 5.52.8.

Validation:

- `./lint.sh` passes.
- `./test.sh`: 2,811 passed, 9 expected skips without PirlyGenes, 92% coverage.
- The artifact check rejects the published 5.52.7 wheel and accepts the new wheel and source archive.
- Isolated build and `twine check --strict` pass; license deprecation warnings are gone.
- Installed the wheel outside the repository and verified the package import and `topiary --help`.
- Rebuilt and validated both distributions with the minimum Setuptools 77.0.3.
- GitHub CI is green: Python 3.10–3.12 tests, required PirlyGenes integration, Python 3.9/3.12 packaging, and docs build/upload. All check runs have zero annotations; Pages deployment is correctly skipped on the PR.

Upstream compatibility references: [Setuptools SPDX support](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html), [checkout releases](https://github.com/actions/checkout/releases), [setup-python releases](https://github.com/actions/setup-python/releases), [cache releases](https://github.com/actions/cache/releases).

Separate follow-up from the requested Isovar audit: #279 tracks raising the optional Isovar floor to 1.7.10 and adding real RNA assembly handoff coverage. It is not part of this packaging/Actions change.
