### PR TITLE
CLI catches CachedPredictor's KeyError cleanly (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 5.55.1
+
+**A `CachedPredictor` coverage-gap error reaches the CLI cleanly (#304).**
+`CachedPredictor` raises `KeyError` — not `ValueError` — for a peptide the
+cache doesn't cover and no fallback can resolve, and for a protein-scan
+occurrence a flank or genotype mismatch leaves uncovered (#296, #302). The
+CLI's top-level handler only caught `(OSError, ValueError)`, so this one
+`CachedPredictor` failure surfaced as a raw Python traceback instead of the
+clean `topiary: error: ...` message every other failure in this path gets.
+`main()` now catches `KeyError` too, and unwraps its message the way
+`ValueError`/`OSError` already render rather than through `str(KeyError(...))`,
+which reprs the message with an extra quoted layer.
+
+Whether a coverage-gap failure during a multi-sequence batch scan should abort
+the whole run (current behavior) or skip and report just the offending
+occurrence is left open — that's a real design choice with its own tradeoffs,
+not a bug, and #304 stays open for it.
+
 ## 5.55.0
 
 **Genotype closes the same coverage gap #302 closed for kind.** A follow-up

--- a/tests/test_cli_script.py
+++ b/tests/test_cli_script.py
@@ -1,6 +1,11 @@
+import pathlib
+
 import pytest
 
 from topiary.cli.script import main
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / "data" / "netmhc_fixtures"
+_HAS_FIXTURES = _FIXTURE_DIR.exists()
 
 
 def test_main_without_args_reports_cli_error(capsys):
@@ -30,5 +35,46 @@ def test_main_missing_mhc_source_reports_cli_error(tmp_path, capsys):
     assert "usage: topiary" in captured.err
     assert "--mhc-predictor" in captured.err
     assert "--mhc-cache-file / --mhc-cache-directory" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Namespace(" not in captured.out
+
+
+@pytest.mark.skipif(not _HAS_FIXTURES, reason="NetMHC fixtures missing")
+def test_main_reports_cached_predictor_miss_as_a_clean_cli_error(
+    tmp_path, capsys,
+):
+    """A CachedPredictor coverage gap reaches the user as a clean CLI
+    error, not a Python traceback (#296, #302, #304).
+
+    ``CachedPredictor`` raises ``KeyError`` -- not ``ValueError`` -- for
+    a peptide the cache doesn't cover and no fallback can resolve. Before
+    this fix, main()'s top-level handler only caught
+    ``(OSError, ValueError)``, so this specific failure was the one
+    ``CachedPredictor`` error the CLI didn't give a clean message for.
+    """
+    fixture = _FIXTURE_DIR / "netmhcpan_41_SLLQHLIGL_A0201.out"
+    # The fixture's cache covers SLLQHLIGL only; ask about a peptide it
+    # was never predicted for, with no fallback configured.
+    peptide_csv = tmp_path / "peptides.csv"
+    peptide_csv.write_text("peptide\nGILGFVFTL\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main([
+            "--peptide-csv", str(peptide_csv),
+            "--mhc-cache-file", str(fixture),
+            "--mhc-cache-format", "netmhcpan",
+        ])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "usage: topiary" in captured.err
+    assert "topiary: error:" in captured.err
+    assert "GILGFVFTL" in captured.err
+    assert "no fallback set" in captured.err
+    # str(KeyError(...)) reprs its message with an extra quoted layer
+    # ("'CachedPredictor: ...'" instead of "CachedPredictor: ..."); the
+    # CLI error must read like the ValueError/OSError messages above it,
+    # not like a KeyError repr.
+    assert "\"'CachedPredictor" not in captured.err
     assert "Traceback" not in captured.err
     assert "Namespace(" not in captured.out

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -172,7 +172,7 @@ from .amino_acids import (
     encode_amino_acids,
 )
 
-__version__ = "5.55.0"
+__version__ = "5.55.1"
 
 __all__ = [
     "normalize_python_types",

--- a/topiary/cli/script.py
+++ b/topiary/cli/script.py
@@ -50,8 +50,17 @@ def main(args_list=None):
     args = parse_args(args_list)
     try:
         df = predict_epitopes_from_args(args)
-    except (OSError, ValueError) as e:
-        arg_parser.error(str(e))
+    except (OSError, ValueError, KeyError) as e:
+        # KeyError alongside OSError/ValueError: CachedPredictor raises it
+        # for exactly two conditions a CLI user needs to see cleanly
+        # rather than as a traceback -- missed peptides with no fallback
+        # configured, and a coverage gap a flank or genotype mismatch
+        # leaves in a protein scan (#296, #302, #304). str(KeyError(...))
+        # would otherwise print with an extra layer of quoting (Python
+        # reprs a KeyError's args), so unwrap it the same way arg_parser
+        # already renders ValueError/OSError text.
+        message = e.args[0] if isinstance(e, KeyError) and e.args else str(e)
+        arg_parser.error(str(message))
     write_outputs(df, args)
     print("Total count: %d" % len(df))
     return 0


### PR DESCRIPTION
Addresses half of #304 (the CLI part; the issue stays open for the batch abort-vs-skip design question, see the comment I left there).

## The bug

`CachedPredictor` raises `KeyError` — not `ValueError` — for exactly two conditions: a peptide the cache doesn't cover with no fallback set, and a protein-scan occurrence a flank or genotype mismatch leaves uncovered (#296, #302). `main()`'s top-level handler only caught `(OSError, ValueError)`, so this one `CachedPredictor` failure reached the user as a raw Python traceback instead of the clean `topiary: error: ...` message every other failure on this path gets.

## The fix

`main()` now catches `KeyError` too. It unwraps the message rather than calling `str()` on the exception directly: `str(KeyError("..."))` reprs the message with an extra quoted layer (`"'CachedPredictor: ...'"` instead of `"CachedPredictor: ..."`), which would have made this one error look different from every `ValueError`/`OSError` message on the same code path. Verified the difference directly before writing the fix.

## Deliberately not in scope

The issue also raised whether a coverage-gap failure during a multi-sequence batch scan should abort the whole run (current behavior) or skip and report just the offending occurrence. I'm not touching that here. The entire point of #296/#302 was replacing a silent wrong answer with a loud failure; adding a skip-and-continue mode would reopen exactly that risk one level up, and it has real design tradeoffs (does a skip get logged, does it change the output shape, is it opt-in) that don't belong bundled into a bug-fix PR. Left a comment on #304 saying so and keeping it open for that discussion.

## Tests

`test_main_reports_cached_predictor_miss_as_a_clean_cli_error` in `tests/test_cli_script.py`, run end-to-end through `main()` with a real NetMHCpan cache fixture and a peptide it doesn't cover. Confirmed it fails against the unfixed CLI (a raw `KeyError` traceback) by stashing the fix, and confirmed the exact quoting difference (`str(KeyError(...))` vs `str(ValueError(...))`) directly in the Python REPL before writing the unwrap logic.

## Verification

`./lint.sh` passes. `./test.sh`: **3,247 passed, 0 failed, 0 errored** — the shared virtualenv's mhctools was upgraded to 3.43.0 by another session partway through this work, which cleared every previously-tracked stale-dependency failure in this repo's local suite.

https://claude.ai/code/session_015pMD1uiTztbB2bTQ1FkY8m