### PR TITLE
Group wide conversion by content, not by hashable cells (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.54.1
+
+**Wide conversion accepts the structured annotations topiary produces (#287).**
+`to_wide` grouped rows by merging the melted frame back on every
+non-prediction column, which required each of those columns to be hashable. An
+RNA-derived `ProteinFragment` carries `supporting_reference_transcripts` as a
+list of every transcript consistent with the assembled sequence, and prediction
+preserves it, so ordinary RNA results reached `TypeError: unhashable type:
+'list'`. Rows are now grouped before the melt and the group id carried through
+it, so the annotation values only have to survive the trip rather than be
+compared.
+
+Grouping is by content: two rows agree when their annotations are equal, not
+when they are the same object, and rows missing the same annotation group
+together instead of splitting on `nan != nan`. Sequence order is part of a
+list's value and distinguishes groups; key and element order in mappings and
+sets is not. Lists, tuples, sets, dicts, nested combinations and NumPy arrays
+all reach the output as themselves, so transcript identities and annotation
+types survive `to_wide` and the round trip back through `from_wide`.
+
 ## 5.54.0
 
 **Cached protein scans describe the occurrence they were asked about (#296).**

--- a/tests/test_wide_structured_annotations.py
+++ b/tests/test_wide_structured_annotations.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 
 from topiary import (
+    CachedPredictor,
     ProteinFragment,
     TopiaryPredictor,
     detect_form,
@@ -289,3 +290,50 @@ def test_two_rna_fragments_keep_their_own_transcript_lists():
     }
     assert by_fragment["rna__abc123"] == {tuple(TRANSCRIPTS)}
     assert by_fragment["rna__def456"] == {("ENST00000999999",)}
+
+
+def test_cached_scan_of_an_rna_fragment_reaches_wide_form():
+    """The two halves of a real run, composed.
+
+    A cached predictor rebinds each peptide to the occurrence it was
+    asked about (#296) and the fragment carries a list of supporting
+    transcripts (#287). Each half was fixed against its own frame; only
+    running them together shows that the frame one produces is a frame
+    the other accepts.
+    """
+    peptide = "SIINFEKLA"
+    # The peptide occurs twice, at 2 and 13, and the cache remembers a
+    # position in a different protein entirely.
+    protein = "GG" + peptide + "GG" + peptide + "GG"
+    rows = {
+        protein[offset:offset + 9]: {
+            "peptide": protein[offset:offset + 9], "allele": ALLELE,
+            "peptide_length": 9, "kind": "pMHC_affinity", "score": 0.5,
+            "affinity": 42.0, "percentile_rank": 2.0, "value": 42.0,
+            "prediction_method_name": "netmhcpan", "predictor_version": "4.2",
+            "source_sequence_name": "ORIGINAL", "peptide_offset": 77,
+        }
+        for offset in range(len(protein) - 9 + 1)
+    }
+    cache = CachedPredictor.from_dataframe(pd.DataFrame(list(rows.values())))
+    fragment = ProteinFragment(
+        fragment_id="rna__x", source_type="variant:snv", sequence=protein,
+        gene="OVA",
+        annotations={"supporting_reference_transcripts": TRANSCRIPTS},
+    )
+
+    long_df = TopiaryPredictor(models=[cache]).predict_from_fragments(
+        [fragment]
+    )
+
+    assert long_df.columns.is_unique
+    repeated = long_df[long_df["peptide"] == peptide]
+    assert sorted(repeated["peptide_offset"]) == [2, 13]
+
+    wide = to_wide(long_df)
+
+    assert len(wide) == len(long_df)
+    assert isinstance(wide["supporting_reference_transcripts"].iloc[0], list)
+    assert from_wide(wide)[
+        "supporting_reference_transcripts"
+    ].iloc[0] == TRANSCRIPTS

--- a/tests/test_wide_structured_annotations.py
+++ b/tests/test_wide_structured_annotations.py
@@ -1,0 +1,291 @@
+"""Wide conversion has to survive the annotations topiary itself produces.
+
+An RNA-derived :class:`ProteinFragment` carries
+``supporting_reference_transcripts`` — every transcript consistent with
+the assembled sequence, as a list — and prediction preserves it.  The
+wide conversion grouped rows by merging on every non-prediction column,
+which required each of them to be hashable, so ordinary RNA results
+reached ``TypeError: unhashable type: 'list'`` (issue #287).
+
+Grouping is a question about which rows belong together, not about what
+the cells contain, so these tests pin both halves: rows group by the
+*value* of a structured annotation, and the annotation that comes out is
+the object that went in.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from topiary import (
+    ProteinFragment,
+    TopiaryPredictor,
+    detect_form,
+    from_wide,
+    to_wide,
+)
+
+ALLELE = "HLA-A*02:01"
+TRANSCRIPTS = ["ENST00000288602", "ENST00000496384"]
+
+
+class TwoKindPredictor:
+    """Two kinds per peptide, so siblings must share one wide row."""
+
+    default_peptide_lengths = [8]
+
+    def _rows(self, peptide):
+        return [
+            {
+                "peptide": peptide, "allele": ALLELE, "kind": kind,
+                "value": value, "score": value / 100.0,
+                "affinity": value if kind == "pMHC_affinity" else math.nan,
+                "percentile_rank": value,
+                "predictor_name": "two-kind", "predictor_version": "1.0",
+            }
+            for kind, value in (("pMHC_affinity", 40.0),
+                                ("pMHC_presentation", 0.8))
+        ]
+
+    def predict_peptides_dataframe(self, peptides):
+        return pd.DataFrame([r for p in peptides for r in self._rows(p)])
+
+    def predict_proteins_dataframe(self, name_to_sequence):
+        rows = []
+        for name, sequence in name_to_sequence.items():
+            for offset in range(len(sequence) - 7):
+                for row in self._rows(sequence[offset:offset + 8]):
+                    rows.append({**row, "source_sequence_name": name,
+                                 "offset": offset})
+        return pd.DataFrame(rows)
+
+
+def _long_row(**extra):
+    row = {
+        "fragment_id": "f", "peptide": "SIINFEKL", "allele": ALLELE,
+        "kind": "pMHC_affinity", "prediction_method_name": "test",
+        "value": 50.0,
+    }
+    row.update(extra)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# The reported failure
+# ---------------------------------------------------------------------------
+
+
+def test_list_valued_annotation_converts_to_wide():
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=["ENST1"]),
+    ])
+
+    wide = to_wide(frame)
+
+    assert len(wide) == 1
+    assert wide["supporting_reference_transcripts"].iloc[0] == ["ENST1"]
+
+
+def test_the_annotation_comes_back_as_a_list_not_a_stand_in():
+    # Deduplicating through a hashable surrogate would hand the caller
+    # the surrogate; the value has to be the object that went in.
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=TRANSCRIPTS),
+    ])
+
+    wide = to_wide(frame)
+    cell = wide["supporting_reference_transcripts"].iloc[0]
+
+    assert isinstance(cell, list)
+    assert cell == TRANSCRIPTS
+
+
+# ---------------------------------------------------------------------------
+# Grouping is by value, and siblings stay together
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_siblings_are_not_split_by_a_list_annotation():
+    # Two kinds for one peptide are two long rows and one wide row.  The
+    # lists are equal but distinct objects, so grouping cannot lean on
+    # identity.
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=list(TRANSCRIPTS)),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  supporting_reference_transcripts=list(TRANSCRIPTS)),
+    ])
+
+    wide = to_wide(frame)
+
+    assert len(wide) == 1
+    assert wide["supporting_reference_transcripts"].iloc[0] == TRANSCRIPTS
+    assert "test_affinity_value" in wide.columns
+    assert "test_presentation_value" in wide.columns
+
+
+def test_different_transcript_lists_stay_different_groups():
+    frame = pd.DataFrame([
+        _long_row(fragment_id="f", supporting_reference_transcripts=["E1"]),
+        _long_row(fragment_id="g", supporting_reference_transcripts=["E2"]),
+    ])
+
+    wide = to_wide(frame)
+
+    assert len(wide) == 2
+    assert sorted(
+        tuple(v) for v in wide["supporting_reference_transcripts"]
+    ) == [("E1",), ("E2",)]
+
+
+def test_transcript_order_is_part_of_the_annotation():
+    # Two orders of the same transcripts are two different annotations,
+    # so they are not silently merged into one row.
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=["E1", "E2"]),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  supporting_reference_transcripts=["E2", "E1"]),
+    ])
+
+    assert len(to_wide(frame)) == 2
+
+
+def test_rows_missing_the_same_annotation_group_together():
+    # Comparing the raw cells would split these, because nan != nan.
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=None),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  supporting_reference_transcripts=None),
+    ])
+
+    assert len(to_wide(frame)) == 1
+
+
+def test_a_list_and_a_missing_value_are_different_groups():
+    frame = pd.DataFrame([
+        _long_row(supporting_reference_transcripts=["E1"]),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  supporting_reference_transcripts=None),
+    ])
+
+    assert len(to_wide(frame)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Other structured annotation values topiary can carry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value, expected_type", [
+    (["E1", "E2"], list),
+    (("E1", "E2"), tuple),
+    ({"assembly": "GRCh38", "caller": "isovar"}, dict),
+    (np.array([1, 2, 3]), np.ndarray),
+    ({"E1", "E2"}, set),
+])
+def test_structured_annotations_survive_with_their_type(value, expected_type):
+    frame = pd.DataFrame([_long_row(structured=value)])
+
+    wide = to_wide(frame)
+
+    assert len(wide) == 1
+    assert isinstance(wide["structured"].iloc[0], expected_type)
+
+
+def test_a_mapping_groups_by_content_not_key_order():
+    frame = pd.DataFrame([
+        _long_row(structured={"a": 1, "b": 2}),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  structured={"b": 2, "a": 1}),
+    ])
+
+    assert len(to_wide(frame)) == 1
+
+
+def test_nested_containers_group_by_content():
+    frame = pd.DataFrame([
+        _long_row(structured={"ids": ["E1", "E2"]}),
+        _long_row(kind="pMHC_presentation", value=0.8,
+                  structured={"ids": ["E1", "E2"]}),
+    ])
+
+    assert len(to_wide(frame)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Composed: fragment -> prediction -> long/wide -> long
+# ---------------------------------------------------------------------------
+
+
+def _rna_fragment():
+    return ProteinFragment(
+        fragment_id="rna__abc123",
+        source_type="variant:snv",
+        sequence="MASIINFEKLGG",
+        gene="OVA",
+        transcript_id=TRANSCRIPTS[0],
+        annotations={
+            "sequence_source": "isovar",
+            "supporting_reference_transcripts": TRANSCRIPTS,
+        },
+    )
+
+
+def test_rna_fragment_predictions_reach_wide_form():
+    df = TopiaryPredictor(models=[TwoKindPredictor()]).predict_from_fragments(
+        [_rna_fragment()]
+    )
+
+    assert "supporting_reference_transcripts" in df.columns
+    assert detect_form(df) == "long"
+
+    wide = to_wide(df)
+
+    assert detect_form(wide) == "wide"
+    assert not wide.empty
+    # Every peptide of one fragment carries the same transcript list, and
+    # the two kinds per peptide share a row rather than splitting.
+    assert len(wide) == len(df) // 2
+    for cell in wide["supporting_reference_transcripts"]:
+        assert cell == TRANSCRIPTS
+
+
+def test_rna_fragment_predictions_round_trip_through_wide():
+    predicted = TopiaryPredictor(
+        models=[TwoKindPredictor()]
+    ).predict_from_fragments([_rna_fragment()])
+
+    restored = from_wide(to_wide(predicted))
+
+    assert len(restored) == len(predicted)
+    for cell in restored["supporting_reference_transcripts"]:
+        assert cell == TRANSCRIPTS
+    assert set(restored["kind"]) == set(predicted["kind"])
+    assert sorted(restored["peptide"]) == sorted(predicted["peptide"])
+
+
+def test_two_rna_fragments_keep_their_own_transcript_lists():
+    other = ProteinFragment(
+        fragment_id="rna__def456",
+        source_type="variant:snv",
+        sequence="MAGILGFVFTL",
+        gene="FLU",
+        transcript_id="ENST00000999999",
+        annotations={
+            "sequence_source": "isovar",
+            "supporting_reference_transcripts": ["ENST00000999999"],
+        },
+    )
+    df = TopiaryPredictor(models=[TwoKindPredictor()]).predict_from_fragments(
+        [_rna_fragment(), other]
+    )
+
+    wide = to_wide(df)
+
+    by_fragment = {
+        fragment_id: {tuple(v) for v in rows["supporting_reference_transcripts"]}
+        for fragment_id, rows in wide.groupby("fragment_id")
+    }
+    assert by_fragment["rna__abc123"] == {tuple(TRANSCRIPTS)}
+    assert by_fragment["rna__def456"] == {("ENST00000999999",)}

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -171,7 +171,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.54.0"
+__version__ = "5.54.1"
 
 __all__ = [
     "normalize_python_types",

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -204,18 +204,24 @@ def _group_ids(df, group_cols):
     return ids
 
 
-def _distinct_group_rows(df, group_cols):
+def _distinct_group_rows(df, group_cols, ids=None):
     """One row per distinct group, first-appearance order, values intact.
 
     The rows come back by position rather than being rebuilt, so a
     container-valued annotation is the same object it was on the way in
     — deduplicating through a hashable stand-in would otherwise hand the
     caller the stand-in.
+
+    Pass *ids* when the caller has already grouped the same rows, so the
+    id attached to a melted row and the row written to the output are
+    the same answer rather than two computations of it.
     """
     columns = list(group_cols)
     if len(df) == 0 or not columns:
         return df[columns].drop_duplicates().reset_index(drop=True)
-    _, first_positions = np.unique(_group_ids(df, columns), return_index=True)
+    if ids is None:
+        ids = _group_ids(df, columns)
+    _, first_positions = np.unique(ids, return_index=True)
     return df.iloc[first_positions][columns].reset_index(drop=True)
 
 
@@ -341,9 +347,10 @@ def to_wide(df):
     # an RNA-derived fragment carries a list of supporting transcripts
     # (#287). The id says which rows belong together; the values only
     # have to survive the trip.
-    work["_topiary_group_id"] = _group_ids(work, group_cols)
+    group_ids = _group_ids(work, group_cols)
+    work["_topiary_group_id"] = group_ids
     if group_cols:
-        group_index = _distinct_group_rows(work, group_cols)
+        group_index = _distinct_group_rows(work, group_cols, ids=group_ids)
         group_index["_topiary_group_id"] = range(len(group_index))
     else:
         group_index = pd.DataFrame({"_topiary_group_id": [0]})

--- a/topiary/wide.py
+++ b/topiary/wide.py
@@ -116,6 +116,109 @@ def _parse_wide_column(col_name):
     return None
 
 
+#: Marks a stand-in built for a container cell, so it cannot collide
+#: with a string cell that happens to look like one.
+_GROUP_TOKEN_TAG = "__topiary_group_token__"
+
+#: One stand-in for every spelling of a missing value, so two rows that
+#: are both missing an annotation land in the same group. Comparing the
+#: raw values would not: ``nan != nan``.
+_GROUP_MISSING = ("__topiary_group_missing__",)
+
+
+def _normalized_container(value):
+    """A hashable, order-canonical copy of one container cell.
+
+    Sequences keep their order — two orders of the same transcripts are
+    two different annotations — while sets and mappings do not, because
+    iteration order is not part of their value.
+    """
+    if isinstance(value, dict):
+        return tuple(sorted(
+            (str(key), _normalized_container(item))
+            for key, item in value.items()
+        ))
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted(
+            (_normalized_container(item) for item in value), key=repr
+        ))
+    if isinstance(value, np.ndarray):
+        return tuple(_normalized_container(item) for item in value.tolist())
+    if isinstance(value, (list, tuple)):
+        return tuple(_normalized_container(item) for item in value)
+    return value
+
+
+def _group_token(value):
+    """A hashable stand-in for one annotation cell.
+
+    Topiary's own fragments carry list-valued annotations —
+    ``supporting_reference_transcripts`` is a list of transcript ids, and
+    prediction preserves it — so grouping the frame by its annotation
+    columns raised ``TypeError: unhashable type: 'list'`` on ordinary RNA
+    results (#287).
+
+    The token stands in only while rows are being grouped. The original
+    object is what reaches the output, so transcript identities survive
+    and a list is still a list on the far side.
+    """
+    if value is None:
+        return _GROUP_MISSING
+    try:
+        if pd.isna(value):
+            return _GROUP_MISSING
+    except (TypeError, ValueError):
+        # pd.isna on a container answers elementwise; a container is
+        # present by definition, so fall through to tokenizing it.
+        pass
+    try:
+        hash(value)
+    except TypeError:
+        return (_GROUP_TOKEN_TAG, _normalized_container(value))
+    return value
+
+
+def _group_ids(df, group_cols):
+    """A group id per row, in first-appearance order.
+
+    **The one place that decides which rows are the same group**, so the
+    id attached to a melted row and the row written to the output cannot
+    disagree about it. Columns are coded independently and the codes
+    combined, which keeps pandas' own null handling: two rows missing the
+    same annotation group together, where comparing ``nan`` to ``nan``
+    would have split them.
+    """
+    if not group_cols:
+        return np.zeros(len(df), dtype=int)
+    codes = []
+    for column in group_cols:
+        series = df[column]
+        try:
+            column_codes, _ = pd.factorize(series, use_na_sentinel=True)
+        except TypeError:
+            column_codes, _ = pd.factorize(
+                series.map(_group_token), use_na_sentinel=True
+            )
+        codes.append(column_codes)
+    ids, _ = pd.factorize(pd.Series(list(zip(*codes))))
+    return ids
+
+
+def _distinct_group_rows(df, group_cols):
+    """One row per distinct group, first-appearance order, values intact.
+
+    The rows come back by position rather than being rebuilt, so a
+    container-valued annotation is the same object it was on the way in
+    — deduplicating through a hashable stand-in would otherwise hand the
+    caller the stand-in.
+    """
+    columns = list(group_cols)
+    if len(df) == 0 or not columns:
+        return df[columns].drop_duplicates().reset_index(drop=True)
+    _, first_positions = np.unique(_group_ids(df, columns), return_index=True)
+    return df.iloc[first_positions][columns].reset_index(drop=True)
+
+
 def detect_form(df):
     """Detect whether a DataFrame is in long or wide form.
 
@@ -156,7 +259,7 @@ def to_wide(df):
     group_cols = [c for c in df.columns if c not in PREDICTION_COLUMNS]
 
     if df.empty:
-        return df[group_cols].drop_duplicates().reset_index(drop=True)
+        return _distinct_group_rows(df, group_cols)
 
     # Determine model keys.  Include version only on collision.
     version_collision = False
@@ -231,29 +334,37 @@ def to_wide(df):
             if version_str and not model_versions.get(method_str):
                 model_versions[method_str] = version_str
 
+    # Group each row before melting, and carry the id through the melt.
+    # Recovering the grouping afterwards by merging the melted frame back
+    # on every group column required each of those columns to be
+    # hashable, which an annotation topiary itself produces need not be:
+    # an RNA-derived fragment carries a list of supporting transcripts
+    # (#287). The id says which rows belong together; the values only
+    # have to survive the trip.
+    work["_topiary_group_id"] = _group_ids(work, group_cols)
+    if group_cols:
+        group_index = _distinct_group_rows(work, group_cols)
+        group_index["_topiary_group_id"] = range(len(group_index))
+    else:
+        group_index = pd.DataFrame({"_topiary_group_id": [0]})
+
     # Melt each long field into wide column entries.
+    carried = ["_topiary_group_id", "_model_key", "_kind_short"]
     records = []
     for long_field, wide_field in LONG_TO_WIDE_FIELD.items():
         if long_field not in work.columns:
             continue
-        temp = work[group_cols + ["_model_key", "_kind_short", long_field]].copy()
+        temp = work[carried + [long_field]].copy()
         temp["_wide_col"] = (
             temp["_model_key"] + "_" + temp["_kind_short"] + "_" + wide_field
         )
         temp = temp.rename(columns={long_field: "_wide_val"})
-        records.append(temp[group_cols + ["_wide_col", "_wide_val"]])
+        records.append(temp[["_topiary_group_id", "_wide_col", "_wide_val"]])
 
     if not records:
-        return work[group_cols].drop_duplicates().reset_index(drop=True)
+        return _distinct_group_rows(work, group_cols)
 
     melted = pd.concat(records, ignore_index=True)
-    if group_cols:
-        group_index = melted[group_cols].drop_duplicates().reset_index(drop=True)
-        group_index["_topiary_group_id"] = range(len(group_index))
-        melted = melted.merge(group_index, on=group_cols, how="left")
-    else:
-        group_index = pd.DataFrame({"_topiary_group_id": [0]})
-        melted["_topiary_group_id"] = 0
 
     # Check for duplicates that would silently collapse in the pivot.
     dup_cols = ["_topiary_group_id", "_wide_col"]


### PR DESCRIPTION
Fixes #287. Version bumped to 5.54.1.

## The bug

`to_wide` recovered its grouping *after* melting, by merging the melted frame back on every non-prediction column. That required each of those columns to be hashable. An RNA-derived `ProteinFragment` carries `supporting_reference_transcripts` — every transcript consistent with the assembled sequence, as a list — and prediction preserves it, so ordinary RNA results reached `TypeError: unhashable type: 'list'` in unchanged code. The reproduction in the issue fails on `a5e4e7f` and on current master.

## The fix

Rows are grouped **before** the melt and the group id carried through it. The id says which rows belong together; the annotation values only have to survive the trip. A list reaches the output as the list it was, and the merge on every group column goes away.

Grouping stays a question about content:

- **Equality, not identity.** Two rows whose transcript lists are equal but distinct objects are one group, so prediction siblings are not split.
- **Nulls group together.** Columns are coded independently and the codes combined, which keeps pandas' own null handling. Comparing raw cells would have split two rows that are both missing an annotation, because `nan != nan`.
- **Order means what it means.** Sequences keep their order, because two orders of the same transcripts are two different annotations. Sets and mappings do not, because iteration order is not part of their value.
- **Types survive.** A container cell is replaced by a hashable stand-in for the duration of the grouping only. Rows come back by position rather than being rebuilt, so the caller never receives the stand-in.

Lists, tuples, sets, dicts, nested combinations and NumPy arrays all convert and round-trip with their identities and their types intact.

## Behavior on frames that already worked

Unchanged. Group order still follows first appearance in the input, since the first melt block already covers every row in order. Null matching is the same as the old `drop_duplicates` and merge, which both treated nulls as equal.

## Tests

`tests/test_wide_structured_annotations.py`, 17 tests. 15 of them fail on this branch with `wide.py` reverted, confirmed by stashing, so they are triggers rather than assertions over unchanged behavior:

- The reported failure, and the annotation coming back as a `list` rather than a stand-in.
- Grouping: siblings not split by equal-but-distinct lists, different lists staying distinct, transcript order distinguishing groups, both-null grouping together, a list and a null staying apart.
- Other structured values, parametrized over list, tuple, dict, set and `np.ndarray`, plus mapping key order and nested containers.
- Composed `ProteinFragment` → `predict_from_fragments` → long → `to_wide` → `from_wide`, including two fragments keeping their own transcript lists.

## Verification

`./lint.sh` passes. `./test.sh` reports 3,204 passed. The 4 failures and 10 errors that remain are pre-existing on master, from the shared virtualenv's mhctools lacking `PeptiVerse`/`PlifePred2` and the unclassified half-life kinds — the ground covered by #288 and #297.

https://claude.ai/code/session_015pMD1uiTztbB2bTQ1FkY8m