### PR TITLE
Rebind cached protein scans to the occurrence they were asked about (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 5.54.0
+
+**Cached protein scans describe the occurrence they were asked about (#296).**
+`CachedPredictor.predict_proteins_dataframe` rebinds every column that says
+*where* a peptide was found to the requested occurrence, instead of rewriting
+the source name while leaving the coordinate and flanking residues pointing at
+the protein the cache was built from. The scan emits a single coordinate,
+`offset`, in mhctools' vocabulary; it no longer also emits the cached
+`peptide_offset`, whose rename onto `offset` produced two columns of the same
+name and made `frame["peptide_offset"]` a DataFrame. Consumers saw that as
+`'DataFrame' object has no attribute 'dtype'` far from its cause. Repeated
+occurrences, nonzero offsets and distinct source names are preserved, and no
+duplicate column is dropped downstream to compensate.
+
+Flanking residues are a prediction input rather than provenance, so they select
+occurrences instead of being rewritten to fit one: a cached row predicted with
+flanks applies only where the scanned sequence really supplies them, matching a
+stored flank against the tail or head of the real context, and a row with no
+flank context still applies wherever the peptide occurs. An occurrence left
+uncovered by flank mismatch raises, naming the peptide, source, offset and
+stored context, rather than returning a score computed for different
+neighbours. `predict_from_named_peptides` resets the coordinate to zero for
+both spellings, so a cache row no longer reports a whole supplied peptide as
+sitting partway through itself. Normalizing a prediction frame that states the
+coordinate twice now reports the producer contract instead of building the
+broken frame. `PROTEIN_SCAN_COLUMNS` names the scan's output shape, and an
+empty scan result no longer carries a duplicate `source_sequence_name`.
+
 ## 5.53.1
 
 **Fail-closed release preflight (#286).** Releases now query PyPI's exact-release

--- a/tests/test_cached_protein_scan_context.py
+++ b/tests/test_cached_protein_scan_context.py
@@ -1,0 +1,335 @@
+"""A cached prediction rebound to a new occurrence must describe that
+occurrence — all of it, or none of it.
+
+:meth:`CachedPredictor.predict_proteins_dataframe` answers "where does
+this peptide sit in the sequence I just handed you".  The cache rows it
+answers from were built somewhere else, and every column saying *where a
+peptide was found* therefore describes the wrong place until it is
+rewritten.  Rewriting only some of them is the bug these tests pin: the
+row named the requested protein while the coordinate still pointed into
+the protein the cache came from, and the two coordinates then collided
+into two columns of the same name (issue #296).
+
+The flanking residues are the same mistake one column over, with the
+opposite fix: they are a prediction *input*, so they cannot be rewritten
+to match a new occurrence — the row simply does not apply there.
+"""
+
+import pandas as pd
+import pytest
+
+from topiary import (
+    PROTEIN_SCAN_COLUMNS,
+    Affinity,
+    CachedPredictor,
+    TopiaryPredictor,
+    apply_filter,
+    evaluate_scores,
+)
+
+ALLELE = "HLA-A*02:01"
+PEPTIDE = "SIINFEKLA"
+
+
+def _row(peptide, *, allele=ALLELE, score=0.5, affinity=150.0, **overrides):
+    row = {
+        "peptide": peptide,
+        "allele": allele,
+        "peptide_length": len(peptide),
+        "kind": "pMHC_affinity",
+        "score": score,
+        "affinity": affinity,
+        "percentile_rank": 2.0,
+        "value": affinity,
+        "prediction_method_name": "netmhcpan",
+        "predictor_version": "4.2",
+    }
+    row.update(overrides)
+    return row
+
+
+def _covering_cache(sequences, length=9, **row_overrides):
+    """A cache holding every ``length``-mer window of *sequences*.
+
+    A sliding-window scan misses on any window the cache lacks, so a test
+    about *which* row comes back has to cover them all or it ends up
+    testing the miss path instead.
+    """
+    rows = {}
+    for sequence in sequences:
+        for offset in range(len(sequence) - length + 1):
+            peptide = sequence[offset:offset + length]
+            rows[peptide] = _row(peptide, **row_overrides)
+    return CachedPredictor.from_dataframe(pd.DataFrame(list(rows.values())))
+
+
+# ---------------------------------------------------------------------------
+# The coordinate: exactly one, and it describes the requested occurrence
+# ---------------------------------------------------------------------------
+
+
+def test_protein_scan_emits_one_coordinate_not_two():
+    # The cache row remembers offset 77 in some other protein.  The scan
+    # is asked about 'x', where the peptide sits at 0.
+    cache = _covering_cache(
+        [PEPTIDE], source_sequence_name="original", peptide_offset=77,
+    )
+    out = cache.predict_proteins_dataframe({"x": PEPTIDE})
+
+    assert "peptide_offset" not in out.columns, (
+        "the producer must not emit topiary's spelling alongside "
+        "mhctools' 'offset' — the adapter renames one onto the other"
+    )
+    assert out["offset"].tolist() == [0]
+    assert out["source_sequence_name"].tolist() == ["x"]
+
+
+def test_predictor_result_has_unique_columns_and_the_new_coordinate():
+    cache = _covering_cache(
+        [PEPTIDE], source_sequence_name="original", peptide_offset=77,
+    )
+    df = TopiaryPredictor(models=[cache]).predict_from_named_sequences(
+        {"x": PEPTIDE}
+    )
+
+    assert df.columns.is_unique
+    assert df["peptide_offset"].tolist() == [0]
+    # A duplicate column made frame[key] a DataFrame, and every consumer
+    # reading a dtype off it failed far from the cause.
+    assert isinstance(df["peptide_offset"], pd.Series)
+
+
+def test_stale_cache_offset_does_not_survive_a_save_load_round_trip(tmp_path):
+    path = tmp_path / "netmhcpan42.tsv"
+    _covering_cache(
+        [PEPTIDE], source_sequence_name="original", peptide_offset=77,
+    ).save(path)
+
+    cache = CachedPredictor.from_topiary_output(path)
+    df = TopiaryPredictor(models=[cache]).predict_from_named_sequences(
+        {"x": PEPTIDE}
+    )
+
+    assert df.columns.is_unique
+    assert df["peptide_offset"].tolist() == [0]
+
+
+def test_repeated_occurrences_keep_their_own_nonzero_offsets():
+    # The peptide occurs twice, at 2 and at 13, and neither is 0.
+    protein = "GG" + PEPTIDE + "GG" + PEPTIDE + "GG"
+    assert protein.index(PEPTIDE) == 2
+    cache = _covering_cache([protein], source_sequence_name="original",
+                            peptide_offset=77)
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+    hits = out[out["peptide"] == PEPTIDE]
+
+    assert sorted(hits["offset"].tolist()) == [2, 13]
+    assert set(hits["source_sequence_name"]) == {"prot"}
+
+
+def test_distinct_source_names_are_preserved_across_proteins():
+    left = "GG" + PEPTIDE
+    right = "GGGG" + PEPTIDE
+    cache = _covering_cache([left, right], source_sequence_name="original",
+                            peptide_offset=77)
+
+    out = cache.predict_proteins_dataframe({"left": left, "right": right})
+    hits = out[out["peptide"] == PEPTIDE]
+
+    assert set(
+        zip(hits["source_sequence_name"], hits["offset"])
+    ) == {("left", 2), ("right", 4)}
+
+
+def test_named_peptides_reset_the_stale_offset_to_zero():
+    # The caller supplied the peptide whole under the name 'x', so it
+    # starts at 0 of 'x' — not partway through itself.
+    cache = _covering_cache(
+        [PEPTIDE], source_sequence_name="original", peptide_offset=77,
+    )
+    df = TopiaryPredictor(models=[cache]).predict_from_named_peptides(
+        {"x": PEPTIDE}
+    )
+
+    assert df.columns.is_unique
+    assert df["peptide_offset"].tolist() == [0]
+    assert df["source_sequence_name"].tolist() == ["x"]
+
+
+def test_declared_scan_columns_are_what_a_scan_actually_emits():
+    """The published shape and the emitted shape are one answer.
+
+    A constant naming the output is only useful if it is the output; a
+    test that reads either one alone cannot see them drift apart.
+    """
+    cache = _covering_cache([PEPTIDE])
+    out = cache.predict_proteins_dataframe({"x": PEPTIDE})
+    empty = cache.predict_proteins_dataframe({"tiny": "MA"})
+
+    assert list(out.columns) == list(PROTEIN_SCAN_COLUMNS)
+    assert list(empty.columns) == list(PROTEIN_SCAN_COLUMNS)
+    assert len(set(PROTEIN_SCAN_COLUMNS)) == len(PROTEIN_SCAN_COLUMNS)
+
+
+def test_empty_protein_scan_result_has_unique_columns():
+    cache = _covering_cache([PEPTIDE])
+    # Nothing to scan: every sequence is shorter than the window.
+    out = cache.predict_proteins_dataframe({"tiny": "MA"})
+
+    assert out.empty
+    assert out.columns.is_unique
+    assert "peptide_offset" not in out.columns
+
+
+# ---------------------------------------------------------------------------
+# Downstream: the frame reaches the DSL intact
+# ---------------------------------------------------------------------------
+
+
+def test_scan_result_survives_apply_filter_and_evaluate_scores():
+    protein = "GG" + PEPTIDE + "GG"
+    cache = _covering_cache([protein], source_sequence_name="original",
+                            peptide_offset=77, affinity=42.0)
+    df = TopiaryPredictor(models=[cache]).predict_from_named_sequences(
+        {"prot": protein}
+    )
+
+    kept = apply_filter(df, Affinity.value <= 500)
+    assert len(kept) == len(df)
+    assert kept["peptide_offset"].tolist() == df["peptide_offset"].tolist()
+
+    scores = evaluate_scores(df, Affinity.value)
+    assert isinstance(scores, pd.Series)
+    assert set(scores.dropna().tolist()) == {42.0}
+
+
+def test_predictor_filter_by_runs_on_a_cached_protein_scan():
+    protein = "GG" + PEPTIDE + "GG"
+    cache = _covering_cache([protein], source_sequence_name="original",
+                            peptide_offset=77, affinity=42.0)
+
+    df = TopiaryPredictor(
+        models=[cache], filter_by=Affinity.value <= 100,
+    ).predict_from_named_sequences({"prot": protein})
+
+    assert not df.empty
+    assert df.columns.is_unique
+    assert (df["peptide_offset"] >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Flanks: a prediction input, so it selects occurrences rather than
+# being rewritten to fit one
+# ---------------------------------------------------------------------------
+
+
+def test_flankless_cache_rows_apply_at_any_occurrence():
+    # A predictor that does not read flanks produces context-independent
+    # scores, so reusing them across proteins is exactly what the cache
+    # is for.
+    protein = "GG" + PEPTIDE + "GG"
+    cache = _covering_cache([protein])
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+
+    assert set(out["peptide"]) >= {PEPTIDE}
+    assert (out["source_sequence_name"] == "prot").all()
+
+
+def _flanked_cache(*proteins, n_flank, c_flank):
+    """Cache covering every window of *proteins*, PEPTIDE's row flanked.
+
+    Every protein a test scans has to be covered, or the scan misses on
+    some unrelated window and raises before flank matching is reached —
+    which would pass the test for the wrong reason.
+    """
+    rows = {}
+    for protein in proteins:
+        for offset in range(len(protein) - 9 + 1):
+            peptide = protein[offset:offset + 9]
+            rows[peptide] = _row(peptide)
+    rows[PEPTIDE] = _row(PEPTIDE, n_flank=n_flank, c_flank=c_flank)
+    return CachedPredictor.from_dataframe(pd.DataFrame(list(rows.values())))
+
+
+def test_flanked_row_applies_where_the_real_neighbours_match():
+    protein = "MA" + PEPTIDE + "GG"
+    cache = _flanked_cache(protein, n_flank="MA", c_flank="GG")
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+    hit = out[out["peptide"] == PEPTIDE]
+
+    assert hit["offset"].tolist() == [2]
+    assert hit["n_flank"].tolist() == ["MA"]
+    assert hit["c_flank"].tolist() == ["GG"]
+
+
+def test_flanked_row_is_not_reused_at_a_differently_flanked_occurrence():
+    # Cached in the context 'MA...GG'; asked about an occurrence whose
+    # real neighbours are 'WW...CC'.  The cached score is a prediction
+    # about a different protein context, so it must not come back
+    # wearing this occurrence's coordinates.
+    cached_protein = "MA" + PEPTIDE + "GG"
+    other = "WW" + PEPTIDE + "CC"
+    cache = _flanked_cache(
+        cached_protein, other, n_flank="MA", c_flank="GG",
+    )
+
+    with pytest.raises(KeyError, match="different flanking context"):
+        cache.predict_proteins_dataframe({"other": other})
+
+
+def test_flank_mismatch_error_names_the_occurrence_and_the_stored_context():
+    cached_protein = "MA" + PEPTIDE + "GG"
+    other = "WW" + PEPTIDE + "CC"
+    cache = _flanked_cache(
+        cached_protein, other, n_flank="MA", c_flank="GG",
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        cache.predict_proteins_dataframe({"other": other})
+
+    message = str(excinfo.value)
+    assert PEPTIDE in message
+    assert "'other'" in message
+    assert "offset 2" in message
+    assert "'MA'" in message and "'GG'" in message
+
+
+def test_a_shorter_stored_flank_matches_the_tail_of_the_real_context():
+    # Predictors store a bounded number of flanking residues, so a
+    # one-residue stored flank is the tail of what really precedes the
+    # peptide, not a claim that nothing else does.
+    protein = "WMA" + PEPTIDE + "GGT"
+    cache = _flanked_cache(protein, n_flank="A", c_flank="G")
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+
+    assert PEPTIDE in set(out["peptide"])
+
+
+def test_a_stored_flank_longer_than_the_sequence_provides_does_not_apply():
+    protein = "A" + PEPTIDE + "G"
+    cache = _flanked_cache(protein, n_flank="MMMA", c_flank="G")
+
+    with pytest.raises(KeyError, match="different flanking context"):
+        cache.predict_proteins_dataframe({"prot": protein})
+
+
+# ---------------------------------------------------------------------------
+# The adapter refuses a frame that states the coordinate twice
+# ---------------------------------------------------------------------------
+
+
+def test_normalizing_a_two_coordinate_frame_reports_the_contract():
+    from topiary.predictor import _normalize_prediction_frame
+
+    df = pd.DataFrame([{
+        "peptide": PEPTIDE, "allele": ALLELE, "kind": "pMHC_affinity",
+        "value": 50.0, "prediction_method_name": "netmhcpan",
+        "offset": 0, "peptide_offset": 77,
+    }])
+
+    with pytest.raises(ValueError, match="coordinate twice"):
+        _normalize_prediction_frame(df)

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -88,6 +88,7 @@ from .cached import (
     PREDICTION_CONTEXT_COLUMNS,
     PREDICTION_KEY_COLUMNS,
     PREDICTION_VALUE_COLUMNS,
+    PROTEIN_SCAN_COLUMNS,
     conflicting_predictions,
     mhcflurry_composite_version,
 )
@@ -170,7 +171,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.53.1"
+__version__ = "5.54.0"
 
 __all__ = [
     "normalize_python_types",
@@ -323,6 +324,7 @@ __all__ = [
     "PREDICTION_KEY_COLUMNS",
     "PREDICTION_VALUE_COLUMNS",
     "PREDICTION_CONTEXT_COLUMNS",
+    "PROTEIN_SCAN_COLUMNS",
     "conflicting_predictions",
     "RNA_EVIDENCE_COLUMNS",
     "DNA_EVIDENCE_COLUMNS",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -65,6 +65,21 @@ _CACHE_COLUMNS = (
     "allele_set",
 )
 
+#: Columns a sliding-window protein scan emits, in mhctools' vocabulary.
+#:
+#: A protein scan answers "where does this peptide sit in the sequence I
+#: just handed you", so the requested occurrence — not the occurrence the
+#: cache happened to be built from — owns the coordinate. It is spelled
+#: ``offset`` because that is what mhctools' protein-scan output calls it
+#: and what :func:`topiary.predictor._normalize_prediction_frame` renames
+#: to ``peptide_offset``; emitting the cached ``peptide_offset`` alongside
+#: it would rename onto an existing column and produce two columns of the
+#: same name, one of them describing a protein the caller never asked
+#: about.
+PROTEIN_SCAN_COLUMNS = tuple(
+    column for column in _CACHE_COLUMNS if column != "peptide_offset"
+) + ("offset",)
+
 # Composite key for the cache index.
 #
 # - (peptide, allele, peptide_length): basic identity.
@@ -662,32 +677,46 @@ class CachedPredictor:
                     )
 
         if not unique_peptides:
-            return pd.DataFrame(
-                columns=list(_CACHE_COLUMNS) + [
-                    "source_sequence_name", "offset",
-                ]
-            )
+            return pd.DataFrame(columns=list(PROTEIN_SCAN_COLUMNS))
         df = self.predict_peptides_dataframe(sorted(unique_peptides))
 
-        # Expand: one row per (peptide, allele) × (name, offset) matching length.
+        # Expand: one row per (peptide, allele) × (name, offset) matching
+        # length.  Each output row describes the *requested* occurrence,
+        # so every column saying where the peptide was found is rewritten
+        # to that occurrence — as a unit.  Rewriting only some of them is
+        # how this went wrong before: the row named the requested protein
+        # while the coordinate and flanks still described the protein the
+        # cache was built from.
         expanded = []
+        unmatched_context = {}
         for _, row in df.iterrows():
             positions = per_peptide_positions.get(row["peptide"], [])
             for (name, offset, length) in positions:
                 if int(row["peptide_length"]) != length:
                     continue
+                sequence = name_to_sequence[name]
+                if not _flanks_apply_at(row, sequence, offset, length):
+                    # The cached score was computed with flanking
+                    # residues this occurrence does not have, so it is a
+                    # prediction about a different context.  Record it in
+                    # case nothing else covers the occurrence.
+                    unmatched_context.setdefault(
+                        (row["peptide"], row["allele"], name, offset), []
+                    ).append(row)
+                    continue
                 r = row.to_dict()
+                r.pop("peptide_offset", None)
                 r["source_sequence_name"] = name
                 r["offset"] = offset
                 expanded.append(r)
 
+        _raise_on_uncovered_occurrences(expanded, unmatched_context)
+
         if not expanded:
-            return pd.DataFrame(
-                columns=list(_CACHE_COLUMNS) + [
-                    "source_sequence_name", "offset",
-                ]
-            )
-        return pd.DataFrame(expanded)
+            return pd.DataFrame(columns=list(PROTEIN_SCAN_COLUMNS))
+        return pd.DataFrame(expanded).reindex(
+            columns=list(PROTEIN_SCAN_COLUMNS)
+        )
 
     # --- fallback resolution ----------------------------------------
 
@@ -1338,6 +1367,78 @@ def _flank_key(value):
     if not s or s.lower() == "nan":
         return ""
     return s.upper()
+
+
+def _flanks_apply_at(row, sequence, offset, length) -> bool:
+    """Whether a cached row's prediction applies at one occurrence.
+
+    Flanking residues are a prediction *input*, not provenance: they sit
+    in :data:`PREDICTION_KEY_COLUMNS` precisely because mhcflurry's
+    processing and presentation predictors score the same peptide
+    differently in different flanking contexts.  So a cached row carrying
+    flanks answers a question about the context it was predicted in, and
+    reusing it at an occurrence with different neighbours reports a score
+    for a protein the caller never asked about.
+
+    A row with no flank context (the empty string :func:`_flank_key`
+    normalizes every missing spelling to) came from a predictor that does
+    not read flanks, so it applies wherever the peptide occurs.
+
+    A stored flank is compared against the occurrence's real neighbours
+    rather than required to equal them: predictors store a bounded number
+    of flanking residues, so the cached ``n_flank`` is the tail of what
+    actually precedes the peptide and ``c_flank`` the head of what
+    follows.  A stored flank longer than the sequence provides fails both
+    tests, which is the right answer — the occurrence cannot supply the
+    context the prediction was made in.
+    """
+    cached_n = _flank_key(row.get("n_flank"))
+    cached_c = _flank_key(row.get("c_flank"))
+    if not cached_n and not cached_c:
+        return True
+    upstream = str(sequence[:offset]).upper()
+    downstream = str(sequence[offset + length:]).upper()
+    if cached_n and not upstream.endswith(cached_n):
+        return False
+    if cached_c and not downstream.startswith(cached_c):
+        return False
+    return True
+
+
+def _raise_on_uncovered_occurrences(expanded, unmatched_context) -> None:
+    """Fail loudly when flank mismatch left an occurrence with no row.
+
+    A peptide whose only cached rows were predicted in a different
+    flanking context is not a cache hit for this occurrence, and it is
+    not something the fallback can repair either: the fallback API takes
+    peptides, so it cannot be asked for a specific protein context.  The
+    remaining honest options are to return a score computed for the wrong
+    neighbours or to say so, and returning it silently is what made this
+    a bug rather than a limitation.
+    """
+    if not unmatched_context:
+        return
+    covered = {
+        (r["peptide"], r["allele"], r["source_sequence_name"], r["offset"])
+        for r in expanded
+    }
+    uncovered = sorted(
+        occurrence for occurrence in unmatched_context if occurrence not in covered
+    )
+    if not uncovered:
+        return
+    peptide, allele, name, offset = uncovered[0]
+    stored = unmatched_context[(peptide, allele, name, offset)][0]
+    extra = "" if len(uncovered) == 1 else f" (and {len(uncovered) - 1} more)"
+    raise KeyError(
+        f"CachedPredictor: {peptide!r} occurs in {name!r} at offset "
+        f"{offset}, but the only cached prediction(s) for it and allele "
+        f"{allele!r} were made in a different flanking context "
+        f"(n_flank={_flank_key(stored.get('n_flank'))!r}, "
+        f"c_flank={_flank_key(stored.get('c_flank'))!r}), so their scores "
+        f"are not predictions about this occurrence{extra}.  Re-predict "
+        f"these sequences, or use a cache built without flank context."
+    )
 
 
 def _bindings_to_dataframe(preds, *, kind: str) -> pd.DataFrame:

--- a/topiary/predictor.py
+++ b/topiary/predictor.py
@@ -546,6 +546,35 @@ def _add_legacy_mutation_columns(df, fragments):
 _MHCTOOLS_COLUMNS = _PRED_COLUMNS
 
 
+def _reject_conflicting_offset_columns(df):
+    """Refuse a frame that states the peptide's coordinate twice.
+
+    ``offset`` is mhctools' name for it and ``peptide_offset`` topiary's,
+    so :func:`_normalize_prediction_frame` renames the first to the
+    second.  When a producer emits both, that rename lands on a column
+    that already exists and pandas keeps them both: the frame comes out
+    with two columns named ``peptide_offset``, and ``frame[key]`` returns
+    a DataFrame where every consumer expects a Series.  The failure then
+    surfaces far away as ``'DataFrame' object has no attribute 'dtype'``,
+    which says nothing about the producer that caused it.
+
+    Neither column can be preferred here.  They disagree exactly when a
+    cached prediction has been rebound to a new occurrence, and the frame
+    alone does not say which of the two coordinates describes the protein
+    the caller asked about — so this reports the contract violation
+    instead of guessing at one and silently mislabelling the rows.
+    """
+    if "offset" not in df.columns or "peptide_offset" not in df.columns:
+        return
+    raise ValueError(
+        "Prediction frame states the peptide coordinate twice: it has "
+        "both 'offset' (mhctools' name) and 'peptide_offset' (topiary's), "
+        "which would rename onto each other and leave two columns of the "
+        "same name.  A producer must emit exactly one coordinate, "
+        "describing the occurrence it was asked about."
+    )
+
+
 def _normalize_prediction_frame(df):
     """Put an mhctools prediction frame into topiary's long form.
 
@@ -554,6 +583,7 @@ def _normalize_prediction_frame(df):
     ``affinity`` for affinity rows.  The single definition of what the
     long form is, shared by the predictor and :func:`from_predictions`.
     """
+    _reject_conflicting_offset_columns(df)
     df = df.rename(columns={
         "offset": "peptide_offset",
         "predictor_name": "prediction_method_name",
@@ -1143,8 +1173,16 @@ class TopiaryPredictor(object):
             columns=["source_sequence_name"], errors="ignore"
         ).merge(peptide_names_df, on="peptide", how="inner")
 
-        if "offset" in expanded_df.columns:
-            expanded_df["offset"] = 0
+        # The caller supplied each peptide whole and named it, so the
+        # peptide starts at 0 of the sequence now named as its source.
+        # Both spellings are reset, not just mhctools': a producer that
+        # already speaks topiary's vocabulary (a cache loaded from a
+        # previous run) carries the offset the peptide had in whatever
+        # protein it was originally found in, and leaving that in place
+        # reports the peptide as sitting partway through itself.
+        for offset_column in ("offset", "peptide_offset"):
+            if offset_column in expanded_df.columns:
+                expanded_df[offset_column] = 0
         return expanded_df
 
     def _format_prediction_df(self, df):


### PR DESCRIPTION
Fixes #296. Version bumped to 5.54.0.

## The bug

`CachedPredictor.predict_proteins_dataframe` answers "where does this peptide sit in the sequence I just handed you", from cache rows that were built somewhere else. It rewrote `source_sequence_name` to the requested protein but left the coordinate and the flanking residues describing the protein the cache came from. Each row named one occurrence and located it in another.

The coordinate then collided. The scan emitted the cached `peptide_offset` alongside mhctools' `offset`, and `_normalize_prediction_frame` renames the second onto the first, so the result carried two columns named `peptide_offset`. `frame["peptide_offset"]` became a DataFrame and consumers failed with `'DataFrame' object has no attribute 'dtype'`, far from the cause.

Reproduced before the fix, with a cache row remembering offset 77 in another protein:

```
producer columns: [... 'source_sequence_name', 'peptide_offset', ... 'offset']
has both offset and peptide_offset: True
result columns unique: False
```

## The fix

Every column saying *where* a peptide was found is rebound to the requested occurrence as a unit. Rewriting only some of them is what made this a bug.

- **One coordinate.** The scan emits `offset` in mhctools' vocabulary and no longer also emits the cached `peptide_offset`. The new `PROTEIN_SCAN_COLUMNS` names that shape and is exported alongside its `PREDICTION_*_COLUMNS` siblings. The empty-result path used the same list and had been emitting a duplicate `source_sequence_name`; that is gone too.
- **Repeated occurrences, nonzero offsets and distinct source names are preserved.** No duplicate column is dropped downstream to compensate.
- **Flanks select occurrences instead of being rewritten to fit one.** They are a prediction input, in `PREDICTION_KEY_COLUMNS` because mhcflurry scores a peptide differently in different contexts, so they cannot be rebound. A flanked row now applies only where the scanned sequence really supplies that context, matching a stored flank against the tail or head of the real neighbours since predictors store a bounded number of residues. A row with no flank context is context-independent and still applies anywhere. An occurrence left uncovered raises, naming the peptide, source, offset and stored context, rather than returning a score computed for different neighbours. The fallback API takes peptides, so it cannot repair a context miss.
- **`predict_from_named_peptides` reset only mhctools' spelling,** so a cache row reported a whole supplied peptide as sitting partway through itself. Both spellings now reset to zero.
- **Normalizing a frame that states the coordinate twice reports the producer contract** instead of building the broken frame. The two columns disagree exactly when the frame no longer says which protein the caller asked about, so neither can be preferred.

## Tests

`tests/test_cached_protein_scan_context.py`, 17 synthetic regressions that build the trigger rather than assert on unchanged fixtures: save/load through `TopiaryPredictor` into `apply_filter` and `evaluate_scores`, multiple occurrences at nonzero offsets, distinct source names across proteins, stale original cache offsets, flank match and mismatch including a short stored flank and one longer than the sequence supplies, the empty-scan shape, and agreement between `PROTEIN_SCAN_COLUMNS` and what a scan actually emits.

The issue also asked for a `score_predictions` integration test. No such callable exists in topiary, so the coverage goes through the public `apply_filter` and `evaluate_scores` plus a predictor-level `filter_by` run.

## Verification

`./lint.sh` passes. `./test.sh` reports 3,187 passed. The 4 failures and 10 errors that remain are pre-existing on clean master, confirmed by stashing this change: they come from the shared virtualenv's mhctools lacking `PeptiVerse`/`PlifePred2` and the unclassified half-life kinds, which is the ground covered by #288 and #297.

https://claude.ai/code/session_015pMD1uiTztbB2bTQ1FkY8m