### PR TITLE
Fix CI coverage retries and defer annotation-dependent test fixtures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-22.04
+    outputs:
+      coverage-jobs: ${{ strategy.job-total }}
     env:
       HAS_NETMHC_TOKEN: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
       # Pin pyensembl's data directory rather than trusting its default.
@@ -118,11 +120,16 @@ jobs:
           export NETMHC_BUNDLE_TMPDIR=$PWD/netmhc-bundle-tmp
           export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
           ./test.sh
-      - name: Publish coverage to Coveralls
-        uses: coverallsapp/github-action@v2.2.3
+      - name: Save coverage for the upload job
+        uses: actions/upload-artifact@v7
         with:
-          parallel: true
-          flag-name: python-${{ matrix.python-version }}
+          name: coverage-python-${{ matrix.python-version }}
+          path: .coverage
+          include-hidden-files: true
+          if-no-files-found: error
+          # A retried matrix member replaces only its own data. Successful
+          # members' artifacts remain available on a failed-jobs-only rerun.
+          overwrite: true
 
   pirlygenes-integration:
     needs: build
@@ -162,6 +169,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       TOPIARY_TEST_REQUIRE_ISOVAR: "1"
+      PYENSEMBL_CACHE_DIR: ${{ github.workspace }}/empty-ensembl-cache
     strategy:
       fail-fast: false
       matrix:
@@ -179,14 +187,14 @@ jobs:
       - name: Install Topiary with Isovar (minimum and latest)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest pytest-cov pytest-xdist
           python -m pip install -e '.[isovar]' '${{ matrix.isovar }}'
       - name: Verify Isovar imports
         run: |
           python -c "import sys; from importlib.metadata import version; import topiary; assert 'isovar' not in sys.modules; import isovar; print('Isovar', version('isovar'))"
       - name: Test Isovar integration
         run: |
-          python -m pytest tests/test_consumer_workflows.py -m isovar --strict-markers
+          ./test.sh -m isovar --strict-markers
 
   packaging:
     runs-on: ubuntu-22.04
@@ -207,12 +215,39 @@ jobs:
           python tests/check_distributions.py dist
           python -m twine check --strict dist/*
 
-  coveralls-finish:
+  coverage:
     needs: build
-    runs-on: ubuntu-latest
-    if: always()
+    runs-on: ubuntu-22.04
     steps:
-      - name: Finalize Coveralls
-        uses: coverallsapp/github-action@v2.2.3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
-          parallel-finished: true
+          python-version: "3.12"
+      - name: Download successful matrix coverage
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-python-*
+          path: coverage-data
+      - name: Combine the complete test matrix
+        env:
+          EXPECTED_COVERAGE_JOBS: ${{ needs.build.outputs.coverage-jobs }}
+        run: |
+          python -m pip install coverage
+          python tests/combine_coverage.py coverage-data "$EXPECTED_COVERAGE_JOBS" coverage.xml
+      - name: Install verified Coveralls reporter
+        run: |
+          # Pin the release and its published binary digest together. Avoid
+          # racing separate "latest" archive and checksum downloads.
+          bash scripts/download_verified.sh \
+            https://github.com/coverallsapp/coverage-reporter/releases/download/v0.6.22/coveralls-linux-x86_64 \
+            34fcaf347627307e505ec207acd617c3bfc6c3e2684b22e760be29eb339c36d5 \
+            "$RUNNER_TEMP/coveralls"
+          chmod +x "$RUNNER_TEMP/coveralls"
+      - name: Publish coverage to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # One non-parallel report: no finish webhook can close a build while
+          # other jobs still need it. Give every rerun a distinct build number.
+          "$RUNNER_TEMP/coveralls" report coverage.xml --format=cobertura \
+            --build-number="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ identifier for each retry. The reporter download is version-pinned, retried with
 HTTP diagnostics, and SHA-256 verified; missing or corrupt coverage stays fatal.
 Ensembl-backed test data is now loaded by fixtures only when selected tests need
 it. Whole-suite collection and Isovar marker selection work without downloading
-reference data. There are no runtime API changes.
+reference data. Isovar integration fixtures request explicit protein windows
+and cover both 21- and 49-amino-acid windows, including mutation offsets and
+read support, so Isovar's changed default does not change test expectations.
+There are no runtime API changes.
 
 ## 5.52.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.52.10
+
+**Reliable CI retries and offline test collection (#282, #280).** Coverage is
+combined from every Python matrix job and published once, with a separate build
+identifier for each retry. The reporter download is version-pinned, retried with
+HTTP diagnostics, and SHA-256 verified; missing or corrupt coverage stays fatal.
+Ensembl-backed test data is now loaded by fixtures only when selected tests need
+it. Whole-suite collection and Isovar marker selection work without downloading
+reference data. There are no runtime API changes.
+
 ## 5.52.9
 
 **Require corrected Isovar RNA assembly (#279).** The optional `isovar` extra

--- a/README.md
+++ b/README.md
@@ -649,3 +649,24 @@ topiary --peptide-csv peptides.csv \
 
 `--mhc-predictor` and `--mhc-alleles` become optional when a cache
 supplies predictions.
+
+## Development checks
+
+Run `./lint.sh` and `./test.sh` before submitting changes. The full suite uses
+real Ensembl annotations and external MHC predictors. Collecting tests does
+not load those resources, and the synthetic Isovar integration tests need only
+the optional package:
+
+```bash
+python -m pytest tests --collect-only
+pip install '.[isovar]' pytest pytest-cov pytest-xdist
+./test.sh -m isovar --strict-markers
+```
+
+CI saves each Python version's coverage as a separate artifact, then combines
+all of them in one upload job. If coverage publication fails, use GitHub's
+**Re-run failed jobs**; successful test jobs and their artifacts are reused.
+Each attempt has a separate Coveralls build number, with no parallel-build
+finalization step. Reporter downloads use a pinned version and SHA-256 digest;
+update both together in `.github/workflows/tests.yml`. Download, checksum,
+missing-artifact, and upload errors all fail CI.

--- a/scripts/download_verified.sh
+++ b/scripts/download_verified.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Download a pinned CI tool: URL, expected SHA-256, destination.
+# Never install a partial download or execute an unverified response body.
+set -euo pipefail
+
+if [[ "$#" != 3 ]]; then
+    echo "Usage: $0 URL SHA256 DESTINATION" >&2
+    exit 2
+fi
+
+download_tmp=$(mktemp "${3}.download.XXXXXX")
+trap 'rm -f -- "$download_tmp"' EXIT
+
+curl --fail --show-error --location \
+    --retry 3 --retry-all-errors --retry-delay 1 --retry-max-time 120 \
+    --connect-timeout 10 --max-time 30 \
+    --output "$download_tmp" "$1"
+printf '%s  %s\n' "$2" "$download_tmp" | shasum -a 256 --check --strict -
+mv -- "$download_tmp" "$3"

--- a/tests/combine_coverage.py
+++ b/tests/combine_coverage.py
@@ -1,0 +1,39 @@
+"""Combine every successful test-matrix artifact into one Cobertura report.
+
+Unlike coverage combine's warning-and-skip behavior, missing, empty or corrupt
+artifacts are fatal: publishing incomplete coverage would hide CI failures.
+"""
+
+import argparse
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from coverage import Coverage, CoverageData
+
+
+def combine_coverage(directory, expected_count, output):
+    """Validate the complete matrix, merge its line/branch data, then write XML."""
+    paths = sorted(directory.glob("coverage-python-*/.coverage"))
+    if expected_count < 1 or len(paths) != expected_count:
+        raise ValueError(
+            f"Expected {expected_count} coverage artifacts, found {len(paths)} in {directory}"
+        )
+
+    with TemporaryDirectory(prefix="topiary-coverage-") as temporary:
+        report = Coverage(config_file=False, data_file=str(Path(temporary) / ".coverage"))
+        for path in paths:
+            data = CoverageData(basename=str(path))
+            data.read()
+            if not data.measured_files():
+                raise ValueError(f"Empty coverage artifact: {path}")
+            report.get_data().update(data)
+        report.xml_report(outfile=str(output))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("expected_count", type=int)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    combine_coverage(args.directory, args.expected_count, args.output)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,47 @@
 """Shared pytest configuration."""
 
+import pytest
+
 from tests.optional_dependencies import require_integration
+
+
+@pytest.fixture(scope="module")
+def cancer_test_variants():
+    """Real BRAF V600E and TP53 R248W variants, constructed only on demand."""
+    from varcode import Variant, VariantCollection
+    from pyensembl import ensembl_grch38
+
+    return VariantCollection([
+        # COSMIC mutation entries 476 (BRAF) and 10656 (TP53).
+        Variant(7, 140753336, "A", "T", ensembl_grch38),
+        Variant(17, 7674221, "G", "A", ensembl_grch38),
+    ])
+
+
+@pytest.fixture(scope="module")
+def cancer_test_effects(cancer_test_variants):
+    """Compute real variant effects during fixture setup, never collection."""
+    return cancer_test_variants.effects()
+
+
+@pytest.fixture(scope="module")
+def gene_expression_dict(cancer_test_variants):
+    """Assign 1.0 FPKM to each gene annotated at the test variants."""
+    return {
+        gene_id: 1.0
+        for variant in cancer_test_variants
+        for gene_id in variant.gene_ids
+    }
+
+
+@pytest.fixture(scope="module")
+def transcript_expression_dict(cancer_test_variants):
+    """Assign 1.0 FPKM to each transcript annotated at the test variants."""
+    return {
+        transcript_id: 1.0
+        for variant in cancer_test_variants
+        for transcript_id in variant.transcript_ids
+    }
 
 
 def pytest_runtest_setup(item):

--- a/tests/data.py
+++ b/tests/data.py
@@ -13,44 +13,16 @@
 # limitations under the License.
 
 """
-Helper functions and shared datasets for tests
+File paths for test data. Annotation-dependent datasets live in pytest fixtures.
 """
 
 
-from __future__ import print_function, division, absolute_import
 import os
 
-from varcode import Variant, VariantCollection
-from pyensembl import ensembl_grch38
 
 def data_path(name):
     """
-    Return the absolute path to a file in the varcode/test/data directory.
-    The name specified should be relative to varcode/test/data.
+    Return the absolute path to a file in Topiary's tests/data directory.
+    The name specified should be relative to tests/data.
     """
     return os.path.join(os.path.dirname(__file__), "data", name)
-
-# BRAF variant coordinates from COSMIC entry:
-# http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=476
-braf_V600E_variant = Variant(7, 140753336, "A", "T", ensembl_grch38)
-
-# TP53 variant coordinates from COSMIC entry:
-# http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=10656
-tp53_R248W_variant = Variant(17, 7674221, "G", "A", ensembl_grch38)
-
-cancer_test_variants = VariantCollection([
-    braf_V600E_variant,
-    tp53_R248W_variant
-])
-
-cancer_test_variant_gene_ids = {
-    gene_id
-    for v in cancer_test_variants
-    for gene_id in v.gene_ids
-}
-
-cancer_test_variant_transcript_ids = {
-    transcript_id
-    for v in cancer_test_variants
-    for transcript_id in v.transcript_ids
-}

--- a/tests/test_ci_coverage.py
+++ b/tests/test_ci_coverage.py
@@ -1,0 +1,188 @@
+"""Exercise CI downloads, complete coverage aggregation, and upload retries."""
+
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from threading import Thread
+import xml.etree.ElementTree as ET
+
+from coverage import CoverageData
+import pytest
+
+
+@pytest.fixture
+def download_server():
+    """Serve controlled HTTP failures to the real curl used by the script."""
+    responses = []
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests.append(self.path)
+            status, body, length = responses[min(len(requests) - 1, len(responses) - 1)]
+            self.send_response(status)
+            self.send_header("Content-Length", str(length))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/reporter", responses, requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("failure", ["none", "transient", "http", "not-found", "partial", "checksum"])
+def test_verified_download_retries_and_fails_closed(tmp_path, download_server, failure):
+    url, responses, requests = download_server
+    body = b"verified reporter bytes\n"
+    success = (200, body, len(body))
+    responses.extend({
+        "none": [success],
+        "transient": [(503, b"unavailable", 11), success],
+        "http": [(503, b"unavailable", 11)],
+        "not-found": [(404, b"missing", 7)],
+        "partial": [(200, body[:4], len(body))],
+        "checksum": [(200, b"wrong binary", 12)],
+    }[failure])
+    destination = tmp_path / "reporter with spaces"
+    destination.write_bytes(b"previous verified installation")
+    script = Path(__file__).resolve().parents[1] / "scripts/download_verified.sh"
+    result = subprocess.run(
+        ["bash", str(script), url, hashlib.sha256(body).hexdigest(), str(destination)],
+        capture_output=True, text=True, timeout=20,
+    )
+    if failure in {"none", "transient"}:
+        assert result.returncode == 0, result.stderr
+        assert destination.read_bytes() == body
+        assert len(requests) == (2 if failure == "transient" else 1)
+    else:
+        assert result.returncode != 0
+        assert destination.read_bytes() == b"previous verified installation"
+        assert len(requests) == (1 if failure == "checksum" else 4)
+        if failure in {"http", "not-found"}:
+            assert str(responses[0][0]) in result.stderr
+        if failure == "checksum":
+            assert "FAILED" in result.stdout
+    assert not list(tmp_path.glob("*.download.*"))
+
+
+@pytest.fixture
+def coverage_matrix(tmp_path):
+    source = tmp_path / "example.py"
+    source.write_text("first = 1\nsecond = 2\nthird = 3\n")
+    directory = tmp_path / "coverage-data"
+    paths = []
+    for line, version in enumerate(["3.10", "3.11", "3.12"], 1):
+        path = directory / f"coverage-python-{version}" / ".coverage"
+        path.parent.mkdir(parents=True)
+        data = CoverageData(basename=str(path))
+        data.add_lines({str(source): {line}})
+        data.write()
+        paths.append(path)
+    return directory, source, paths
+
+
+def _combine(directory, output):
+    script = Path(__file__).with_name("combine_coverage.py")
+    return subprocess.run(
+        [sys.executable, str(script), str(directory), "3", str(output)],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def test_combine_covers_union_and_reuses_successful_jobs_on_retry(tmp_path, coverage_matrix):
+    directory, source, paths = coverage_matrix
+    output = tmp_path / "coverage.xml"
+    result = _combine(directory, output)
+    assert result.returncode == 0, result.stderr
+    assert ET.parse(output).getroot().attrib["line-rate"] == "1"
+    assert all(path.is_file() for path in paths)
+
+    # Only the retried member changes. Other matrix artifacts are reused,
+    # and the old combined result must not leak into the next upload.
+    retried = CoverageData(basename=str(paths[-1]))
+    retried.erase()
+    retried.add_lines({str(source): {2}})
+    retried.write()
+    result = _combine(directory, output)
+    assert result.returncode == 0, result.stderr
+    lines = ET.parse(output).findall(".//line")
+    assert {int(line.attrib["number"]): int(line.attrib["hits"]) for line in lines} == {
+        1: 1, 2: 1, 3: 0,
+    }
+
+
+@pytest.mark.parametrize("failure", ["missing", "extra", "empty", "corrupt", "incompatible"])
+def test_combine_refuses_incomplete_or_invalid_matrix(tmp_path, coverage_matrix, failure):
+    directory, source, paths = coverage_matrix
+    if failure == "missing":
+        paths[-1].unlink()
+    elif failure == "extra":
+        extra = directory / "coverage-python-unexpected" / ".coverage"
+        extra.parent.mkdir()
+        extra.write_bytes(paths[0].read_bytes())
+    elif failure in {"empty", "corrupt"}:
+        paths[-1].write_bytes(b"" if failure == "empty" else b"not a coverage database")
+    else:
+        data = CoverageData(basename=str(paths[-1]))
+        data.erase()
+        data.add_arcs({str(source): {(-1, 1), (1, -1)}})
+        data.write()
+    output = tmp_path / "coverage.xml"
+    result = _combine(directory, output)
+    assert result.returncode != 0
+    assert not output.exists()
+    assert paths[-1].name in result.stderr or "coverage" in result.stderr.lower()
+
+
+def test_workflow_separates_coverage_and_preserves_matrix_artifacts():
+    workflow = Path(".github/workflows/tests.yml").read_text()
+    build = workflow.split("  build:\n", 1)[1].split("  pirlygenes-integration:\n", 1)[0]
+    upload = workflow.split("  coverage:\n", 1)[1]
+    assert "coverallsapp/github-action" not in workflow
+    assert "parallel-finished" not in workflow
+    assert "coveralls" not in build
+    assert "coverage-jobs: ${{ strategy.job-total }}" in build
+    assert "include-hidden-files: true" in build
+    assert "overwrite: true" in build
+    assert "if-no-files-found: error" in build
+    assert "needs: build" in upload
+    assert "always()" not in upload
+    assert "continue-on-error" not in upload
+    assert "needs.build.outputs.coverage-jobs" in upload
+    assert "tests/combine_coverage.py" in upload
+    assert "scripts/download_verified.sh" in upload
+
+
+@pytest.mark.parametrize("status", [0, 42])
+def test_actual_upload_step_has_retry_identity_and_propagates_errors(tmp_path, status):
+    workflow = Path(".github/workflows/tests.yml").read_text()
+    step = workflow.split("      - name: Publish coverage to Coveralls\n", 1)[1]
+    command = textwrap.dedent(step.split("        run: |\n", 1)[1])
+    reporter = tmp_path / "coveralls"
+    reporter.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\nexit "$REPORT_STATUS"\n')
+    reporter.chmod(0o755)
+    for attempt in (1, 2):
+        result = subprocess.run(
+            ["bash", "-eo", "pipefail", "-c", command],
+            env=dict(os.environ, RUNNER_TEMP=str(tmp_path), GITHUB_RUN_ID="12345",
+                     GITHUB_RUN_ATTEMPT=str(attempt), REPORT_STATUS=str(status)),
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == status
+        assert result.stdout.splitlines() == [
+            "report", "coverage.xml", "--format=cobertura",
+            f"--build-number=12345-{attempt}",
+        ]

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,70 @@
+"""Collecting tests must not load reference data for deselected tests."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize("selection", [
+    ["--collect-only"],
+    ["-m", "isovar", "--strict-markers"],
+])
+def test_collection_and_marker_selection_without_reference_data(tmp_path, selection):
+    """Run the whole collection, with empty caches and forbidden I/O."""
+    cache = tmp_path / "ensembl"
+    cache.mkdir()
+    code = textwrap.dedent("""
+        import sys
+
+        def forbid_network(event, args):
+            if event in {"socket.connect", "socket.getaddrinfo"}:
+                raise AssertionError("Network access during collection/Isovar tests")
+
+        sys.addaudithook(forbid_network)
+        import pyensembl
+
+        def forbid_annotation(*args, **kwargs):
+            raise AssertionError("Unselected Ensembl annotation was accessed")
+
+        pyensembl.Genome.db = property(forbid_annotation)
+        pyensembl.Genome.download = forbid_annotation
+        pyensembl.Genome.index = forbid_annotation
+
+        import pytest
+        raise SystemExit(pytest.main(["tests", "-q", *sys.argv[1:]]))
+    """)
+    env = dict(os.environ, PYENSEMBL_CACHE_DIR=str(cache))
+    # The child selects tests explicitly; do not inherit xdist/coverage options
+    # or pytest-cov's subprocess instrumentation from its parent test run.
+    for name in list(env):
+        if name in {"PYTEST_ADDOPTS", "COVERAGE_PROCESS_START"} or name.startswith("COV_CORE_"):
+            env.pop(name)
+    result = subprocess.run(
+        [sys.executable, "-c", code, *selection],
+        cwd=Path(__file__).resolve().parents[1], env=env,
+        text=True, capture_output=True, timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not list(cache.rglob("*")), "Collection/Isovar selection wrote reference data"
+    expected = "collected" if "--collect-only" in selection else "deselected"
+    assert expected in result.stdout
+
+
+def test_data_path_import_does_not_import_annotation_libraries():
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent("""
+            import sys
+            from pathlib import Path
+            from tests.data import data_path
+            assert "varcode" not in sys.modules
+            assert "pyensembl" not in sys.modules
+            assert Path(data_path("")) == Path("tests/data").resolve()
+        """)],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True, capture_output=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pytest
 
 from topiary import (
+    DEFAULT_PROTEIN_SEQUENCE_LENGTH,
     EvalContext,
     Presentation,
     TopiaryPredictor,
@@ -425,7 +426,10 @@ def isovar_fragments_from_reads(monkeypatch):
     from isovar.read_evidence import ReadEvidence
     from isovar.reference_context import ReferenceContext
 
-    def assemble(strand, assembly, ref, alt, prefixes, suffix):
+    def assemble(
+        strand, assembly, ref, alt, prefixes, suffix,
+        protein_sequence_length=DEFAULT_PROTEIN_SEQUENCE_LENGTH,
+    ):
         def genomic(sequence):
             return sequence if strand == "+" else reverse_complement_dna(sequence)
 
@@ -467,6 +471,7 @@ def isovar_fragments_from_reads(monkeypatch):
                 [variant], alignment_file=object(), read_collector=Collector(),
                 protein_sequence_creator=ProteinSequenceCreator(
                     variant_sequence_assembly=assembly,
+                    protein_sequence_length=protein_sequence_length,
                 ),
                 filter_thresholds={}, filter_flags=[],
             )
@@ -508,14 +513,22 @@ def test_isovar_multibase_mutation_keeps_second_changed_codon(
 @pytest.mark.isovar
 @pytest.mark.parametrize("strand", ["+", "-"])
 @pytest.mark.parametrize("assembly", [False, True])
+@pytest.mark.parametrize("protein_sequence_length,sequence,interval", [
+    (21, "TTT" + "K" * 15 + "GGG", (3, 18)),
+    (49, "TTTT" + "K" * 15 + "G" * 10, (4, 19)),
+])
 def test_isovar_long_insertion_reaches_fragment_and_predictions(
     isovar_fragments_from_reads, strand, assembly,
+    protein_sequence_length, sequence, interval,
 ):
+    # Explicit windows cover Topiary's default and the longer context used by
+    # Isovar 1.8.0. A dependency's default must not determine this fixture.
     fragment, = isovar_fragments_from_reads(
         strand, assembly, "", "A" * 45, ["ACG" * 4] * 3, "G" * 30,
+        protein_sequence_length=protein_sequence_length,
     )
-    assert fragment.sequence == "TTT" + "K" * 15 + "GG"
-    assert list(fragment.target_intervals) == [(3, 18)]
+    assert fragment.sequence == sequence
+    assert list(fragment.target_intervals) == [interval]
     assert fragment.n_rna_alt_reads_supporting_protein_sequence == 6
     assert fragment.n_rna_alt_fragments_supporting_protein_sequence == 3
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,7 +1,6 @@
 import pytest
 from mhctools import NetMHC
 from topiary import TopiaryPredictor
-from .data import cancer_test_variants
 
 alleles = [
     "A02:01",
@@ -17,7 +16,7 @@ def mhc_model():
     return NetMHC(alleles=alleles, default_peptide_lengths=[8, 9, 10])
 
 
-def test_epitopes_to_dataframe_transcript_expression(mhc_model):
+def test_epitopes_to_dataframe_transcript_expression(mhc_model, cancer_test_variants):
     predictor = TopiaryPredictor(mhc_model=mhc_model, only_novel_epitopes=False)
     df = predictor.predict_from_variants(
         variants=cancer_test_variants,
@@ -36,7 +35,7 @@ def test_epitopes_to_dataframe_transcript_expression(mhc_model):
     ).all(), "Invalid FPKM values in DataFrame transcript_expression column"
 
 
-def test_epitopes_to_dataframe_gene_expression(mhc_model):
+def test_epitopes_to_dataframe_gene_expression(mhc_model, cancer_test_variants):
     predictor = TopiaryPredictor(mhc_model=mhc_model, only_novel_epitopes=False)
 
     df = predictor.predict_from_variants(

--- a/tests/test_effect_expression_filters.py
+++ b/tests/test_effect_expression_filters.py
@@ -1,26 +1,9 @@
-from .data import (
-    cancer_test_variants,
-    cancer_test_variant_gene_ids,
-    cancer_test_variant_transcript_ids,
-)
 from topiary.filters import apply_effect_expression_filters
-
-cancer_test_effects = cancer_test_variants.effects()
 
 DEFAULT_FPKM = 1.0
 
-# associate every gene ID with 1.0 FPKM
-gene_expression_dict = {
-    gene_id: DEFAULT_FPKM for gene_id in cancer_test_variant_gene_ids
-}
 
-# associate every transcript with 1.0 FPKM
-transcript_expression_dict = {
-    transcript_id: DEFAULT_FPKM for transcript_id in cancer_test_variant_transcript_ids
-}
-
-
-def test_apply_effect_gene_expression_below_threshold():
+def test_apply_effect_gene_expression_below_threshold(cancer_test_effects, gene_expression_dict):
     filtered = apply_effect_expression_filters(
         cancer_test_effects,
         gene_expression_dict=gene_expression_dict,
@@ -33,7 +16,7 @@ def test_apply_effect_gene_expression_below_threshold():
     ), "All variants should have been filtered out but got: %s" % (filtered,)
 
 
-def test_apply_effect_gene_expression_above_threshold():
+def test_apply_effect_gene_expression_above_threshold(cancer_test_effects, gene_expression_dict):
     filtered = apply_effect_expression_filters(
         cancer_test_effects,
         gene_expression_dict=gene_expression_dict,
@@ -46,7 +29,7 @@ def test_apply_effect_gene_expression_above_threshold():
     ), "Expected %s effects but got %s" % (len(cancer_test_effects), len(filtered))
 
 
-def test_apply_effect_gene_expression_equal_threshold():
+def test_apply_effect_gene_expression_equal_threshold(cancer_test_effects, gene_expression_dict):
     # expect genes with expression at threshold to NOT get filtered
     filtered = apply_effect_expression_filters(
         cancer_test_effects,
@@ -60,7 +43,7 @@ def test_apply_effect_gene_expression_equal_threshold():
     ), "Expected %s effects but got %s" % (len(cancer_test_effects), len(filtered))
 
 
-def test_apply_effect_transcript_expression_below_threshold():
+def test_apply_effect_transcript_expression_below_threshold(cancer_test_effects, transcript_expression_dict):
     filtered = apply_effect_expression_filters(
         cancer_test_effects,
         gene_expression_dict=None,
@@ -73,7 +56,7 @@ def test_apply_effect_transcript_expression_below_threshold():
     ), "All effects should have been filtered out but got: %s" % (filtered,)
 
 
-def test_apply_effect_transcript_expression_above_threshold():
+def test_apply_effect_transcript_expression_above_threshold(cancer_test_effects, transcript_expression_dict):
     filtered = apply_effect_expression_filters(
         cancer_test_effects,
         gene_expression_dict=None,
@@ -86,7 +69,7 @@ def test_apply_effect_transcript_expression_above_threshold():
     ), "Expected %s effects but got %s" % (len(cancer_test_effects), len(filtered))
 
 
-def test_apply_effect_transcript_expression_equal_threshold():
+def test_apply_effect_transcript_expression_equal_threshold(cancer_test_effects, transcript_expression_dict):
     # expect transcripts with expression at threshold to NOT be filtered
     filtered = apply_effect_expression_filters(
         cancer_test_effects,

--- a/tests/test_epitopes_from_commandline_args.py
+++ b/tests/test_epitopes_from_commandline_args.py
@@ -1,10 +1,9 @@
 from topiary.cli.args import arg_parser, predict_epitopes_from_args
 
 from .common import eq_
-from .data import cancer_test_variants
 
 
-def test_cancer_epitopes_from_args():
+def test_cancer_epitopes_from_args(cancer_test_variants):
     epitope_lengths = [9, 10]
     alleles = ["HLA-A*02:01", "C0701"]
     args_list = [

--- a/tests/test_optional_integration_selection.py
+++ b/tests/test_optional_integration_selection.py
@@ -95,11 +95,7 @@ def test_ci_requires_both_absent_and_installed_environments(dependency):
     assert f"{dependency}-integration:" in workflow
     assert f"python -m pip install -e '.[{dependency}]'" in workflow
     assert f'TOPIARY_TEST_REQUIRE_{dependency.upper()}: "1"' in workflow
-    command = (
-        "python -m pytest tests/test_consumer_workflows.py"
-        if dependency == "isovar" else "./test.sh"
-    )
-    assert f"{command} -m {dependency} --strict-markers" in workflow
+    assert f"./test.sh -m {dependency} --strict-markers" in workflow
 
 
 def test_external_predictors_are_not_created_during_test_collection():

--- a/tests/test_predict_from_variants_refactor.py
+++ b/tests/test_predict_from_variants_refactor.py
@@ -28,9 +28,6 @@ from topiary.predictor import (
     fragment_from_effect,
 )
 
-from .data import cancer_test_variants
-
-
 ALLELES = ["HLA-A*02:01"]
 
 
@@ -49,7 +46,7 @@ def _predictor(**kwargs):
 
 
 class TestLegacyColumnContract:
-    def test_required_columns_present(self):
+    def test_required_columns_present(self, cancer_test_variants):
         df = _predictor().predict_from_variants(cancer_test_variants)
         required = {
             "peptide", "peptide_offset", "peptide_length", "allele",
@@ -63,7 +60,7 @@ class TestLegacyColumnContract:
         missing = required - set(df.columns)
         assert not missing, f"Missing legacy columns: {missing}"
 
-    def test_peptide_offset_is_absolute(self):
+    def test_peptide_offset_is_absolute(self, cancer_test_variants):
         """Offset should be relative to the full mutant protein, not
         to the sliding-window subsequence."""
         df = _predictor().predict_from_variants(cancer_test_variants)
@@ -75,7 +72,7 @@ class TestLegacyColumnContract:
             "peptide_offset appears to be fragment-local, not absolute protein"
         )
 
-    def test_mutation_interval_populated_when_overlapping(self):
+    def test_mutation_interval_populated_when_overlapping(self, cancer_test_variants):
         df = _predictor().predict_from_variants(cancer_test_variants)
         aff = df[df["kind"] == "pMHC_affinity"]
         mutant = aff[aff["contains_mutant_residues"].eq(True)]
@@ -87,7 +84,7 @@ class TestLegacyColumnContract:
         assert nonmutant["mutation_start_in_peptide"].isna().all()
         assert nonmutant["mutation_end_in_peptide"].isna().all()
 
-    def test_internal_annotation_keys_not_leaked(self):
+    def test_internal_annotation_keys_not_leaked(self, cancer_test_variants):
         """Internal bookkeeping keys stashed on fragment.annotations
         must not appear as columns on the returned DataFrame."""
         df = _predictor().predict_from_variants(cancer_test_variants)
@@ -98,7 +95,7 @@ class TestLegacyColumnContract:
         ):
             assert leaked not in df.columns, f"Internal key leaked: {leaked}"
 
-    def test_only_novel_epitopes_drops_non_mutant_rows(self):
+    def test_only_novel_epitopes_drops_non_mutant_rows(self, cancer_test_variants):
         # padding=16 gives a 33-residue subseq for a single-aa mutation,
         # so the outer 9-mers don't overlap the mutation and we can
         # verify that only_novel_epitopes=True drops them.
@@ -118,7 +115,7 @@ class TestLegacyColumnContract:
 
 
 class TestFragmentColumnsOnVariantPath:
-    def test_fragment_id_and_source_type_populated(self):
+    def test_fragment_id_and_source_type_populated(self, cancer_test_variants):
         df = _predictor().predict_from_variants(cancer_test_variants)
         assert "fragment_id" in df.columns
         assert "source_type" in df.columns
@@ -126,7 +123,7 @@ class TestFragmentColumnsOnVariantPath:
         # Both BRAF V600E and TP53 R248W are single-residue substitutions
         assert (df["source_type"] == "variant:snv").all()
 
-    def test_overlaps_target_matches_contains_mutant(self):
+    def test_overlaps_target_matches_contains_mutant(self, cancer_test_variants):
         """For variant fragments, overlaps_target and
         contains_mutant_residues derive from the same interval — they
         should agree row-by-row."""
@@ -134,7 +131,7 @@ class TestFragmentColumnsOnVariantPath:
         aff = df[df["kind"] == "pMHC_affinity"]
         assert (aff["overlaps_target"] == aff["contains_mutant_residues"]).all()
 
-    def test_wt_peptide_populated_for_substitutions(self):
+    def test_wt_peptide_populated_for_substitutions(self, cancer_test_variants):
         """Substitution effects have matched-length original/mutant
         proteins, so wt_peptide is derived from the reference slice."""
         df = _predictor().predict_from_variants(cancer_test_variants)
@@ -145,7 +142,7 @@ class TestFragmentColumnsOnVariantPath:
         mutant = aff[aff["contains_mutant_residues"].eq(True)]
         assert (mutant["peptide"] != mutant["wt_peptide"]).all()
 
-    def test_predict_wt_populates_wt_prediction_columns(self):
+    def test_predict_wt_populates_wt_prediction_columns(self, cancer_test_variants):
         """predict_wt=True should run on the variant path after legacy
         mutation columns are attached but before filter/sort."""
         df = _predictor(predict_wt=True).predict_from_variants(
@@ -335,7 +332,7 @@ class TestExpressionDictPlumbing:
     """Regression: legacy gene_expression_dict / transcript_expression_dict
     still propagate into the column output through the refactored path."""
 
-    def test_transcript_expression_dict_populates_column(self):
+    def test_transcript_expression_dict_populates_column(self, cancer_test_variants):
         expr_dict = {
             transcript_id: 42.0
             for v in cancer_test_variants
@@ -347,7 +344,7 @@ class TestExpressionDictPlumbing:
         assert "transcript_expression" in df.columns
         assert (df["transcript_expression"] == 42.0).all()
 
-    def test_gene_expression_dict_populates_column(self):
+    def test_gene_expression_dict_populates_column(self, cancer_test_variants):
         expr_dict = {
             gene_id: 7.5
             for v in cancer_test_variants

--- a/tests/test_variant_expression_filters.py
+++ b/tests/test_variant_expression_filters.py
@@ -1,27 +1,9 @@
 
 from topiary.filters import apply_variant_expression_filters
 
-from .data import (
-    cancer_test_variants,
-    cancer_test_variant_gene_ids,
-    cancer_test_variant_transcript_ids,
-)
-
 DEFAULT_FPKM = 1.0
 
-# associate every gene ID with 1.0 FPKM
-gene_expression_dict = {
-    gene_id: DEFAULT_FPKM
-    for gene_id in cancer_test_variant_gene_ids
-}
-
-# associate every transcript with 1.0 FPKM
-transcript_expression_dict = {
-    transcript_id: DEFAULT_FPKM
-    for transcript_id in cancer_test_variant_transcript_ids
-}
-
-def test_apply_variant_gene_expression_below_threshold():
+def test_apply_variant_gene_expression_below_threshold(cancer_test_variants, gene_expression_dict):
     filtered = apply_variant_expression_filters(
         cancer_test_variants,
         gene_expression_dict=gene_expression_dict,
@@ -31,7 +13,7 @@ def test_apply_variant_gene_expression_below_threshold():
     assert len(filtered) == 0, \
         "All variants should have been filtered out but got: %s" % (filtered,)
 
-def test_apply_variant_gene_expression_above_threshold():
+def test_apply_variant_gene_expression_above_threshold(cancer_test_variants, gene_expression_dict):
     filtered = apply_variant_expression_filters(
         cancer_test_variants,
         gene_expression_dict=gene_expression_dict,
@@ -41,7 +23,7 @@ def test_apply_variant_gene_expression_above_threshold():
     assert len(filtered) == len(cancer_test_variants), \
         "Expected %s variants but got %s" % (len(cancer_test_variants), len(filtered))
 
-def test_apply_variant_transcript_expression_below_threshold():
+def test_apply_variant_transcript_expression_below_threshold(cancer_test_variants, transcript_expression_dict):
     filtered = apply_variant_expression_filters(
         cancer_test_variants,
         gene_expression_dict=None,
@@ -51,7 +33,7 @@ def test_apply_variant_transcript_expression_below_threshold():
     assert len(filtered) == 0, \
         "All variants should have been filtered out but got: %s" % (filtered,)
 
-def test_apply_variant_transcript_expression_above_threshold():
+def test_apply_variant_transcript_expression_above_threshold(cancer_test_variants, transcript_expression_dict):
     filtered = apply_variant_expression_filters(
         cancer_test_variants,
         gene_expression_dict=None,

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -168,7 +168,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.52.9"
+__version__ = "5.52.10"
 
 __all__ = [
     "TopiaryPredictor",

--- a/topiary/io_isovar.py
+++ b/topiary/io_isovar.py
@@ -179,10 +179,10 @@ def fragments_from_isovar_results(isovar_results):
 #: A fragment is scanned by a sliding window later, so the assembled
 #: sequence has to be long enough to contain every peptide that could
 #: cover the mutation — the peptide length plus padding on both sides.
-#: This matches isovar's own default rather than raising it: with
-#: assembly on, a longer window still has to be reachable from the
-#: reads, and asking for more than the data supports silently returns
-#: fewer variants rather than longer sequences.
+#: Topiary keeps its historical 21-amino-acid default independently of
+#: Isovar's default. Callers can request a different length or supply a
+#: configured ProteinSequenceCreator; available RNA context still limits
+#: the assembled sequence.
 DEFAULT_PROTEIN_SEQUENCE_LENGTH = 21
 
 


### PR DESCRIPTION
## Summary

Closes #282. Closes #280. Closes #285.

- Publish combined coverage once after all Python matrix members pass, using retry-specific build identifiers. Preserve successful artifacts during failed-job retries.
- Download the pinned Coveralls reporter with bounded HTTP retries and SHA-256 validation; incomplete coverage and upload failures stay fatal.
- Load annotation-backed test data through lazy fixtures. Whole-suite collection and optional-integration selection work without reference downloads.
- Make Isovar fixture windows explicit and test both 21- and 49-aa requests across strands and assembly modes, with exact sequence, mutation-interval, read/fragment-support and prediction assertions. This works with both Isovar 1.7.10 and 1.8.0.
- Correct the stale comment about Isovar's default. Topiary's runtime context policy is unchanged; adopting peptide-aware controls remains #284.
- Version: 5.52.10.

## Current local validation

- `./lint.sh`: passed.
- `./test.sh -n 0`, with both integrations required and the shared environment using editable Topiary, PirlyGenes 6.0.4, oncoref 1.8.194, Isovar 1.8.0, Varcode 7.0.0, PyEnsembl 2.10.4 and mhctools 3.35.1: **2,877 passed, zero skipped, 92% coverage**.
- Minimum Isovar 1.7.10: **24 real consumer-workflow tests passed**, including both explicit window sizes.
- Prior review verified actionlint, strict docs, sdist/wheel content checks and strict Twine checks. Fresh CI is required for this updated head.

## Prior CI retry proof

Before the Isovar fixture update, all nine jobs passed in the [PR workflow](https://github.com/openvax/topiary/actions/runs/34151075923), and [docs passed](https://github.com/openvax/topiary/actions/runs/34151075927).
The [push workflow retry](https://github.com/openvax/topiary/actions/runs/34151064845/attempts/2) reused all three original coverage artifacts, reverified the checksum and published the new build identifier successfully: [Coveralls 34151064845-2](https://coveralls.io/jobs/187491846).

An upstream coverage.py in-memory merge bug is filed at https://github.com/coveragepy/coveragepy/issues/2279. This PR uses its working disk-backed public API with a temporary database.
