### PR TITLE
Fail closed on exact-version PyPI release preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.53.1
+
+**Fail-closed release preflight (#286).** Releases now query PyPI's exact-release
+JSON endpoint through the selected Python interpreter. Only a confirmed HTTP
+404 permits release to continue; network, TLS, server and malformed-response
+errors stop before lint, tests, builds or uploads, with a clear diagnostic.
+Standard packaging rules distinguish nearby versions while recognizing
+equivalent spellings. Yanked, prerelease and interpreter-incompatible releases
+cannot disappear behind pip's installability filtering. The read-only
+`pypi_release_exists` API and `python -m topiary.cli.release PROJECT VERSION`
+command share one implementation. Packaging >=23.2 supplies validated package
+names; no custom version regex or shell output parsing remains.
+
 ## 5.53.0
 
 **Peptide-aware RNA reconstruction (#284).** `fragments_from_variants` exposes

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,11 +28,8 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-# Check version isn't already on PyPI
-if "${PYTHON}" -m pip index versions topiary 2>/dev/null | grep -q "${VERSION}"; then
-    echo "ERROR: topiary ${VERSION} already exists on PyPI"
-    exit 1
-fi
+# Stop on an existing release OR an unverifiable lookup, before any gates run.
+"${PYTHON}" -m topiary.cli.release topiary "${VERSION}"
 
 # Lint
 ./lint.sh

--- a/docs/api.md
+++ b/docs/api.md
@@ -513,3 +513,29 @@ available_properties()
 ```
 
 Groups: `"core"`, `"manufacturability"`, `"immunogenicity"`. See [Peptide Properties](properties.md) for details.
+
+## Release preflight
+
+```python
+from topiary import pypi_release_exists
+
+exists = pypi_release_exists("topiary", "5.53.0", timeout=10)
+```
+
+Returns `True` for a matching PyPI release, including yanked releases and
+releases incompatible with the running Python. Returns `False` only for HTTP
+404 (project or version absent). Network/server errors and malformed or
+mismatched metadata raise `RuntimeError`; invalid names or versions raise
+`ValueError`. Versions use [standard packaging comparisons](https://packaging.pypa.io/en/stable/version.html),
+not substring matching: `1.0` and `1.0.0` are equivalent, but `1.0.1` and
+`1.0rc1` are different releases.
+
+The lookup uses PyPI's [release-specific JSON API](https://docs.pypi.org/api/json/#get-a-release),
+independent of pip index settings and Python/platform filtering. It performs no
+upload or reservation; a subsequent upload still has to reject duplicates.
+
+For release scripts, use `python -m topiary.cli.release PROJECT VERSION`.
+It returns success only when the release is confirmed absent, otherwise a
+nonzero exit and a diagnostic. `deploy.sh` uses this same implementation and
+interpreter before lint, tests, build or upload. A failed lookup never gives
+permission to publish; fix the lookup error and retry the release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ mhctools>=3.39.0
 varcode>=4.18.0
 gtfparse>=0.0.4
 mhcnames
-# PEP 440 ordering for resolve_default_versions
-packaging
+# PEP 440 versions and validated package names for release preflight
+packaging>=23.2
 argcomplete>=1.10

--- a/tests/test_consumer_workflows.py
+++ b/tests/test_consumer_workflows.py
@@ -57,6 +57,32 @@ PVACSEQ_PRESENTATION = (
 )
 
 
+@pytest.mark.parametrize("scenario, allowed", [
+    ("absent", True), ("published", False), ("timeout", False),
+    ("http_error", False), ("bad_metadata", False), ("wrong_version", False),
+])
+def test_release_api_and_cli_enforce_the_same_publish_policy(monkeypatch, scenario, allowed):
+    from urllib.error import HTTPError
+    from topiary import release
+    from tests.test_release import response
+    from tests.test_twin_conformance import RELEASE_PREFLIGHT_DOORS
+
+    def lookup(request, timeout):
+        if scenario in {"absent", "http_error"}:
+            status = 404 if scenario == "absent" else 503
+            raise HTTPError(request.full_url, status, "simulated", {}, None)
+        if scenario == "timeout":
+            raise TimeoutError("lookup timed out")
+        if scenario == "bad_metadata":
+            return response({})
+        version = "5.53.0" if scenario == "published" else "5.53.1"
+        return response({"info": {"name": "topiary", "version": version}})
+
+    monkeypatch.setattr(release, "urlopen", lookup)
+    for door in RELEASE_PREFLIGHT_DOORS:
+        assert door("topiary", "5.53.0") is allowed
+
+
 def _long(reader, path):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -1,5 +1,6 @@
 """Regression tests for deploy.sh release safety checks."""
 
+import json
 import os
 from pathlib import Path
 import shutil
@@ -39,9 +40,12 @@ def _fake_python(path):
 set -eu
 printf '%s\\n' "$*" >> "$PYTHON_INVOCATION_LOG"
 if [[ "${1:-}" == "-c" ]]; then
-    printf '%s\\n' "5.52.5"
+    printf '%s\\n' "${RELEASE_VERSION:-5.52.5}"
 elif [[ "${1:-}" == "-m" && "${2:-}" == "pip" ]]; then
-    exit 1
+    printf '%s\\n' "${PYPI_LISTING:-Available versions: 5.52.4}"
+    exit "${PYPI_LOOKUP_STATUS:-0}"
+elif [[ "${1:-}" == "-m" && "${2:-}" == "topiary.cli.release" ]]; then
+    exec "$REAL_PYTHON" "$RELEASE_CHECK_DRIVER" "$@"
 elif [[ "${1:-}" == "-m" && "${2:-}" == "build" ]]; then
     mkdir -p dist
     touch dist/topiary-5.52.5-py3-none-any.whl
@@ -66,6 +70,46 @@ def _release_repo(tmp_path):
         repo / "scripts" / "resolve_python.sh",
     )
     (repo / "topiary" / "__init__.py").write_text('__version__ = "5.52.5"\n')
+    for name in ("release.py", "cli/release.py"):
+        source = SOURCE_ROOT / "topiary" / name
+        destination = repo / "topiary" / name
+        destination.parent.mkdir(exist_ok=True)
+        shutil.copy2(source, destination)
+    (repo / "topiary" / "cli" / "__init__.py").touch()
+    # Exercise the real Python preflight and CLI in a subprocess; only the
+    # HTTP boundary is replaced. No test may publish or contact PyPI.
+    (repo / "pypi_response.py").write_text('''import io
+import os
+import runpy
+import socket
+import ssl
+import sys
+from urllib.error import HTTPError, URLError
+from topiary import release
+
+def response(request, timeout):
+    with open(os.environ["PYPI_REQUEST_LOG"], "a") as log:
+        log.write(request.full_url + "\\n")
+    assert timeout == 10
+    error = os.environ.get("PYPI_ERROR")
+    if error == "timeout":
+        raise TimeoutError("lookup timed out")
+    if error == "dns":
+        raise URLError(socket.gaierror("DNS lookup failed"))
+    if error == "tls":
+        raise URLError(ssl.SSLError("certificate verification failed"))
+    status = int(os.environ.get("PYPI_STATUS", "404"))
+    if status >= 400:
+        raise HTTPError(request.full_url, status, "simulated PyPI failure", {}, None)
+    body = os.environ.get("PYPI_BODY", "").encode()
+    result = io.BytesIO(body)
+    result.status = status
+    return result
+
+release.urlopen = response
+sys.argv = sys.argv[2:]
+runpy.run_module(sys.argv[0], run_name="__main__")
+''')
     (repo / ".gitignore").write_text(".venv/\nbuild/\ndist/\n")
     for name in ("lint.sh", "test.sh"):
         (repo / name).write_text(
@@ -96,6 +140,8 @@ def _deploy(repo, env_updates):
         "GATE_PYTHON_LOG": str(repo.parent / "gate-python.log"),
         "PYTHON_INVOCATION_LOG": str(repo.parent / "python-invocations.log"),
         "REAL_PYTHON": sys.executable,
+        "RELEASE_CHECK_DRIVER": str(repo / "pypi_response.py"),
+        "PYPI_REQUEST_LOG": str(repo.parent / "pypi-requests.log"),
     })
     for name, value in env_updates.items():
         if value is None:
@@ -103,6 +149,126 @@ def _deploy(repo, env_updates):
         else:
             env[name] = value
     return _run(["bash", "deploy.sh"], repo, env)
+
+
+def _assert_release_stopped(repo):
+    """Failure must precede every gate, build, upload and tag mutation."""
+    assert not (repo.parent / "gate-python.log").exists()
+    invocations = (repo.parent / "python-invocations.log").read_text()
+    assert "-m build" not in invocations
+    assert "-m twine" not in invocations
+    assert not (repo / "dist").exists()
+    assert not _git(repo, "tag", "--list").stdout
+    assert not _git(repo, "ls-remote", "--tags", "origin").stdout
+
+
+@pytest.mark.parametrize("error, diagnostic", [
+    ("timeout", "timed out"), ("dns", "DNS lookup failed"),
+    ("tls", "certificate verification failed"),
+])
+def test_preflight_stops_on_network_errors(tmp_path, error, diagnostic):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYPI_ERROR": error, "PYPI_LOOKUP_STATUS": "1",
+    })
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+    _assert_release_stopped(repo)
+
+
+@pytest.mark.parametrize("status", [403, 429, 500, 503])
+def test_preflight_stops_on_http_errors(tmp_path, status):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYPI_STATUS": str(status), "PYPI_LOOKUP_STATUS": "1",
+    })
+    assert result.returncode != 0
+    assert str(status) in result.stderr
+    _assert_release_stopped(repo)
+
+
+@pytest.mark.parametrize("reported_version", ["5.52.5", "5.52.5.0", "v5.52.5"])
+def test_preflight_refuses_already_published_version(tmp_path, reported_version):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYPI_STATUS": "200",
+        "PYPI_BODY": json.dumps({"info": {"name": "topiary", "version": reported_version}}),
+        "PYPI_LISTING": "Available versions: 5.52.5",
+    })
+    assert result.returncode != 0
+    assert "topiary 5.52.5 already exists on PyPI" in result.stderr
+    _assert_release_stopped(repo)
+
+
+@pytest.mark.parametrize("nearby_version", ["5.52.50", "15.52.5", "5.52.5rc1", "5x52x5"])
+def test_preflight_does_not_confuse_similar_versions(tmp_path, nearby_version):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYPI_STATUS": "404", "PYPI_LISTING": f"Available versions: {nearby_version}",
+    })
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "tag", "--list").stdout.strip() == "v5.52.5"
+
+
+@pytest.mark.parametrize("body", [
+    "<html>upstream unavailable</html>", "null", "[]", "{}", '{"info": null}',
+    '{"info": {"version": "5.52.5"}}',
+    '{"info": {"name": "another-project", "version": "5.52.5"}}',
+    '{"info": {"name": "topiary", "version": "5.52.50"}}',
+    '{"info": {"name": "topiary", "version": "not-a-version"}}',
+])
+def test_preflight_stops_on_invalid_response(tmp_path, body):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYPI_STATUS": "200", "PYPI_BODY": body,
+    })
+    assert result.returncode != 0
+    assert "Could not verify" in result.stderr
+    _assert_release_stopped(repo)
+
+
+def test_preflight_does_not_filter_yanked_or_incompatible_prereleases(tmp_path):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "RELEASE_VERSION": "5.52.5rc1", "PYPI_STATUS": "200",
+        "PYPI_BODY": json.dumps({"info": {"name": "topiary", "version": "5.52.5rc1",
+                                           "yanked": True, "requires_python": ">=100"},
+                                 "urls": []}),
+    })
+    assert result.returncode != 0
+    assert "5.52.5rc1 already exists on PyPI" in result.stderr
+    _assert_release_stopped(repo)
+
+
+def test_preflight_rejects_invalid_local_version_before_network(tmp_path):
+    repo = _release_repo(tmp_path)
+    result = _deploy(repo, {
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "RELEASE_VERSION": "not-a-version",
+    })
+    assert result.returncode != 0
+    assert "Invalid version" in result.stderr
+    assert not (tmp_path / "pypi-requests.log").exists()
+    _assert_release_stopped(repo)
+
+
+@pytest.mark.parametrize("gate", ["branch", "worktree"])
+def test_deploy_checks_repository_before_network(tmp_path, gate):
+    repo = _release_repo(tmp_path)
+    if gate == "branch":
+        _git(repo, "checkout", "-b", "not-master")
+    else:
+        (repo / "uncommitted.txt").write_text("preserve me")
+    result = _deploy(repo, {"PYTHON": str(_fake_python(tmp_path / "selected python"))})
+    assert result.returncode != 0
+    assert not (tmp_path / "pypi-requests.log").exists()
+    _assert_release_stopped(repo)
 
 
 @pytest.mark.parametrize(
@@ -142,7 +308,10 @@ def test_deploy_uses_one_interpreter_for_every_release_step(tmp_path, selection)
     ]
     invocations = (tmp_path / "python-invocations.log").read_text().splitlines()
     assert any(command.startswith("-c import topiary") for command in invocations)
-    assert "-m pip index versions topiary" in invocations
+    assert "-m topiary.cli.release topiary 5.52.5" in invocations
+    assert (tmp_path / "pypi-requests.log").read_text().splitlines() == [
+        "https://pypi.org/pypi/topiary/5.52.5/json",
+    ]
     assert "-m build" in invocations
     assert "-m twine upload dist/topiary-5.52.5-py3-none-any.whl" in invocations
     assert "v5.52.5" in _git(repo, "tag", "--list").stdout
@@ -169,7 +338,7 @@ def test_deploy_script_uses_one_configured_python():
     script = Path("deploy.sh").read_text()
     assert "resolve_topiary_python" in script
     assert 'VERSION=$("${PYTHON}" -c' in script
-    assert '"${PYTHON}" -m pip index versions topiary' in script
+    assert '"${PYTHON}" -m topiary.cli.release topiary "${VERSION}"' in script
     assert '"${PYTHON}" -m build' in script
     assert '"${PYTHON}" -m twine upload dist/*' in script
     assert "rm -rf dist build" in script

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,92 @@
+"""The exact-release lookup must distinguish absence from uncertainty."""
+
+from http.client import IncompleteRead
+from io import BytesIO
+import json
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from topiary import pypi_release_exists
+from topiary import release
+
+
+def response(payload, status=200):
+    result = BytesIO(json.dumps(payload).encode())
+    result.status = status
+    return result
+
+
+@pytest.mark.parametrize("version, reported", [
+    ("5.53", "5.53.0"), ("5.53.0.0", "5.53.0"),
+    ("v5.53.0", "5.53.0"), ("5.53.0rc1", "5.53.0rc1"),
+    ("5.53.0.post1", "5.53.0.post1"), ("5.53.0.dev1", "5.53.0.dev1"),
+])
+def test_release_exists_uses_standard_versions_and_names(monkeypatch, version, reported):
+    requested = []
+
+    def get(request, timeout):
+        requested.append(request)
+        assert timeout == 3
+        return response({"info": {"name": "Example.Project", "version": reported,
+                                   "yanked": True, "requires_python": ">=100"}, "urls": []})
+
+    monkeypatch.setattr(release, "urlopen", get)
+    monkeypatch.setenv("PIP_INDEX_URL", "https://wrong-index.example/simple")
+    monkeypatch.setenv("PIP_EXTRA_INDEX_URL", "https://another-index.example/simple")
+    assert pypi_release_exists("Example_Project", version, timeout=3) is True
+    assert requested[0].full_url.startswith("https://pypi.org/pypi/example-project/")
+    assert requested[0].get_header("Accept") == "application/json"
+    assert requested[0].get_header("Cache-control") == "no-cache"
+
+
+@pytest.mark.parametrize("project, version", [
+    ("", "1.0"), ("../topiary", "1.0"), ("topiary@elsewhere", "1.0"),
+    ("topiary", ""), ("topiary", "not-a-version"),
+])
+def test_invalid_identifiers_fail_before_request(monkeypatch, project, version):
+    def unexpected_request(*args, **kwargs):
+        pytest.fail("Invalid input reached the network")
+
+    monkeypatch.setattr(release, "urlopen", unexpected_request)
+    with pytest.raises(ValueError):
+        pypi_release_exists(project, version)
+
+
+@pytest.mark.parametrize("error", [
+    URLError("DNS failure"), TimeoutError("timed out"),
+    ConnectionResetError("connection reset"), IncompleteRead(b"{", 20),
+    HTTPError("https://pypi.org", 503, "Service Unavailable", {}, None),
+])
+def test_lookup_failure_preserves_diagnostic_and_cause(monkeypatch, error):
+    def fail(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(release, "urlopen", fail)
+    with pytest.raises(RuntimeError, match="Could not verify topiary 5.53.0 on PyPI") as raised:
+        pypi_release_exists("topiary", "5.53.0")
+    assert raised.value.__cause__ is error
+    assert str(error) in str(raised.value)
+
+
+def test_only_404_means_absent(monkeypatch):
+    def absent(request, **kwargs):
+        raise HTTPError(request.full_url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(release, "urlopen", absent)
+    assert pypi_release_exists("topiary", "5.53.0") is False
+
+
+@pytest.mark.parametrize("status", [201, 202, 204, 206, 304])
+def test_nonstandard_success_status_is_not_release_evidence(monkeypatch, status):
+    monkeypatch.setattr(release, "urlopen", lambda *a, **kw: response({}, status=status))
+    with pytest.raises(RuntimeError, match=f"unexpected HTTP status {status}"):
+        pypi_release_exists("topiary", "5.53.0")
+
+
+def test_invalid_encoding_is_not_absence(monkeypatch):
+    result = BytesIO(b"\xff")
+    result.status = 200
+    monkeypatch.setattr(release, "urlopen", lambda *a, **kw: result)
+    with pytest.raises(RuntimeError, match="Could not verify"):
+        pypi_release_exists("topiary", "5.53.0")

--- a/tests/test_twin_conformance.py
+++ b/tests/test_twin_conformance.py
@@ -222,6 +222,24 @@ FRAGMENT_SERIALIZATION_DOORS = (
 )
 
 
+def release_allowed_through_api(project, version):
+    from topiary import pypi_release_exists
+
+    try:
+        return not pypi_release_exists(project, version)
+    except (ValueError, RuntimeError):
+        return False
+
+
+def release_allowed_through_cli(project, version):
+    from topiary.cli.release import main
+
+    return main([project, version]) == 0
+
+
+RELEASE_PREFLIGHT_DOORS = (release_allowed_through_api, release_allowed_through_cli)
+
+
 def whole_peptides_through_predictor(model, peptides):
     return TopiaryPredictor(models=model).predict_from_named_peptides(
         {str(i): peptide for i, peptide in enumerate(peptides)},

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -1,4 +1,5 @@
 from .serialization import normalize_python_types
+from .release import pypi_release_exists
 from .predictor import (
     TopiaryPredictor,
     fragment_from_effect,
@@ -169,10 +170,11 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.53.0"
+__version__ = "5.53.1"
 
 __all__ = [
     "normalize_python_types",
+    "pypi_release_exists",
     "TopiaryPredictor",
     "AMINO_ACIDS",
     "AMINO_ACID_INDEX",

--- a/topiary/cli/release.py
+++ b/topiary/cli/release.py
@@ -1,0 +1,28 @@
+"""Fail-closed release preflight: python -m topiary.cli.release PROJECT VERSION."""
+
+import argparse
+import sys
+
+from ..release import pypi_release_exists
+
+
+def main(argv=None):
+    """Return zero only when PyPI confirms that the release does not exist."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project")
+    parser.add_argument("version")
+    args = parser.parse_args(argv)
+    try:
+        exists = pypi_release_exists(args.project, args.version)
+    except (ValueError, RuntimeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if exists:
+        print(f"ERROR: {args.project} {args.version} already exists on PyPI", file=sys.stderr)
+        return 1
+    print(f"Confirmed {args.project} {args.version} is not published on PyPI")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/topiary/release.py
+++ b/topiary/release.py
@@ -1,0 +1,72 @@
+"""Read-only release checks against the PyPI upload destination."""
+
+import json
+from http.client import HTTPException
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+
+def pypi_release_exists(project, version, *, timeout=10):
+    """Check whether an exact package version already exists on PyPI.
+
+    Parameters
+    ----------
+    project : str
+        Valid distribution name. Case, hyphens, underscores and dots are
+        normalized using standard packaging rules.
+    version : str
+        PEP 440 version. Equivalent spellings, such as ``1.0`` and ``1.0.0``,
+        identify the same release; substrings and prereleases do not.
+    timeout : float, optional
+        Timeout in seconds for the HTTPS request; defaults to 10.
+
+    Returns
+    -------
+    bool
+        True for matching release metadata, including yanked releases or
+        releases with no remaining files. False only when PyPI returns HTTP
+        404 (the project or version does not exist).
+
+    Raises
+    ------
+    ValueError
+        The project name or version is invalid, including empty input.
+    RuntimeError
+        PyPI cannot be reached, returns another HTTP error, or returns
+        malformed/mismatched metadata. An unverifiable release is never
+        treated as an available version.
+
+    Notes
+    -----
+    Queries PyPI's release-specific JSON API, not pip's configured index or
+    interpreter-filtered list of installable releases. This is a read-only
+    preflight, not a reservation: the upload must still reject duplicates.
+    """
+    project = canonicalize_name(project, validate=True)
+    version = Version(version)
+    url = f"https://pypi.org/pypi/{quote(project, safe='')}/{quote(str(version), safe='')}/json"
+    request = Request(url, headers={"Accept": "application/json", "Cache-Control": "no-cache"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            if response.status != 200:
+                raise ValueError(f"unexpected HTTP status {response.status}")
+            payload = json.load(response)
+        if not isinstance(payload, dict) or not isinstance(payload.get("info"), dict):
+            raise ValueError("response has no release metadata")
+        info = payload["info"]
+        if not isinstance(info.get("name"), str) or canonicalize_name(info["name"]) != project:
+            raise ValueError("response names a different project")
+        if not isinstance(info.get("version"), str) or Version(info["version"]) != version:
+            raise ValueError("response names a different version")
+        return True
+    except HTTPError as error:
+        error.close()
+        if error.code == 404:
+            return False
+        raise RuntimeError(f"Could not verify {project} {version} on PyPI: {error}") from error
+    except (OSError, HTTPException, ValueError) as error:
+        raise RuntimeError(f"Could not verify {project} {version} on PyPI: {error}") from error


### PR DESCRIPTION
## Summary

Closes #286. Bumps Topiary to 5.53.1.

- Replace the `pip index | grep` deployment guard with one public `pypi_release_exists` implementation using PyPI's exact-release JSON endpoint and standard packaging name/version rules.
- Permit deployment only on a confirmed HTTP 404. Existing/equivalent releases, network/TLS/HTTP errors, and malformed/mismatched responses stop with a diagnostic before lint, tests, build, upload or tagging.
- Route the deployment CLI through that same function and selected Python interpreter. Preserve the existing branch, clean-tree, lint/test, build/upload and tagging gates.
- Export and document the read-only API; declare `packaging>=23.2` for validated package names. No custom version parser or mutable globals.

## Verification

- Reproduced seven failures with the old guard before replacing it: network errors permitted release and similarly named versions incorrectly blocked it.
- Focused workflow/interpreter/conformance suite: **202 passed**.
- Release/deploy tests against minimum `packaging==23.2`: **58 passed**.
- Lint, strict documentation build, isolated wheel/sdist build, distribution validation and strict Twine checks passed.
- Live read-only checks correctly recognize published `5.53.0` and equivalent `5.53`, and the currently absent `5.53.1`.
- Full `./test.sh` with both optional integrations required: **3,184 passed, zero failures/errors/skips**, 92% coverage, in a task-local virtualenv with editable local Topiary 5.53.1, mhctools 3.42.0, Isovar 1.8.3, PirlyGenes 6.0.4 and oncoref 1.8.194. `pip check` passed. Lint, strict docs, isolated distribution validation and strict Twine checks also passed with that same interpreter.

The executable deployment tests run the actual shell script and actual Python API/CLI in disposable Git repositories; only HTTP, lint/test gates, build and upload are simulated. Tests assert refusal produces no build, upload or local/remote release tag. The API/CLI pair is registered in the twin-conformance module and exercised together by a consumer workflow test.

## Separate follow-ups

- #295: pytest temporary-directory isolation. Validation uses a dedicated `PYTEST_DEBUG_TEMPROOT`; this PR does not change test-runner policy.
- #297: shared dependency-environment changes during validation. The initial shared-environment run had 3,183 passes and one missing-`platformdirs` subprocess failure while the mhctools editable install was replaced. The complete rerun uses a task-local virtualenv; this PR does not modify the shared environment.
