### PR TITLE
Decide flank coverage per kind, not per occurrence (#302)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 coverage.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 5.54.2
+
+**A prediction kind no longer disappears behind one that applies (#302).**
+Follow-up to #296. `CachedPredictor.predict_proteins_dataframe` declines to
+attach a flanked cache row to an occurrence whose real neighbours differ, and
+raises when flank mismatch leaves an occurrence uncovered. Coverage was decided
+per `(peptide, allele, source, offset)`, so an occurrence counted as covered as
+soon as any kind applied. A cache holding a flanked row for one kind and a
+flankless row for another therefore lost the flanked kind without a word. One
+cache holds exactly one `(method, version)` pair, so that mix is not two
+different predictors merged; it is one model whose rows arrived by two routes
+and were joined by `concat`, which the version invariant permits. A protein
+scan records the flanking context it scored in; a peptide-level run has none to
+record.
+
+The failure was absence-shaped: a caller filtering on presentation saw no rows
+for the peptide and read it as a weak presenter, when the cache in fact held no
+presentation prediction applicable to that context. Coverage is now decided per
+`(peptide, allele, kind, source, offset)`, and the error names the kind that
+did not apply alongside the peptide, source, offset and stored flank context. A
+kind the cache simply does not hold for a peptide stays quiet, since only rows
+that were found and then excluded are recorded.
+
 ## 5.54.1
 
 **Wide conversion accepts the structured annotations topiary produces (#287).**

--- a/tests/test_cached_protein_scan_context.py
+++ b/tests/test_cached_protein_scan_context.py
@@ -333,3 +333,133 @@ def test_normalizing_a_two_coordinate_frame_reports_the_contract():
 
     with pytest.raises(ValueError, match="coordinate twice"):
         _normalize_prediction_frame(df)
+
+
+# ---------------------------------------------------------------------------
+# Coverage is per kind: one kind cannot vouch for another (#302)
+# ---------------------------------------------------------------------------
+
+
+def _mixed_flank_cache(protein, *, flanked_kind, n_flank, c_flank):
+    """Cache where one kind reads flanks and the rest do not.
+
+    One cache holds exactly one ``(method, version)`` pair, so this is
+    not two different predictors' caches merged — that is refused at
+    construction. It is one model whose rows reached the cache by two
+    routes, which :meth:`CachedPredictor.concat` joins without complaint
+    because the version invariant holds: a protein scan records the
+    flanking context it scored in, and a peptide-level run has none to
+    record.
+    """
+    rows = [
+        _row(protein[offset:offset + 9])
+        for offset in range(len(protein) - 9 + 1)
+    ]
+    rows.append(_row(
+        PEPTIDE, kind=flanked_kind, score=0.9, affinity=None,
+        n_flank=n_flank, c_flank=c_flank,
+    ))
+    return CachedPredictor.from_dataframe(pd.DataFrame(rows))
+
+
+def test_a_kind_that_applies_does_not_vouch_for_one_that_does_not():
+    # The affinity row has no flank context and applies here; the
+    # presentation row was predicted somewhere else.  Reporting only the
+    # affinity would read as "no presentation prediction", which is not
+    # what the cache says.
+    protein = "MA" + PEPTIDE + "GG"
+    cache = _mixed_flank_cache(
+        protein, flanked_kind="pMHC_presentation",
+        n_flank="WW", c_flank="CC",
+    )
+
+    with pytest.raises(KeyError, match="different flanking context"):
+        cache.predict_proteins_dataframe({"prot": protein})
+
+
+def test_the_uncovered_kind_is_named_in_the_error():
+    protein = "MA" + PEPTIDE + "GG"
+    cache = _mixed_flank_cache(
+        protein, flanked_kind="pMHC_presentation",
+        n_flank="WW", c_flank="CC",
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        cache.predict_proteins_dataframe({"prot": protein})
+
+    message = str(excinfo.value)
+    assert "pMHC_presentation" in message
+    assert PEPTIDE in message
+    assert "'WW'" in message and "'CC'" in message
+
+
+def test_a_kind_the_cache_never_held_stays_quiet():
+    # A cache that simply has no presentation row for a peptide is not
+    # the same as one whose only presentation row does not apply here.
+    # Only the second is worth an error.
+    protein = "MASIINFEKLAGGQ"
+    rows = [
+        _row(protein[offset:offset + 9])
+        for offset in range(len(protein) - 9 + 1)
+    ]
+    rows.append(_row(protein[0:9], kind="pMHC_presentation", score=0.9))
+    cache = CachedPredictor.from_dataframe(pd.DataFrame(rows))
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+
+    kinds = out.groupby("peptide")["kind"].apply(lambda s: set(s)).to_dict()
+    assert kinds[protein[0:9]] == {"pMHC_affinity", "pMHC_presentation"}
+    assert kinds[PEPTIDE] == {"pMHC_affinity"}
+
+
+def test_a_flanked_kind_that_applies_is_still_returned_alongside_others():
+    protein = "MA" + PEPTIDE + "GG"
+    cache = _mixed_flank_cache(
+        protein, flanked_kind="pMHC_presentation",
+        n_flank="MA", c_flank="GG",
+    )
+
+    out = cache.predict_proteins_dataframe({"prot": protein})
+    hits = out[out["peptide"] == PEPTIDE]
+
+    assert set(hits["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
+    assert set(hits["offset"]) == {2}
+
+
+def test_concat_of_a_scan_cache_and_a_peptide_cache_reaches_the_same_check():
+    """The mix arrives through a public door, not only a built frame.
+
+    A scan-built cache and a peptide-built cache from the same model at
+    the same version satisfy the version invariant, so ``concat`` joins
+    them — and the result holds a flanked and a flankless row for one
+    ``(peptide, allele)``. Building the frame by hand would test the
+    check without showing that a caller can get here.
+    """
+    scanned = CachedPredictor.from_dataframe(pd.DataFrame([
+        _row(PEPTIDE, kind="pMHC_presentation", score=0.9, affinity=None,
+             n_flank="WW", c_flank="CC"),
+    ]))
+    from_peptides = CachedPredictor.from_dataframe(pd.DataFrame([
+        _row(PEPTIDE),
+    ]))
+
+    merged = CachedPredictor.concat([scanned, from_peptides])
+    rows = merged.predict_peptides_dataframe([PEPTIDE])
+
+    assert set(rows["kind"]) == {"pMHC_affinity", "pMHC_presentation"}
+    assert set(rows["n_flank"]) == {"WW", ""}
+
+    # Scanning a protein whose real flanks are MA / GG must not let the
+    # applicable affinity row vouch for the presentation row.
+    protein = "MA" + PEPTIDE + "GG"
+    covering = CachedPredictor.concat([
+        merged,
+        CachedPredictor.from_dataframe(pd.DataFrame([
+            _row(protein[offset:offset + 9])
+            for offset in range(len(protein) - 9 + 1)
+            if protein[offset:offset + 9] != PEPTIDE
+        ])),
+    ])
+
+    with pytest.raises(KeyError, match="pMHC_presentation"):
+        covering.predict_proteins_dataframe({"prot": protein})

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -171,7 +171,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.54.1"
+__version__ = "5.54.2"
 
 __all__ = [
     "normalize_python_types",

--- a/topiary/cached.py
+++ b/topiary/cached.py
@@ -698,10 +698,16 @@ class CachedPredictor:
                 if not _flanks_apply_at(row, sequence, offset, length):
                     # The cached score was computed with flanking
                     # residues this occurrence does not have, so it is a
-                    # prediction about a different context.  Record it in
-                    # case nothing else covers the occurrence.
+                    # prediction about a different context.  Record it
+                    # under its own kind: a cache mixing a flank-reading
+                    # predictor with one that ignores flanks would
+                    # otherwise count the occurrence as covered by the
+                    # kind that survived, and drop the other silently
+                    # (#302).
                     unmatched_context.setdefault(
-                        (row["peptide"], row["allele"], name, offset), []
+                        (row["peptide"], row["allele"], row["kind"],
+                         name, offset),
+                        [],
                     ).append(row)
                     continue
                 r = row.to_dict()
@@ -1406,7 +1412,7 @@ def _flanks_apply_at(row, sequence, offset, length) -> bool:
 
 
 def _raise_on_uncovered_occurrences(expanded, unmatched_context) -> None:
-    """Fail loudly when flank mismatch left an occurrence with no row.
+    """Fail loudly when flank mismatch left a kind with no row.
 
     A peptide whose only cached rows were predicted in a different
     flanking context is not a cache hit for this occurrence, and it is
@@ -1415,25 +1421,39 @@ def _raise_on_uncovered_occurrences(expanded, unmatched_context) -> None:
     remaining honest options are to return a score computed for the wrong
     neighbours or to say so, and returning it silently is what made this
     a bug rather than a limitation.
+
+    Coverage is decided per ``(peptide, allele, kind, source, offset)``
+    rather than per occurrence, because the two are not the same question
+    for a cache holding both a flank-reading predictor and one that
+    ignores flanks.  Deciding it per occurrence let the surviving kind
+    vouch for the excluded one, so a presentation score predicted in
+    another context disappeared behind an affinity row and the caller
+    read the silence as a weak presenter (#302).
+
+    A kind the cache simply does not hold for a peptide is not this
+    situation and stays quiet: only rows that were found and then
+    excluded are recorded here.
     """
     if not unmatched_context:
         return
     covered = {
-        (r["peptide"], r["allele"], r["source_sequence_name"], r["offset"])
+        (r["peptide"], r["allele"], r["kind"],
+         r["source_sequence_name"], r["offset"])
         for r in expanded
     }
     uncovered = sorted(
-        occurrence for occurrence in unmatched_context if occurrence not in covered
+        (key for key in unmatched_context if key not in covered),
+        key=repr,
     )
     if not uncovered:
         return
-    peptide, allele, name, offset = uncovered[0]
-    stored = unmatched_context[(peptide, allele, name, offset)][0]
+    peptide, allele, kind, name, offset = uncovered[0]
+    stored = unmatched_context[uncovered[0]][0]
     extra = "" if len(uncovered) == 1 else f" (and {len(uncovered) - 1} more)"
     raise KeyError(
         f"CachedPredictor: {peptide!r} occurs in {name!r} at offset "
-        f"{offset}, but the only cached prediction(s) for it and allele "
-        f"{allele!r} were made in a different flanking context "
+        f"{offset}, but the only cached {kind!r} prediction(s) for it and "
+        f"allele {allele!r} were made in a different flanking context "
         f"(n_flank={_flank_key(stored.get('n_flank'))!r}, "
         f"c_flank={_flank_key(stored.get('c_flank'))!r}), so their scores "
         f"are not predictions about this occurrence{extra}.  Re-predict "


### PR DESCRIPTION
Fixes #302. Follow-up to #296. Version bumped to 5.54.2.

## The bug

`predict_proteins_dataframe` declines to attach a flanked cache row to an occurrence whose real neighbours differ, and raises when flank mismatch leaves an occurrence uncovered. Coverage was keyed on `(peptide, allele, source, offset)`, so an occurrence counted as covered the moment *any* kind applied.

A cache holding a flanked row for one kind and a flankless row for another therefore lost the flanked kind in silence:

```python
# One model, one version. For SIINFEKLA / HLA-A*02:01 the cache holds
#   pMHC_affinity     with no flank context
#   pMHC_presentation with flanks WW / CC
# Scan a protein where the peptide's real flanks are MA / GG.
out = cache.predict_proteins_dataframe({"prot": "MA" + "SIINFEKLA" + "GG"})
# -> one row, pMHC_affinity. pMHC_presentation is gone, with nothing said.
```

The affinity row covered the occurrence, so nothing raised.

## How that mix arises

I first described it as two predictors' caches concatenated. That was wrong, and I corrected the issue: `_unique_version_pair` refuses a cache spanning more than one `(prediction_method_name, predictor_version)` pair.

It is one model whose rows arrived by two routes and were joined by `concat`, which the version invariant permits. A protein scan records the flanking context it scored in; a peptide-level run has none to record and normalization backfills the empty string. `test_concat_of_a_scan_cache_and_a_peptide_cache_reaches_the_same_check` builds it that way rather than by hand, so the test shows a caller can actually get here.

## Why an error rather than a note

The failure is absence-shaped. A caller filtering on presentation saw no rows for the peptide and read it as a weak presenter, when the cache in fact held no presentation prediction applicable to that context. Nothing in the frame or the logs distinguished "predicted and poor" from "never predicted here". Returning a score computed for different neighbours is the alternative the parent issue already ruled out.

## The fix

Coverage is keyed on `(peptide, allele, kind, source, offset)`, and the error names the kind that did not apply alongside the peptide, source, offset and stored flank context.

A kind the cache simply does not hold for a peptide stays quiet, since only rows that were found and then excluded are recorded. That reverse case is pinned by its own test, because over-firing here would be as bad as the silence it replaces.

## Tests

Five added to `tests/test_cached_protein_scan_context.py`, bringing it to 22:

- A kind that applies does not vouch for one that does not, and the uncovered kind is named in the error. Both fail on this branch with `cached.py` reverted, confirmed by stashing.
- A kind the cache never held stays quiet, and a flanked kind that *does* apply is still returned alongside the others. Both pass either way by design: they pin the behavior that must not change.
- The `concat` path above.

## Verification

`./lint.sh` passes. Full-suite result to follow in a comment; the targeted file is 22 passed.

https://claude.ai/code/session_015pMD1uiTztbB2bTQ1FkY8m